### PR TITLE
Update catalog for v0.0.4

### DIFF
--- a/.github/workflows/release-ts-functions.yaml
+++ b/.github/workflows/release-ts-functions.yaml
@@ -36,6 +36,7 @@ jobs:
         run: |
           cd functions/ts
           npm run kpt:docker-build -- --tag=latest
+          npm run kpt:docker-build -- --tag=stable
       - name: Run all e2e tests
         run: |
           sudo curl https://storage.googleapis.com/kpt-dev/latest/linux_amd64/kpt -o /usr/local/bin/kpt
@@ -45,3 +46,4 @@ jobs:
         run: |
           cd functions/ts
           npm run kpt:docker-push -- --tag=latest
+          npm run kpt:docker-push -- --tag=stable

--- a/functions/ts/package-lock.json
+++ b/functions/ts/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-functions",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -109,9 +109,9 @@
       "dev": true
     },
     "@types/jasmine": {
-      "version": "3.5.10",
-      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.5.10.tgz",
-      "integrity": "sha512-3F8qpwBAiVc5+HPJeXJpbrl+XjawGmciN5LgiO7Gv1pl1RHtjoMNqZpqEksaPJW05ViKe8snYInRs6xB25Xdew==",
+      "version": "3.5.11",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.5.11.tgz",
+      "integrity": "sha512-fg1rOd/DehQTIJTifGqGVY6q92lDgnLfs7C6t1ccSwQrMyoTGSoH6wWzhJDZb6ezhsdwAX4EIBLe8w5fXWmEng==",
       "dev": true
     },
     "@types/js-yaml": {
@@ -121,9 +121,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.44",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.44.tgz",
-      "integrity": "sha512-jM6QVv0Sm5d3nW+nUD5jSzPcO6oPqboitSNcwgBay9hifVq/Rauq1PYnROnsmuw45JMBiTnsPAno0bKu2e2xrg==",
+      "version": "14.0.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.23.tgz",
+      "integrity": "sha512-Z4U8yDAl5TFkmYsZdFPdjeMa57NOvnaf1tljHzhouaPEp7LCj2JKkejpI1ODviIAQuW4CcQmxkQ77rnLsOOoKw==",
       "dev": true
     },
     "@types/request": {
@@ -1089,9 +1089,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "long": {
@@ -1409,9 +1409,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
       "dev": true
     },
     "process": {
@@ -1948,9 +1948,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
+      "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
       "dev": true
     },
     "underscore": {

--- a/functions/ts/package-lock.json
+++ b/functions/ts/package-lock.json
@@ -1061,9 +1061,9 @@
       }
     },
     "kpt-functions": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/kpt-functions/-/kpt-functions-0.14.2.tgz",
