### PR TITLE
Set namespace function and e2e test

### DIFF
--- a/functions/starlark/set_namespace.star
+++ b/functions/starlark/set_namespace.star
@@ -1,0 +1,10 @@
+# set the namespace on each resource
+def run(r, ns_value):
+  for resource in r:
+    # mutate the resource
+    resource["metadata"]["namespace"] = ns_value
+
+# get the value of the annotation to add
+ns_value = ctx.resource_list["functionConfig"]["spec"]["namespace_value"]
+
+run(ctx.resource_list["items"], ns_value)


### PR DESCRIPTION
Users currently have no way to set the namespace of all resources when using Config Sync with unstructured layout.
This function provides a way for users to easily set the namespace field.
Fixes GoogleContainerTools/kpt#683