### PR TITLE
Added docker-cli package to kustomize_build fn

### DIFF
--- a/functions/ts/build/kustomize_build.Dockerfile
+++ b/functions/ts/build/kustomize_build.Dockerfile
@@ -35,7 +35,7 @@ RUN npm run build && \
 
 FROM node:lts-alpine
 
-RUN apk add git
+RUN apk add git docker-cli
 
 # Run as non-root user as a best-practices:
 # https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md


### PR DESCRIPTION
This is to make docker-in-docker possible for kustomize_build fn:

kustomize build command may work with kpt-function
based plugins, but in order to make it work
kustomize_build function must contain docker-cli
to be able to run docker in docker.