-      "integrity": "sha512-v7vucO172H68Y1FzD+HIaLk4j7JNiGHfX6f6hTmzRFhXDMOolwxdBD8UpNLD8En/U1egBvSan77Cf4xYfO5rCA==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/kpt-functions/-/kpt-functions-0.14.3.tgz",
+      "integrity": "sha512-KjOU98y+EVmi2l6i8EFITpBMw5RfcHpJ0FkeEjLoAiMlbHH4fvI3KBhdZRHDrp8HDt2UxnP2kxxb/X5D1fPqvA==",
       "requires": {
         "argparse": "^1.0.10",
         "js-yaml": "^3.13.1",

--- a/functions/ts/package.json
+++ b/functions/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-functions",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "kpt typescript sdk functions",
   "author": "kpt Authors",
   "license": "Apache-2.0",
@@ -23,21 +23,21 @@
   },
   "dependencies": {
     "child_process": "1.0.2",
-    "js-yaml": "^3.13.1",
+    "js-yaml": "^3.14.0",
     "kpt-functions": "^0.14.3"
   },
   "devDependencies": {
-    "@types/jasmine": "^3.3.12",
+    "@types/jasmine": "^3.5.11",
     "@types/js-yaml": "^3.12.1",
-    "@types/node": "^12.12.44",
+    "@types/node": "^14.0.23",
     "create-kpt-functions": "^0.17.0",
-    "jasmine": "^3.4.0",
+    "jasmine": "^3.5.0",
     "license-checker": "^25.0.1",
-    "prettier": "1.18.2",
+    "prettier": "2.0.5",
     "tslint": "^6.0.0",
     "tslint-config-prettier": "1.18.0",
     "tslint-consistent-codestyle": "^1.16.0",
-    "typescript": "~3.7.0"
+    "typescript": "~3.9.6"
   },
   "kpt": {
     "docker_repo_base": "gcr.io/kpt-functions"

--- a/functions/ts/package.json
+++ b/functions/ts/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "child_process": "1.0.2",
     "js-yaml": "^3.13.1",
-    "kpt-functions": "^0.14.2"
+    "kpt-functions": "^0.14.3"
   },
   "devDependencies": {
     "@types/jasmine": "^3.3.12",

--- a/functions/ts/src/gen/io.k8s.api.admissionregistration.v1beta1.ts
+++ b/functions/ts/src/gen/io.k8s.api.admissionregistration.v1beta1.ts
@@ -161,7 +161,7 @@ export class MutatingWebhookConfigurationList {
 
   constructor(desc: MutatingWebhookConfigurationList) {
     this.apiVersion = MutatingWebhookConfigurationList.apiVersion;
-    this.items = desc.items.map(i => new MutatingWebhookConfiguration(i));
+    this.items = desc.items.map((i) => new MutatingWebhookConfiguration(i));
     this.kind = MutatingWebhookConfigurationList.kind;
     this.metadata = desc.metadata;
   }
@@ -389,7 +389,7 @@ export class ValidatingWebhookConfigurationList {
 
   constructor(desc: ValidatingWebhookConfigurationList) {
     this.apiVersion = ValidatingWebhookConfigurationList.apiVersion;
-    this.items = desc.items.map(i => new ValidatingWebhookConfiguration(i));
+    this.items = desc.items.map((i) => new ValidatingWebhookConfiguration(i));
     this.kind = ValidatingWebhookConfigurationList.kind;
     this.metadata = desc.metadata;
   }

--- a/functions/ts/src/gen/io.k8s.api.apps.v1.ts
+++ b/functions/ts/src/gen/io.k8s.api.apps.v1.ts
@@ -73,7 +73,7 @@ export class ControllerRevisionList {
 
   constructor(desc: ControllerRevisionList) {
     this.apiVersion = ControllerRevisionList.apiVersion;
-    this.items = desc.items.map(i => new ControllerRevision(i));
+    this.items = desc.items.map((i) => new ControllerRevision(i));
     this.kind = ControllerRevisionList.kind;
     this.metadata = desc.metadata;
   }
@@ -200,7 +200,7 @@ export class DaemonSetList {
 
   constructor(desc: DaemonSetList) {
     this.apiVersion = DaemonSetList.apiVersion;
-    this.items = desc.items.map(i => new DaemonSet(i));
+    this.items = desc.items.map((i) => new DaemonSet(i));
     this.kind = DaemonSetList.kind;
     this.metadata = desc.metadata;
   }
@@ -412,7 +412,7 @@ export class DeploymentList {
 
   constructor(desc: DeploymentList) {
     this.apiVersion = DeploymentList.apiVersion;
-    this.items = desc.items.map(i => new Deployment(i));
+    this.items = desc.items.map((i) => new Deployment(i));
     this.kind = DeploymentList.kind;
     this.metadata = desc.metadata;
   }
@@ -613,7 +613,7 @@ export class ReplicaSetList {
 
   constructor(desc: ReplicaSetList) {
     this.apiVersion = ReplicaSetList.apiVersion;
-    this.items = desc.items.map(i => new ReplicaSet(i));
+    this.items = desc.items.map((i) => new ReplicaSet(i));
     this.kind = ReplicaSetList.kind;
     this.metadata = desc.metadata;
   }
@@ -815,7 +815,7 @@ export class StatefulSetList {
 
   constructor(desc: StatefulSetList) {
     this.apiVersion = StatefulSetList.apiVersion;
-    this.items = desc.items.map(i => new StatefulSet(i));
+    this.items = desc.items.map((i) => new StatefulSet(i));
     this.kind = StatefulSetList.kind;
     this.metadata = desc.metadata;
   }
@@ -880,7 +880,7 @@ export class StatefulSetSpec {
     this.volumeClaimTemplates =
       desc.volumeClaimTemplates !== undefined
         ? desc.volumeClaimTemplates.map(
-            i => new apiCoreV1.PersistentVolumeClaim(i)
+            (i) => new apiCoreV1.PersistentVolumeClaim(i)
           )
         : undefined;
   }

--- a/functions/ts/src/gen/io.k8s.api.apps.v1beta1.ts
+++ b/functions/ts/src/gen/io.k8s.api.apps.v1beta1.ts
@@ -73,7 +73,7 @@ export class ControllerRevisionList {
 
   constructor(desc: ControllerRevisionList) {
     this.apiVersion = ControllerRevisionList.apiVersion;
-    this.items = desc.items.map(i => new ControllerRevision(i));
+    this.items = desc.items.map((i) => new ControllerRevision(i));
     this.kind = ControllerRevisionList.kind;
     this.metadata = desc.metadata;
   }
@@ -204,7 +204,7 @@ export class DeploymentList {
 
   constructor(desc: DeploymentList) {
     this.apiVersion = DeploymentList.apiVersion;
-    this.items = desc.items.map(i => new Deployment(i));
+    this.items = desc.items.map((i) => new Deployment(i));
     this.kind = DeploymentList.kind;
     this.metadata = desc.metadata;
   }
@@ -562,7 +562,7 @@ export class StatefulSetList {
 
   constructor(desc: StatefulSetList) {
     this.apiVersion = StatefulSetList.apiVersion;
-    this.items = desc.items.map(i => new StatefulSet(i));
+    this.items = desc.items.map((i) => new StatefulSet(i));
     this.kind = StatefulSetList.kind;
     this.metadata = desc.metadata;
   }
@@ -627,7 +627,7 @@ export class StatefulSetSpec {
     this.volumeClaimTemplates =
       desc.volumeClaimTemplates !== undefined
         ? desc.volumeClaimTemplates.map(
-            i => new apiCoreV1.PersistentVolumeClaim(i)
+            (i) => new apiCoreV1.PersistentVolumeClaim(i)
           )
         : undefined;
   }

--- a/functions/ts/src/gen/io.k8s.api.apps.v1beta2.ts
+++ b/functions/ts/src/gen/io.k8s.api.apps.v1beta2.ts
@@ -73,7 +73,7 @@ export class ControllerRevisionList {
 
   constructor(desc: ControllerRevisionList) {
     this.apiVersion = ControllerRevisionList.apiVersion;
-    this.items = desc.items.map(i => new ControllerRevision(i));
+    this.items = desc.items.map((i) => new ControllerRevision(i));
     this.kind = ControllerRevisionList.kind;
     this.metadata = desc.metadata;
   }
@@ -200,7 +200,7 @@ export class DaemonSetList {
 
   constructor(desc: DaemonSetList) {
     this.apiVersion = DaemonSetList.apiVersion;
-    this.items = desc.items.map(i => new DaemonSet(i));
+    this.items = desc.items.map((i) => new DaemonSet(i));
     this.kind = DaemonSetList.kind;
     this.metadata = desc.metadata;
   }
@@ -412,7 +412,7 @@ export class DeploymentList {
 
   constructor(desc: DeploymentList) {
     this.apiVersion = DeploymentList.apiVersion;
-    this.items = desc.items.map(i => new Deployment(i));
+    this.items = desc.items.map((i) => new Deployment(i));
     this.kind = DeploymentList.kind;
     this.metadata = desc.metadata;
   }
@@ -613,7 +613,7 @@ export class ReplicaSetList {
 
   constructor(desc: ReplicaSetList) {
     this.apiVersion = ReplicaSetList.apiVersion;
-    this.items = desc.items.map(i => new ReplicaSet(i));
+    this.items = desc.items.map((i) => new ReplicaSet(i));
     this.kind = ReplicaSetList.kind;
     this.metadata = desc.metadata;
   }
@@ -892,7 +892,7 @@ export class StatefulSetList {
 
   constructor(desc: StatefulSetList) {
     this.apiVersion = StatefulSetList.apiVersion;
-    this.items = desc.items.map(i => new StatefulSet(i));
+    this.items = desc.items.map((i) => new StatefulSet(i));
     this.kind = StatefulSetList.kind;
     this.metadata = desc.metadata;
   }
@@ -957,7 +957,7 @@ export class StatefulSetSpec {
     this.volumeClaimTemplates =
       desc.volumeClaimTemplates !== undefined
         ? desc.volumeClaimTemplates.map(
-            i => new apiCoreV1.PersistentVolumeClaim(i)
+            (i) => new apiCoreV1.PersistentVolumeClaim(i)
           )
         : undefined;
   }

--- a/functions/ts/src/gen/io.k8s.api.autoscaling.v1.ts
+++ b/functions/ts/src/gen/io.k8s.api.autoscaling.v1.ts
@@ -94,7 +94,7 @@ export class HorizontalPodAutoscalerList {
 
   constructor(desc: HorizontalPodAutoscalerList) {
     this.apiVersion = HorizontalPodAutoscalerList.apiVersion;
-    this.items = desc.items.map(i => new HorizontalPodAutoscaler(i));
+    this.items = desc.items.map((i) => new HorizontalPodAutoscaler(i));
     this.kind = HorizontalPodAutoscalerList.kind;
     this.metadata = desc.metadata;
   }

--- a/functions/ts/src/gen/io.k8s.api.autoscaling.v2beta1.ts
+++ b/functions/ts/src/gen/io.k8s.api.autoscaling.v2beta1.ts
@@ -165,7 +165,7 @@ export class HorizontalPodAutoscalerList {
 
   constructor(desc: HorizontalPodAutoscalerList) {
     this.apiVersion = HorizontalPodAutoscalerList.apiVersion;
-    this.items = desc.items.map(i => new HorizontalPodAutoscaler(i));
+    this.items = desc.items.map((i) => new HorizontalPodAutoscaler(i));
     this.kind = HorizontalPodAutoscalerList.kind;
     this.metadata = desc.metadata;
   }

--- a/functions/ts/src/gen/io.k8s.api.autoscaling.v2beta2.ts
+++ b/functions/ts/src/gen/io.k8s.api.autoscaling.v2beta2.ts
@@ -149,7 +149,7 @@ export class HorizontalPodAutoscalerList {
 
   constructor(desc: HorizontalPodAutoscalerList) {
     this.apiVersion = HorizontalPodAutoscalerList.apiVersion;
-    this.items = desc.items.map(i => new HorizontalPodAutoscaler(i));
+    this.items = desc.items.map((i) => new HorizontalPodAutoscaler(i));
     this.kind = HorizontalPodAutoscalerList.kind;
     this.metadata = desc.metadata;
   }

--- a/functions/ts/src/gen/io.k8s.api.batch.v1.ts
+++ b/functions/ts/src/gen/io.k8s.api.batch.v1.ts
@@ -101,7 +101,7 @@ export class JobList {
 
   constructor(desc: JobList) {
     this.apiVersion = JobList.apiVersion;
-    this.items = desc.items.map(i => new Job(i));
+    this.items = desc.items.map((i) => new Job(i));
     this.kind = JobList.kind;
     this.metadata = desc.metadata;
   }

--- a/functions/ts/src/gen/io.k8s.api.batch.v1beta1.ts
+++ b/functions/ts/src/gen/io.k8s.api.batch.v1beta1.ts
@@ -72,7 +72,7 @@ export class CronJobList {
 
   constructor(desc: CronJobList) {
     this.apiVersion = CronJobList.apiVersion;
-    this.items = desc.items.map(i => new CronJob(i));
+    this.items = desc.items.map((i) => new CronJob(i));
     this.kind = CronJobList.kind;
     this.metadata = desc.metadata;
   }

--- a/functions/ts/src/gen/io.k8s.api.certificates.v1beta1.ts
+++ b/functions/ts/src/gen/io.k8s.api.certificates.v1beta1.ts
@@ -92,7 +92,7 @@ export class CertificateSigningRequestList {
 
   constructor(desc: CertificateSigningRequestList) {
     this.apiVersion = CertificateSigningRequestList.apiVersion;
-    this.items = desc.items.map(i => new CertificateSigningRequest(i));
+    this.items = desc.items.map((i) => new CertificateSigningRequest(i));
     this.kind = CertificateSigningRequestList.kind;
     this.metadata = desc.metadata;
   }

--- a/functions/ts/src/gen/io.k8s.api.coordination.v1.ts
+++ b/functions/ts/src/gen/io.k8s.api.coordination.v1.ts
@@ -63,7 +63,7 @@ export class LeaseList {
 
   constructor(desc: LeaseList) {
     this.apiVersion = LeaseList.apiVersion;
-    this.items = desc.items.map(i => new Lease(i));
+    this.items = desc.items.map((i) => new Lease(i));
     this.kind = LeaseList.kind;
     this.metadata = desc.metadata;
   }

--- a/functions/ts/src/gen/io.k8s.api.coordination.v1beta1.ts
+++ b/functions/ts/src/gen/io.k8s.api.coordination.v1beta1.ts
@@ -63,7 +63,7 @@ export class LeaseList {
 
   constructor(desc: LeaseList) {
     this.apiVersion = LeaseList.apiVersion;
-    this.items = desc.items.map(i => new Lease(i));
+    this.items = desc.items.map((i) => new Lease(i));
     this.kind = LeaseList.kind;
     this.metadata = desc.metadata;
   }

--- a/functions/ts/src/gen/io.k8s.api.core.v1.ts
+++ b/functions/ts/src/gen/io.k8s.api.core.v1.ts
@@ -440,7 +440,7 @@ export class ComponentStatusList {
 
   constructor(desc: ComponentStatusList) {
     this.apiVersion = ComponentStatusList.apiVersion;
-    this.items = desc.items.map(i => new ComponentStatus(i));
+    this.items = desc.items.map((i) => new ComponentStatus(i));
     this.kind = ComponentStatusList.kind;
     this.metadata = desc.metadata;
   }
@@ -570,7 +570,7 @@ export class ConfigMapList {
 
   constructor(desc: ConfigMapList) {
     this.apiVersion = ConfigMapList.apiVersion;
-    this.items = desc.items.map(i => new ConfigMap(i));
+    this.items = desc.items.map((i) => new ConfigMap(i));
     this.kind = ConfigMapList.kind;
     this.metadata = desc.metadata;
   }
@@ -1087,7 +1087,7 @@ export class EndpointsList {
 
   constructor(desc: EndpointsList) {
     this.apiVersion = EndpointsList.apiVersion;
-    this.items = desc.items.map(i => new Endpoints(i));
+    this.items = desc.items.map((i) => new Endpoints(i));
     this.kind = EndpointsList.kind;
     this.metadata = desc.metadata;
   }
@@ -1311,7 +1311,7 @@ export class EventList {
 
   constructor(desc: EventList) {
     this.apiVersion = EventList.apiVersion;
-    this.items = desc.items.map(i => new Event(i));
+    this.items = desc.items.map((i) => new Event(i));
     this.kind = EventList.kind;
     this.metadata = desc.metadata;
   }
@@ -1816,7 +1816,7 @@ export class LimitRangeList {
 
   constructor(desc: LimitRangeList) {
     this.apiVersion = LimitRangeList.apiVersion;
-    this.items = desc.items.map(i => new LimitRange(i));
+    this.items = desc.items.map((i) => new LimitRange(i));
     this.kind = LimitRangeList.kind;
     this.metadata = desc.metadata;
   }
@@ -1980,7 +1980,7 @@ export class NamespaceList {
 
   constructor(desc: NamespaceList) {
     this.apiVersion = NamespaceList.apiVersion;
-    this.items = desc.items.map(i => new Namespace(i));
+    this.items = desc.items.map((i) => new Namespace(i));
     this.kind = NamespaceList.kind;
     this.metadata = desc.metadata;
   }
@@ -2171,7 +2171,7 @@ export class NodeList {
 
   constructor(desc: NodeList) {
     this.apiVersion = NodeList.apiVersion;
-    this.items = desc.items.map(i => new Node(i));
+    this.items = desc.items.map((i) => new Node(i));
     this.kind = NodeList.kind;
     this.metadata = desc.metadata;
   }
@@ -2533,7 +2533,7 @@ export class PersistentVolumeClaimList {
 
   constructor(desc: PersistentVolumeClaimList) {
     this.apiVersion = PersistentVolumeClaimList.apiVersion;
-    this.items = desc.items.map(i => new PersistentVolumeClaim(i));
+    this.items = desc.items.map((i) => new PersistentVolumeClaim(i));
     this.kind = PersistentVolumeClaimList.kind;
     this.metadata = desc.metadata;
   }
@@ -2634,7 +2634,7 @@ export class PersistentVolumeList {
 
   constructor(desc: PersistentVolumeList) {
     this.apiVersion = PersistentVolumeList.apiVersion;
-    this.items = desc.items.map(i => new PersistentVolume(i));
+    this.items = desc.items.map((i) => new PersistentVolume(i));
     this.kind = PersistentVolumeList.kind;
     this.metadata = desc.metadata;
   }
@@ -2938,7 +2938,7 @@ export class PodList {
 
   constructor(desc: PodList) {
     this.apiVersion = PodList.apiVersion;
-    this.items = desc.items.map(i => new Pod(i));
+    this.items = desc.items.map((i) => new Pod(i));
     this.kind = PodList.kind;
     this.metadata = desc.metadata;
   }
@@ -3239,7 +3239,7 @@ export class PodTemplateList {
 
   constructor(desc: PodTemplateList) {
     this.apiVersion = PodTemplateList.apiVersion;
-    this.items = desc.items.map(i => new PodTemplate(i));
+    this.items = desc.items.map((i) => new PodTemplate(i));
     this.kind = PodTemplateList.kind;
     this.metadata = desc.metadata;
   }
@@ -3556,7 +3556,7 @@ export class ReplicationControllerList {
 
   constructor(desc: ReplicationControllerList) {
     this.apiVersion = ReplicationControllerList.apiVersion;
-    this.items = desc.items.map(i => new ReplicationController(i));
+    this.items = desc.items.map((i) => new ReplicationController(i));
     this.kind = ReplicationControllerList.kind;
     this.metadata = desc.metadata;
   }
@@ -3724,7 +3724,7 @@ export class ResourceQuotaList {
 
   constructor(desc: ResourceQuotaList) {
     this.apiVersion = ResourceQuotaList.apiVersion;
-    this.items = desc.items.map(i => new ResourceQuota(i));
+    this.items = desc.items.map((i) => new ResourceQuota(i));
     this.kind = ResourceQuotaList.kind;
     this.metadata = desc.metadata;
   }
@@ -4020,7 +4020,7 @@ export class SecretList {
 
   constructor(desc: SecretList) {
     this.apiVersion = SecretList.apiVersion;
-    this.items = desc.items.map(i => new Secret(i));
+    this.items = desc.items.map((i) => new Secret(i));
     this.kind = SecretList.kind;
     this.metadata = desc.metadata;
   }
@@ -4254,7 +4254,7 @@ export class ServiceAccountList {
 
   constructor(desc: ServiceAccountList) {
     this.apiVersion = ServiceAccountList.apiVersion;
-    this.items = desc.items.map(i => new ServiceAccount(i));
+    this.items = desc.items.map((i) => new ServiceAccount(i));
     this.kind = ServiceAccountList.kind;
     this.metadata = desc.metadata;
   }
@@ -4318,7 +4318,7 @@ export class ServiceList {
 
   constructor(desc: ServiceList) {
     this.apiVersion = ServiceList.apiVersion;
-    this.items = desc.items.map(i => new Service(i));
+    this.items = desc.items.map((i) => new Service(i));
     this.kind = ServiceList.kind;
     this.metadata = desc.metadata;
   }

--- a/functions/ts/src/gen/io.k8s.api.events.v1beta1.ts
+++ b/functions/ts/src/gen/io.k8s.api.events.v1beta1.ts
@@ -149,7 +149,7 @@ export class EventList {
 
   constructor(desc: EventList) {
     this.apiVersion = EventList.apiVersion;
-    this.items = desc.items.map(i => new Event(i));
+    this.items = desc.items.map((i) => new Event(i));
     this.kind = EventList.kind;
     this.metadata = desc.metadata;
   }

--- a/functions/ts/src/gen/io.k8s.api.extensions.v1beta1.ts
+++ b/functions/ts/src/gen/io.k8s.api.extensions.v1beta1.ts
@@ -131,7 +131,7 @@ export class DaemonSetList {
 
   constructor(desc: DaemonSetList) {
     this.apiVersion = DaemonSetList.apiVersion;
-    this.items = desc.items.map(i => new DaemonSet(i));
+    this.items = desc.items.map((i) => new DaemonSet(i));
     this.kind = DaemonSetList.kind;
     this.metadata = desc.metadata;
   }
@@ -346,7 +346,7 @@ export class DeploymentList {
 
   constructor(desc: DeploymentList) {
     this.apiVersion = DeploymentList.apiVersion;
-    this.items = desc.items.map(i => new Deployment(i));
+    this.items = desc.items.map((i) => new Deployment(i));
     this.kind = DeploymentList.kind;
     this.metadata = desc.metadata;
   }
@@ -665,7 +665,7 @@ export class IngressList {
 
   constructor(desc: IngressList) {
     this.apiVersion = IngressList.apiVersion;
-    this.items = desc.items.map(i => new Ingress(i));
+    this.items = desc.items.map((i) => new Ingress(i));
     this.kind = IngressList.kind;
     this.metadata = desc.metadata;
   }
@@ -817,7 +817,7 @@ export class NetworkPolicyList {
 
   constructor(desc: NetworkPolicyList) {
     this.apiVersion = NetworkPolicyList.apiVersion;
-    this.items = desc.items.map(i => new NetworkPolicy(i));
+    this.items = desc.items.map((i) => new NetworkPolicy(i));
     this.kind = NetworkPolicyList.kind;
     this.metadata = desc.metadata;
   }
@@ -960,7 +960,7 @@ export class PodSecurityPolicyList {
 
   constructor(desc: PodSecurityPolicyList) {
     this.apiVersion = PodSecurityPolicyList.apiVersion;
-    this.items = desc.items.map(i => new PodSecurityPolicy(i));
+    this.items = desc.items.map((i) => new PodSecurityPolicy(i));
     this.kind = PodSecurityPolicyList.kind;
     this.metadata = desc.metadata;
   }
@@ -1193,7 +1193,7 @@ export class ReplicaSetList {
 
   constructor(desc: ReplicaSetList) {
     this.apiVersion = ReplicaSetList.apiVersion;
-    this.items = desc.items.map(i => new ReplicaSet(i));
+    this.items = desc.items.map((i) => new ReplicaSet(i));
     this.kind = ReplicaSetList.kind;
     this.metadata = desc.metadata;
   }

--- a/functions/ts/src/gen/io.k8s.api.networking.v1.ts
+++ b/functions/ts/src/gen/io.k8s.api.networking.v1.ts
@@ -100,7 +100,7 @@ export class NetworkPolicyList {
 
   constructor(desc: NetworkPolicyList) {
     this.apiVersion = NetworkPolicyList.apiVersion;
-    this.items = desc.items.map(i => new NetworkPolicy(i));
+    this.items = desc.items.map((i) => new NetworkPolicy(i));
     this.kind = NetworkPolicyList.kind;
     this.metadata = desc.metadata;
   }

--- a/functions/ts/src/gen/io.k8s.api.networking.v1beta1.ts
+++ b/functions/ts/src/gen/io.k8s.api.networking.v1beta1.ts
@@ -110,7 +110,7 @@ export class IngressList {
 
   constructor(desc: IngressList) {
     this.apiVersion = IngressList.apiVersion;
-    this.items = desc.items.map(i => new Ingress(i));
+    this.items = desc.items.map((i) => new Ingress(i));
     this.kind = IngressList.kind;
     this.metadata = desc.metadata;
   }

--- a/functions/ts/src/gen/io.k8s.api.node.v1beta1.ts
+++ b/functions/ts/src/gen/io.k8s.api.node.v1beta1.ts
@@ -63,7 +63,7 @@ export class RuntimeClassList {
 
   constructor(desc: RuntimeClassList) {
     this.apiVersion = RuntimeClassList.apiVersion;
-    this.items = desc.items.map(i => new RuntimeClass(i));
+    this.items = desc.items.map((i) => new RuntimeClass(i));
     this.kind = RuntimeClassList.kind;
     this.metadata = desc.metadata;
   }

--- a/functions/ts/src/gen/io.k8s.api.policy.v1beta1.ts
+++ b/functions/ts/src/gen/io.k8s.api.policy.v1beta1.ts
@@ -186,7 +186,7 @@ export class PodDisruptionBudgetList {
 
   constructor(desc: PodDisruptionBudgetList) {
     this.apiVersion = PodDisruptionBudgetList.apiVersion;
-    this.items = desc.items.map(i => new PodDisruptionBudget(i));
+    this.items = desc.items.map((i) => new PodDisruptionBudget(i));
     this.kind = PodDisruptionBudgetList.kind;
     this.metadata = desc.metadata;
   }
@@ -324,7 +324,7 @@ export class PodSecurityPolicyList {
 
   constructor(desc: PodSecurityPolicyList) {
     this.apiVersion = PodSecurityPolicyList.apiVersion;
-    this.items = desc.items.map(i => new PodSecurityPolicy(i));
+    this.items = desc.items.map((i) => new PodSecurityPolicy(i));
     this.kind = PodSecurityPolicyList.kind;
     this.metadata = desc.metadata;
   }

--- a/functions/ts/src/gen/io.k8s.api.rbac.v1.ts
+++ b/functions/ts/src/gen/io.k8s.api.rbac.v1.ts
@@ -131,7 +131,7 @@ export class ClusterRoleBindingList {
 
   constructor(desc: ClusterRoleBindingList) {
     this.apiVersion = ClusterRoleBindingList.apiVersion;
-    this.items = desc.items.map(i => new ClusterRoleBinding(i));
+    this.items = desc.items.map((i) => new ClusterRoleBinding(i));
     this.kind = ClusterRoleBindingList.kind;
     this.metadata = desc.metadata;
   }
@@ -177,7 +177,7 @@ export class ClusterRoleList {
 
   constructor(desc: ClusterRoleList) {
     this.apiVersion = ClusterRoleList.apiVersion;
-    this.items = desc.items.map(i => new ClusterRole(i));
+    this.items = desc.items.map((i) => new ClusterRole(i));
     this.kind = ClusterRoleList.kind;
     this.metadata = desc.metadata;
   }
@@ -346,7 +346,7 @@ export class RoleBindingList {
 
   constructor(desc: RoleBindingList) {
     this.apiVersion = RoleBindingList.apiVersion;
-    this.items = desc.items.map(i => new RoleBinding(i));
+    this.items = desc.items.map((i) => new RoleBinding(i));
     this.kind = RoleBindingList.kind;
     this.metadata = desc.metadata;
   }
@@ -392,7 +392,7 @@ export class RoleList {
 
   constructor(desc: RoleList) {
     this.apiVersion = RoleList.apiVersion;
-    this.items = desc.items.map(i => new Role(i));
+    this.items = desc.items.map((i) => new Role(i));
     this.kind = RoleList.kind;
     this.metadata = desc.metadata;
   }

--- a/functions/ts/src/gen/io.k8s.api.rbac.v1beta1.ts
+++ b/functions/ts/src/gen/io.k8s.api.rbac.v1beta1.ts
@@ -131,7 +131,7 @@ export class ClusterRoleBindingList {
 
   constructor(desc: ClusterRoleBindingList) {
     this.apiVersion = ClusterRoleBindingList.apiVersion;
-    this.items = desc.items.map(i => new ClusterRoleBinding(i));
+    this.items = desc.items.map((i) => new ClusterRoleBinding(i));
     this.kind = ClusterRoleBindingList.kind;
     this.metadata = desc.metadata;
   }
@@ -177,7 +177,7 @@ export class ClusterRoleList {
 
   constructor(desc: ClusterRoleList) {
     this.apiVersion = ClusterRoleList.apiVersion;
-    this.items = desc.items.map(i => new ClusterRole(i));
+    this.items = desc.items.map((i) => new ClusterRole(i));
     this.kind = ClusterRoleList.kind;
     this.metadata = desc.metadata;
   }
@@ -346,7 +346,7 @@ export class RoleBindingList {
 
   constructor(desc: RoleBindingList) {
     this.apiVersion = RoleBindingList.apiVersion;
-    this.items = desc.items.map(i => new RoleBinding(i));
+    this.items = desc.items.map((i) => new RoleBinding(i));
     this.kind = RoleBindingList.kind;
     this.metadata = desc.metadata;
   }
@@ -392,7 +392,7 @@ export class RoleList {
 
   constructor(desc: RoleList) {
     this.apiVersion = RoleList.apiVersion;
-    this.items = desc.items.map(i => new Role(i));
+    this.items = desc.items.map((i) => new Role(i));
     this.kind = RoleList.kind;
     this.metadata = desc.metadata;
   }

--- a/functions/ts/src/gen/io.k8s.api.scheduling.v1.ts
+++ b/functions/ts/src/gen/io.k8s.api.scheduling.v1.ts
@@ -84,7 +84,7 @@ export class PriorityClassList {
 
   constructor(desc: PriorityClassList) {
     this.apiVersion = PriorityClassList.apiVersion;
-    this.items = desc.items.map(i => new PriorityClass(i));
+    this.items = desc.items.map((i) => new PriorityClass(i));
     this.kind = PriorityClassList.kind;
     this.metadata = desc.metadata;
   }

--- a/functions/ts/src/gen/io.k8s.api.scheduling.v1beta1.ts
+++ b/functions/ts/src/gen/io.k8s.api.scheduling.v1beta1.ts
@@ -84,7 +84,7 @@ export class PriorityClassList {
 
   constructor(desc: PriorityClassList) {
     this.apiVersion = PriorityClassList.apiVersion;
-    this.items = desc.items.map(i => new PriorityClass(i));
+    this.items = desc.items.map((i) => new PriorityClass(i));
     this.kind = PriorityClassList.kind;
     this.metadata = desc.metadata;
   }

--- a/functions/ts/src/gen/io.k8s.api.storage.v1.ts
+++ b/functions/ts/src/gen/io.k8s.api.storage.v1.ts
@@ -110,7 +110,7 @@ export class StorageClassList {
 
   constructor(desc: StorageClassList) {
     this.apiVersion = StorageClassList.apiVersion;
-    this.items = desc.items.map(i => new StorageClass(i));
+    this.items = desc.items.map((i) => new StorageClass(i));
     this.kind = StorageClassList.kind;
     this.metadata = desc.metadata;
   }
@@ -213,7 +213,7 @@ export class VolumeAttachmentList {
 
   constructor(desc: VolumeAttachmentList) {
     this.apiVersion = VolumeAttachmentList.apiVersion;
-    this.items = desc.items.map(i => new VolumeAttachment(i));
+    this.items = desc.items.map((i) => new VolumeAttachment(i));
     this.kind = VolumeAttachmentList.kind;
     this.metadata = desc.metadata;
   }

--- a/functions/ts/src/gen/io.k8s.api.storage.v1beta1.ts
+++ b/functions/ts/src/gen/io.k8s.api.storage.v1beta1.ts
@@ -62,7 +62,7 @@ export class CSIDriverList {
 
   constructor(desc: CSIDriverList) {
     this.apiVersion = CSIDriverList.apiVersion;
-    this.items = desc.items.map(i => new CSIDriver(i));
+    this.items = desc.items.map((i) => new CSIDriver(i));
     this.kind = CSIDriverList.kind;
     this.metadata = desc.metadata;
   }
@@ -177,7 +177,7 @@ export class CSINodeList {
 
   constructor(desc: CSINodeList) {
     this.apiVersion = CSINodeList.apiVersion;
-    this.items = desc.items.map(i => new CSINode(i));
+    this.items = desc.items.map((i) => new CSINode(i));
     this.kind = CSINodeList.kind;
     this.metadata = desc.metadata;
   }
@@ -323,7 +323,7 @@ export class StorageClassList {
 
   constructor(desc: StorageClassList) {
     this.apiVersion = StorageClassList.apiVersion;
-    this.items = desc.items.map(i => new StorageClass(i));
+    this.items = desc.items.map((i) => new StorageClass(i));
     this.kind = StorageClassList.kind;
     this.metadata = desc.metadata;
   }
@@ -426,7 +426,7 @@ export class VolumeAttachmentList {
 
   constructor(desc: VolumeAttachmentList) {
     this.apiVersion = VolumeAttachmentList.apiVersion;
-    this.items = desc.items.map(i => new VolumeAttachment(i));
+    this.items = desc.items.map((i) => new VolumeAttachment(i));
     this.kind = VolumeAttachmentList.kind;
     this.metadata = desc.metadata;
   }

--- a/functions/ts/src/gen/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.ts
+++ b/functions/ts/src/gen/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.ts
@@ -144,7 +144,7 @@ export class CustomResourceDefinitionList {
 
   constructor(desc: CustomResourceDefinitionList) {
     this.apiVersion = CustomResourceDefinitionList.apiVersion;
-    this.items = desc.items.map(i => new CustomResourceDefinition(i));
+    this.items = desc.items.map((i) => new CustomResourceDefinition(i));
     this.kind = CustomResourceDefinitionList.kind;
     this.metadata = desc.metadata;
   }

--- a/functions/ts/src/gen/io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.ts
+++ b/functions/ts/src/gen/io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.ts
@@ -94,7 +94,7 @@ export class APIServiceList {
 
   constructor(desc: APIServiceList) {
     this.apiVersion = APIServiceList.apiVersion;
-    this.items = desc.items.map(i => new APIService(i));
+    this.items = desc.items.map((i) => new APIService(i));
     this.kind = APIServiceList.kind;
     this.metadata = desc.metadata;
   }

--- a/functions/ts/src/gen/io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.ts
+++ b/functions/ts/src/gen/io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.ts
@@ -94,7 +94,7 @@ export class APIServiceList {
 
   constructor(desc: APIServiceList) {
     this.apiVersion = APIServiceList.apiVersion;
-    this.items = desc.items.map(i => new APIService(i));
+    this.items = desc.items.map((i) => new APIService(i));
     this.kind = APIServiceList.kind;
     this.metadata = desc.metadata;
   }

--- a/functions/ts/src/helm_template.ts
+++ b/functions/ts/src/helm_template.ts
@@ -33,7 +33,7 @@ export async function helmTemplate(configs: Configs) {
     const child = spawnSync('helm', args);
     error = child.stderr;
     let objects = safeLoadAll(child.stdout);
-    objects = objects.filter(o => isKubernetesObject(o));
+    objects = objects.filter((o) => isKubernetesObject(o));
     configs.insert(...objects);
   } catch (err) {
     configs.addResults(generalResult(err, 'error'));

--- a/functions/ts/src/helm_template.ts
+++ b/functions/ts/src/helm_template.ts
@@ -40,7 +40,10 @@ export async function helmTemplate(configs: Configs) {
   }
   if (error && error.length > 0) {
     configs.addResults(
-      generalResult(`Helm template command results in error: ${error}`, 'error')
+      generalResult(
+        `Helm template command results in error: ${error.toString()}`,
+        'error'
+      )
     );
   }
 }
@@ -50,6 +53,9 @@ function readArguments(configs: Configs) {
   let nameArg;
   let pathArg;
   const configMap = configs.getFunctionConfigMap();
+  if (!configMap) {
+    return args;
+  }
   configMap.forEach((value: string, key: string) => {
     if (key === CHART_NAME) {
       nameArg = value;

--- a/functions/ts/src/helm_template_test.ts
+++ b/functions/ts/src/helm_template_test.ts
@@ -14,22 +14,24 @@
  * limitations under the License.
  */
 
-import { Configs, TestRunner, FunctionConfigError } from 'kpt-functions';
+import { Configs, TestRunner, Result } from 'kpt-functions';
 import { helmTemplate } from './helm_template';
 import { Namespace } from './gen/io.k8s.api.core.v1';
 
 const RUNNER = new TestRunner(helmTemplate);
 
 describe('helmTemplate', () => {
-  it('outputs error given undefined function config', async () => {
+  it('outputs helm template error result given undefined function config', async () => {
     const input = new Configs(undefined, undefined);
+    const helmError = `Helm template command results in error: Error: "helm template" requires at least 1 argument\n\nUsage:  helm template [NAME] [CHART] [flags]\n`;
+    const errorResult: Result = {
+      severity: 'error',
+      message: helmError,
+    };
+    const output = new Configs(undefined);
+    output.addResults(errorResult);
 
-    await RUNNER.assert(
-      input,
-      new Configs(undefined),
-      FunctionConfigError,
-      'functionConfig expected, instead undefined'
-    );
+    await RUNNER.assert(input, output);
   });
 
   const namespace = Namespace.named('namespace');

--- a/functions/ts/src/helm_template_test.ts
+++ b/functions/ts/src/helm_template_test.ts
@@ -14,26 +14,13 @@
  * limitations under the License.
  */
 
-import { Configs, TestRunner, Result } from 'kpt-functions';
+import { Configs, TestRunner } from 'kpt-functions';
 import { helmTemplate } from './helm_template';
 import { Namespace } from './gen/io.k8s.api.core.v1';
 
 const RUNNER = new TestRunner(helmTemplate);
 
 describe('helmTemplate', () => {
-  it('outputs helm template error result given undefined function config', async () => {
-    const input = new Configs(undefined, undefined);
-    const helmError = `Helm template command results in error: Error: "helm template" requires at least 1 argument\n\nUsage:  helm template [NAME] [CHART] [flags]\n`;
-    const errorResult: Result = {
-      severity: 'error',
-      message: helmError,
-    };
-    const output = new Configs(undefined);
-    output.addResults(errorResult);
-
-    await RUNNER.assert(input, output);
-  });
-
   const namespace = Namespace.named('namespace');
   it('outputs error given namespace function config', async () => {
     const input = new Configs(undefined, namespace);

--- a/functions/ts/src/istioctl_analyze.ts
+++ b/functions/ts/src/istioctl_analyze.ts
@@ -74,7 +74,7 @@ function addIstioResults(
   configs: Configs
 ) {
   if (outputs && outputs.length) {
-    outputs.forEach(output => {
+    outputs.forEach((output) => {
       const result = kubernetesObjectResult(
         output.message,
         object,

--- a/functions/ts/src/istioctl_analyze.ts
+++ b/functions/ts/src/istioctl_analyze.ts
@@ -52,7 +52,7 @@ export async function istioctlAnalyze(configs: Configs) {
       if (error && error.length > 0) {
         configs.addResults(
           configFileResult(
-            `Istioctl analyze command results in error: ${error}`,
+            `Istioctl analyze command results in error: ${error.toString}`,
             '',
             'error'
           )
@@ -95,6 +95,9 @@ function readArguments(configs: Configs) {
   // Initialize to output json
   const args: string[] = ['analyze', '-', '-o', 'json'];
   const configMap = configs.getFunctionConfigMap();
+  if (!configMap) {
+    return args;
+  }
   configMap.forEach((value: string, key: string) => {
     if (key === FLAG_ARGS) {
       args.push(value);

--- a/functions/ts/src/istioctl_analyze_test.ts
+++ b/functions/ts/src/istioctl_analyze_test.ts
@@ -21,15 +21,10 @@ import { Namespace, ConfigMap } from './gen/io.k8s.api.core.v1';
 const RUNNER = new TestRunner(istioctlAnalyze);
 
 describe('istioctlAnalyze', () => {
-  it('outputs error given undefined function config', async () => {
+  it('outputs undefined given undefined function config', async () => {
     const input = new Configs(undefined, undefined);
 
-    await RUNNER.assert(
-      input,
-      new Configs(undefined),
-      FunctionConfigError,
-      'functionConfig expected, instead undefined'
-    );
+    await RUNNER.assert(input, new Configs(undefined));
   });
 
   const namespace = Namespace.named('namespace');

--- a/functions/ts/src/kubeval.ts
+++ b/functions/ts/src/kubeval.ts
@@ -138,14 +138,14 @@ function buildKubevalArgs(
 
 function writeToStream(stream: Writable, data: string): Promise<void> {
   return new Promise((resolve, reject) =>
-    stream.write(data, 'utf-8', err => (err ? reject(err) : resolve()))
+    stream.write(data, 'utf-8', (err) => (err ? reject(err) : resolve()))
   );
 }
 
 function readStdoutToString(childProcess: ChildProcess): Promise<string> {
-  return new Promise<string>(resolve => {
+  return new Promise<string>((resolve) => {
     let result = '';
-    childProcess.stdout!!.on('data', data => {
+    childProcess.stdout!!.on('data', (data) => {
       result += data.toString();
     });
     childProcess.on('close', () => {

--- a/functions/ts/src/kubeval_test.ts
+++ b/functions/ts/src/kubeval_test.ts
@@ -8,7 +8,7 @@ describe('kubeval', () => {
   it('handles undefined function config', async () => {
     const input = new Configs(undefined, undefined);
 
-    await RUNNER.assert(input, new Configs(undefined), Error);
+    await RUNNER.assert(input, new Configs(undefined));
   });
 
   const namespace = Namespace.named('namespace');

--- a/functions/ts/src/kustomize_build.ts
+++ b/functions/ts/src/kustomize_build.ts
@@ -30,7 +30,7 @@ export async function kustomizeBuild(configs: Configs) {
     const child = spawnSync('kustomize', args);
     error = child.stderr;
     let objects = safeLoadAll(child.stdout);
-    objects = objects.filter(o => isKubernetesObject(o));
+    objects = objects.filter((o) => isKubernetesObject(o));
     configs.insert(...objects);
   } catch (err) {
     configs.addResults(generalResult(err, 'error'));

--- a/functions/ts/src/kustomize_build.ts
+++ b/functions/ts/src/kustomize_build.ts
@@ -38,7 +38,7 @@ export async function kustomizeBuild(configs: Configs) {
   if (error && error.length > 0) {
     configs.addResults(
       generalResult(
-        `Kustomize build command results in error: ${error}`,
+        `Kustomize build command results in error: ${error.toString()}`,
         'error'
       )
     );
@@ -48,6 +48,9 @@ export async function kustomizeBuild(configs: Configs) {
 function readArguments(configs: Configs) {
   const args: string[] = [];
   const configMap = configs.getFunctionConfigMap();
+  if (!configMap) {
+    return args;
+  }
   configMap.forEach((value: string, key: string) => {
     if (key === BUILD_PATH) {
       args.push(value);

--- a/functions/ts/src/kustomize_build_test.ts
+++ b/functions/ts/src/kustomize_build_test.ts
@@ -14,22 +14,24 @@
  * limitations under the License.
  */
 
-import { Configs, TestRunner, FunctionConfigError } from 'kpt-functions';
+import { Configs, TestRunner, Result } from 'kpt-functions';
 import { kustomizeBuild } from './kustomize_build';
 import { Namespace } from './gen/io.k8s.api.core.v1';
 
 const RUNNER = new TestRunner(kustomizeBuild);
 
 describe('kustomizeBuild', () => {
-  it('outputs error given undefined function config', async () => {
+  it('outputs kustomize error result given undefined function config', async () => {
     const input = new Configs(undefined, undefined);
+    const kustomizeError = `Kustomize build command results in error: Error: unable to find one of 'kustomization.yaml', 'kustomization.yml' or 'Kustomization' in directory '${process.cwd()}'\n`;
+    const errorResult: Result = {
+      severity: 'error',
+      message: kustomizeError,
+    };
+    const output = new Configs(undefined);
+    output.addResults(errorResult);
 
-    await RUNNER.assert(
-      input,
-      new Configs(undefined),
-      FunctionConfigError,
-      'functionConfig expected, instead undefined'
-    );
+    await RUNNER.assert(input, output);
   });
 
   const namespace = Namespace.named('namespace');

--- a/functions/ts/src/kustomize_build_test.ts
+++ b/functions/ts/src/kustomize_build_test.ts
@@ -14,26 +14,13 @@
  * limitations under the License.
  */
 
-import { Configs, TestRunner, Result } from 'kpt-functions';
+import { Configs, TestRunner } from 'kpt-functions';
 import { kustomizeBuild } from './kustomize_build';
 import { Namespace } from './gen/io.k8s.api.core.v1';
 
 const RUNNER = new TestRunner(kustomizeBuild);
 
 describe('kustomizeBuild', () => {
-  it('outputs kustomize error result given undefined function config', async () => {
-    const input = new Configs(undefined, undefined);
-    const kustomizeError = `Kustomize build command results in error: Error: unable to find one of 'kustomization.yaml', 'kustomization.yml' or 'Kustomization' in directory '${process.cwd()}'\n`;
-    const errorResult: Result = {
-      severity: 'error',
-      message: kustomizeError,
-    };
-    const output = new Configs(undefined);
-    output.addResults(errorResult);
-
-    await RUNNER.assert(input, output);
-  });
-
   const namespace = Namespace.named('namespace');
   it('outputs error given namespace function config', async () => {
     const input = new Configs(undefined, namespace);


### PR DESCRIPTION
- Update kpt-functions version and other dependency versions
- Formatting changes from updating Prettier to v2
- Use error.toString() when making results message to fix multi-line yaml discrepancy when testing
- Prepare to release 0.0.4