### PR TITLE
ARG instead of EVN to set component version

### DIFF
--- a/functions/ts/build/helm_template.Dockerfile
+++ b/functions/ts/build/helm_template.Dockerfile
@@ -2,7 +2,7 @@ FROM node:lts-alpine as builder
 
 RUN apk add bash curl git && apk update
 
-ENV HELM_VERSION="v3.2.1"
+ARG HELM_VERSION="v3.2.1"
 RUN curl -fsSL -o /helm-${HELM_VERSION}-linux-amd64.tar.gz https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz && \
     tar -zxvf /helm-${HELM_VERSION}-linux-amd64.tar.gz && \
     mv /linux-amd64/helm /usr/local/bin/helm

--- a/functions/ts/build/istioctl_analyze.Dockerfile
+++ b/functions/ts/build/istioctl_analyze.Dockerfile
@@ -2,7 +2,7 @@ FROM node:lts-alpine as builder
 
 RUN apk add bash curl git && apk update
 
-ENV ISTIOCTL_VERSION="1.6.2"
+ARG ISTIOCTL_VERSION="1.6.2"
 RUN curl -fsSL -o /istio-${ISTIOCTL_VERSION}-linux-amd64.tar.gz https://github.com/istio/istio/releases/download/${ISTIOCTL_VERSION}/istio-${ISTIOCTL_VERSION}-linux-amd64.tar.gz && \
     tar -zxvf /istio-${ISTIOCTL_VERSION}-linux-amd64.tar.gz && \
     mv /istio-${ISTIOCTL_VERSION}/bin/istioctl /usr/local/bin/istioctl

--- a/functions/ts/build/kubeval.Dockerfile
+++ b/functions/ts/build/kubeval.Dockerfile
@@ -1,6 +1,6 @@
 FROM node:lts-alpine as builder
 
-ENV KUBEVAL_VERSION="0.15.0"
+ARG KUBEVAL_VERSION="0.15.0"
 RUN apk add curl && \
     curl -sSLf https://github.com/instrumenta/kubeval/releases/download/${KUBEVAL_VERSION}/kubeval-linux-amd64.tar.gz | \
     tar xzf - -C /usr/local/bin

--- a/functions/ts/build/kustomize_build.Dockerfile
+++ b/functions/ts/build/kustomize_build.Dockerfile
@@ -2,7 +2,7 @@ FROM node:lts-alpine as builder
 
 RUN apk add bash curl git && apk update
 
-ENV KUSTOMIZE_VERSION="v3.6.1"
+ARG KUSTOMIZE_VERSION="v3.6.1"
 RUN curl -fsSL -o /kustomize-${KUSTOMIZE_VERSION}-linux-amd64.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz && \
     tar -zxvf /kustomize-${KUSTOMIZE_VERSION}-linux-amd64.tar.gz && \
     mv kustomize /usr/local/bin/kustomize


### PR DESCRIPTION
Probably this will be a helpful thing:

This change allows to override the value
of the component versions, e.g.[1].
According to [2] ENV values persist in
Dockerfile and ARG can be redefinded with
--build-arg parameter, that probably would
be great to do without changes in the
Dockerfile itself.

[1]
functions/ts$ docker build -f build/kustomize_build.Dockerfile --build-arg KUSTOMIZE_VERSION=v3.8.0 ./

[2]
https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg