### PR TITLE
Supporting build golang functions with multiple versions

### DIFF
--- a/functions/go/Makefile
+++ b/functions/go/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 SHELL=/bin/bash
 GOPATH := $(shell go env GOPATH)
-TAG := dev
+TAG ?= dev
 
 # Edit this list to contain all go functions
 FUNCTIONS := \
@@ -28,7 +28,7 @@ FUNCTION_BUILDS := $(patsubst %,%-BUILD,$(FUNCTIONS))
 # Targets to push images
 FUNCTION_PUSH := $(patsubst %,%-PUSH,$(FUNCTIONS))
 # Current function name used by individual function targets
-CURRENT_FUNCTION := unknown
+CURRENT_FUNCTION ?= unknown
 
 .DEFAULT_GOAL := help
 .PHONY: help

--- a/scripts/get-versions.sh
+++ b/scripts/get-versions.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+VERNUM='0|[1-9][0-9]*'
+
+# An example is "set-namespace/v1.2.3"
+SEMVER_REGEX="\
+^[a-zA-Z]*(-[a-zA-Z]+)*\/\
+[vV]?($VERNUM)\\.($VERNUM)\\.($VERNUM)$"
+
+function validate_version {
+  local version=$1
+  if [[ "$version" =~ $SEMVER_REGEX ]]; then
+    local major=${BASH_REMATCH[2]}
+    local minor=${BASH_REMATCH[3]}
+    local patch=${BASH_REMATCH[4]}
+
+    echo v$major.$minor.$patch
+    echo v$major.$minor
+    echo v$major
+  else
+    echo $version
+  fi
+}

--- a/scripts/go-function-build.sh
+++ b/scripts/go-function-build.sh
@@ -2,9 +2,16 @@
 
 set -euo pipefail
 
+source ../../scripts/get-versions.sh
+
 image_tag=${TAG:-dev}
+tags=$(validate_version ${image_tag})
 prefix="release-go-functions-"
 [[ "${image_tag}" = "${prefix}"* ]] && image_tag="${image_tag#$prefix}"
-image_name=gcr.io/kpt-functions/"${CURRENT_FUNCTION}"
-image="${image_name}":"${image_tag}"
-docker build -t "${image}" -t "${image_name}" -f "${CURRENT_FUNCTION}"/Dockerfile "${CURRENT_FUNCTION}"
+image_name=gcr.io/kpt-fn/"${CURRENT_FUNCTION}"
+tag_params=""
+for tag in ${tags}; do
+  tag_params="$tag_params -t ${image_name}:${tag}"
+done
+
+docker build ${tag_params} -f "${CURRENT_FUNCTION}"/Dockerfile "${CURRENT_FUNCTION}"


### PR DESCRIPTION
For example, we can run the following in functions/go directory
CURRENT_FUNCTION=set-namespace TAG=set-namespace/v1.2.3 make func-build
We will get the image tagged as
gcr.io/kpt-fn/set-namespace:v1.2.3
gcr.io/kpt-fn/set-namespace:v1.2
gcr.io/kpt-fn/set-namespace:v1