### PR TITLE
add dependency update for helm inflator

### DIFF
--- a/functions/ts/src/helm_inflator_test.ts
+++ b/functions/ts/src/helm_inflator_test.ts
@@ -62,6 +62,12 @@ foo: bar
                 stderr: '',
                 error: undefined,
               };
+            case 'dependency':
+              return {
+                stdout: '',
+                stderr: '',
+                error: undefined,
+              };
             default:
               return {
                 stdout: '',
@@ -213,7 +219,7 @@ describe('error when run helm command', () => {
     const output = input.deepCopy();
     output.addResults(
       generalResult(
-        'Error: Helm command template chart-name bar --values whatever results in error: helm error',
+        'Error: Helm command dependency update bar results in error: helm error',
         'error'
       )
     );

--- a/tests/helm_inflator.sh
+++ b/tests/helm_inflator.sh
@@ -56,7 +56,7 @@ assert_contains_string out.yaml "name: extra-args-redis-master"
 
 helm_testcase "kpt_helm_inflator_imperative_pipeline"
 kpt fn source example-configs |
-  kpt fn run --mount type=bind,src="$(pwd)/${CHARTS_SRC}",dst=/source --image gcr.io/kpt-functions/helm-inflator:"${TAG}" --as-current-user -- local-chart-path=/source/zookeeper name=my-zookeeper | 
+  kpt fn run --mount type=bind,src="$(pwd)/${CHARTS_SRC}",dst=/source,rw=true --image gcr.io/kpt-functions/helm-inflator:"${TAG}" --as-current-user --network -- local-chart-path=/source/zookeeper name=my-zookeeper | 
   kpt fn run --mount type=bind,src="$(pwd)/${CHARTS_SRC}",dst=/source --image gcr.io/kpt-functions/helm-inflator:"${TAG}" --as-current-user -- name=my-redis local-chart-path=/source/redis |
   kpt fn sink .
 assert_dir_exists default


### PR DESCRIPTION
`zookeeper` chart used in the test is updated to include a dependency. `helm-inflator` needs to update the dependency before running `template` command.