### PR TITLE
Updated sops binary to the latest release 3.6.1

### DIFF
--- a/functions/ts/build/sops.Dockerfile
+++ b/functions/ts/build/sops.Dockerfile
@@ -2,7 +2,7 @@ FROM node:lts-alpine as builder
 
 RUN apk add bash curl git && apk update
 
-ARG SOPS_VERSION="v3.6.0"
+ARG SOPS_VERSION="v3.6.1"
 RUN curl -fsSL -o /usr/local/bin/sops https://github.com/mozilla/sops/releases/download/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux && \
     chmod +x /usr/local/bin/sops
 


### PR DESCRIPTION
some usefull features were added
e.g.: --unencrypted-regex
usage example:
--unencrypted-regex '^(kind|apiVersion|group|metadata)$'

see
https://github.com/mozilla/sops/releases/tag/v3.6.1

unencrypted-regex wasn't supported in the
previous versions and if someone uses it
sops krm-function with older binary won't be able
to decrypt that.


PS
build is failing, but I guess just need to rebase after https://github.com/GoogleContainerTools/kpt-functions-catalog/pull/121 is merged