### PR TITLE
Split curated and contrib functions in the build and release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,7 +89,7 @@ jobs:
     - name: Build node and Go docker images with latest tag
       if: matrix.platform == 'ubuntu-latest'
       run: |
-        make TAG=latest build
+        make TAG=unstable build
     - name: Run all tests
       if: matrix.platform == 'ubuntu-latest'
       run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,17 +59,6 @@ This catalog is documented on the [kpt website]. Follow the
 Changes to other documentation such as examples and README files can follow the
 same pull request format as code changes.
 
-## How to Release
-
-We have spearate a release process for each language: golang and typescript.
-All functions written in the language get released together. Maintainers should
-create releases through the
-[Github UI](https://github.com/GoogleContainerTools/kpt-functions-catalog/releases).
-
-The release title and the release tag version should both be of the form
-`release-[lang]-functions-v[version number]`. Risky changes are encouraged to be
-tagged as pre-releases to confirm production readiness.
-
 ## Contact Us
 
 Do you need a review or release of configuration functions? We’d love to hear

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,7 +12,7 @@ kpt-functions-catalog repo.
    `{funtion-name} {semver}`. The release notes for this function should be in
    the body. 
 1. Click `Publish release` button.
-1. Send an announcement email in the kpt-function users google group.
-   <!--- TODO: create this google group and link it here -->
+1. Send an announcement email in the [kpt users google group].
 
 [releases pages]: https://github.com/GoogleContainerTools/kpt-functions-catalog/releases
+[kpt users google group]: https://groups.google.com/g/kpt-users

--- a/examples/helm-inflator/README.md
+++ b/examples/helm-inflator/README.md
@@ -88,7 +88,7 @@ metadata:
   annotations:
     config.kubernetes.io/function: |
       container:
-        image: gcr.io/kpt-functions/helm-inflator
+        image: gcr.io/kpt-fn-contrib/helm-inflator
     config.kubernetes.io/path: fn-config.yaml
 data:
   name: chart

--- a/examples/helm-inflator/local-configs/fn-config.yaml
+++ b/examples/helm-inflator/local-configs/fn-config.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     config.kubernetes.io/function: |
       container:
-        image: gcr.io/kpt-functions/helm-inflator
+        image: gcr.io/kpt-fn-contrib/helm-inflator:unstable
 data:
   name: chart
   local-chart-path: /source

--- a/examples/istioctl-analyze/fn-config.yaml
+++ b/examples/istioctl-analyze/fn-config.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     config.k8s.io/function: |
       container:
-        image: gcr.io/kpt-functions/istioctl-analyze
+        image: gcr.io/kpt-fn-contrib/istioctl-analyze:unstable
     config.kubernetes.io/local-config: 'true'
 data:
   '--use-kube': 'false'

--- a/examples/kubeval/fn-config.yaml
+++ b/examples/kubeval/fn-config.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     config.k8s.io/function: |
       container:
-        image: gcr.io/kpt-functions/kubeval
+        image: gcr.io/kpt-fn/kubeval:unstable
         network: true
     config.kubernetes.io/local-config: 'true'
 data:

--- a/examples/set-namespace/.expected/diff.patch
+++ b/examples/set-namespace/.expected/diff.patch
@@ -21,7 +21,7 @@ index 1c43349..2460ffb 100644
    - name: etcd-server-ssl
 diff --git a/functions/fn-config.yaml b/functions/fn-config.yaml
 deleted file mode 100644
-index 47eab5e..0000000
+index f2e0be4..0000000
 --- a/functions/fn-config.yaml
 +++ /dev/null
 @@ -1,11 +0,0 @@
@@ -32,7 +32,7 @@ index 47eab5e..0000000
 -  annotations:
 -    config.k8s.io/function: |
 -      container:
--        image: gcr.io/kpt-functions/set-namespace
+-        image: gcr.io/kpt-fn/set-namespace:unstable
 -    config.kubernetes.io/local-config: 'true'
 -data:
 -  "namespace": "example-ns"

--- a/examples/set-namespace/functions/fn-config.yaml
+++ b/examples/set-namespace/functions/fn-config.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     config.k8s.io/function: |
       container:
-        image: gcr.io/kpt-functions/set-namespace
+        image: gcr.io/kpt-fn/set-namespace:unstable
     config.kubernetes.io/local-config: 'true'
 data:
   "namespace": "example-ns"

--- a/examples/sops/local-configs/function.yaml
+++ b/examples/sops/local-configs/function.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     config.k8s.io/function: |
       container:
-        image: gcr.io/kpt-functions/sops
+        image: gcr.io/kpt-fn-contrib/sops:unstable
         envs:
         - SOPS_IMPORT_PGP
     config.kubernetes.io/local-config: "true"
@@ -20,7 +20,7 @@ metadata:
   annotations:
     config.k8s.io/function: |
       container:
-        image: gcr.io/kpt-functions/sops
+        image: gcr.io/kpt-fn-contrib/sops:unstable
         envs:
         - SOPS_IMPORT_PGP
     config.kubernetes.io/local-config: "true"

--- a/functions/go/Makefile
+++ b/functions/go/Makefile
@@ -14,19 +14,22 @@
 SHELL=/bin/bash
 GOPATH := $(shell go env GOPATH)
 TAG ?= dev
+CURATED_GCR = gcr.io/kpt-fn
 
-# Edit this list to contain all go functions
-FUNCTIONS := \
+# Edit this list to contain all of the curated go functions
+CURATED_FUNCTIONS := \
 	set-namespace
+# Use functions/ts/Makefile as a reference to modify this file to support contrib functions.
+FUNCTIONS := $(CURATED_FUNCTIONS)
 
 # Targets for running all function tests
 FUNCTION_TESTS := $(patsubst %,%-TEST,$(FUNCTIONS))
 
 FUNCTION_CHECKLICENSES := $(patsubst %,%-CHECKLICENSES,$(FUNCTIONS))
 # Targets to build functions
-FUNCTION_BUILDS := $(patsubst %,%-BUILD,$(FUNCTIONS))
+CURATED_FUNCTION_BUILDS := $(patsubst %,%-CURATED-BUILD,$(CURATED_FUNCTIONS))
 # Targets to push images
-FUNCTION_PUSH := $(patsubst %,%-PUSH,$(FUNCTIONS))
+CURATED_FUNCTION_PUSH := $(patsubst %,%-CURATED-PUSH,$(CURATED_FUNCTIONS))
 # Current function name used by individual function targets
 CURRENT_FUNCTION ?= unknown
 
@@ -50,18 +53,18 @@ $(FUNCTION_TESTS):
 	$(MAKE) CURRENT_FUNCTION=$(subst -TEST,,$@) func-test
 
 .PHONY: build
-build: $(FUNCTION_BUILDS) ## Build all function images. 'TAG' env is used to specify tag. 'dev' will be used if not set.
+build: $(CURATED_FUNCTION_BUILDS) ## Build all function images. 'TAG' env is used to specify tag. 'dev' will be used if not set.
 
-.PHONY: $(FUNCTION_BUILDS)
-$(FUNCTION_BUILDS):
-	$(MAKE) CURRENT_FUNCTION=$(subst -BUILD,,$@) TAG=$(TAG) func-build
+.PHONY: $(CURATED_FUNCTION_BUILDS)
+$(CURATED_FUNCTION_BUILDS):
+	$(MAKE) CURRENT_FUNCTION=$(subst -CURATED-BUILD,,$@) TAG=$(TAG) DEFAULT_GCR=$(CURATED_GCR) func-build
 
 .PHONY: push
-push: $(FUNCTION_PUSH) ## Push images to registry. WARN: This operation should only be done in CI environment.
+push: $(CURATED_FUNCTION_PUSH) ## Push images to registry. WARN: This operation should only be done in CI environment.
 
-.PHONY: $(FUNCTION_PUSH)
-$(FUNCTION_PUSH):
-	$(MAKE) CURRENT_FUNCTION=$(subst -PUSH,,$@) TAG=$(TAG) func-push
+.PHONY: $(CURATED_FUNCTION_PUSH)
+$(CURATED_FUNCTION_PUSH):
+	$(MAKE) CURRENT_FUNCTION=$(subst -CURATED-PUSH,,$@) TAG=$(TAG) DEFAULT_GCR=$(CURATED_GCR) func-push
 
 .PHONY: check-licenses
 check-licenses: install-go-licenses $(FUNCTION_CHECKLICENSES)

--- a/functions/ts/Makefile
+++ b/functions/ts/Makefile
@@ -13,6 +13,8 @@
 # limitations under the License.
 SHELL=/bin/bash
 TAG ?= dev
+CURATED_GCR = gcr.io/kpt-fn
+CONTRIB_GCR = gcr.io/kpt-fn-contrib
 
 .DEFAULT_GOAL := help
 .PHONY: help
@@ -20,20 +22,31 @@ help: ## Print this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: test build npm-ci push
-FUNCTIONS := \
+
+# Edit this list to contain all of the curated ts functions
+CURATED_FUNCTIONS := \
+	kubeval
+
+# Edit this list to contain all of the non-curated ts functions
+CONTRIB_FUNCTIONS := \
 	helm-inflator \
 	istioctl-analyze \
-	kubeval \
 	sops
+
+FUNCTIONS := $(CURATED_FUNCTIONS) $(CONTRIB_FUNCTIONS)
 
 # Targets for running all function tests
 FUNCTION_TESTS := $(patsubst %,%-TEST,$(FUNCTIONS))
 
 FUNCTION_CHECKLICENSES := $(patsubst %,%-CHECKLICENSES,$(FUNCTIONS))
-# Targets to build functions
-FUNCTION_BUILDS := $(patsubst %,%-BUILD,$(FUNCTIONS))
-# Targets to push images
-FUNCTION_PUSH := $(patsubst %,%-PUSH,$(FUNCTIONS))
+# Targets to build curated functions
+CURATED_FUNCTION_BUILDS := $(patsubst %,%-CURATED-BUILD,$(CURATED_FUNCTIONS))
+# Targets to build non-curated functions
+CONTRIB_FUNCTION_BUILDS := $(patsubst %,%-CONTRIB-BUILD,$(CONTRIB_FUNCTIONS))
+# Targets to push curated function images
+CURATED_FUNCTION_PUSH := $(patsubst %,%-CURATED-PUSH,$(CURATED_FUNCTIONS))
+# Targets to push non-curated function images
+CONTRIB_FUNCTION_PUSH := $(patsubst %,%-CONTRIB-PUSH,$(CONTRIB_FUNCTIONS))
 # Targets to run npm ci
 FUNCTION_NPM_CI := $(patsubst %,%-NPM-CI,$(FUNCTIONS))
 # Current function name used by individual function targets
@@ -51,17 +64,25 @@ test: $(FUNCTION_TESTS) ## Run unit tests for all functions
 $(FUNCTION_TESTS):
 	$(MAKE) CURRENT_FUNCTION=$(subst -TEST,,$@) func-test
 
-build: $(FUNCTION_BUILDS) ## Build all function images. Variable 'TAG' is used to specify tag. 'dev' will be used if not set.
+build: $(CURATED_FUNCTION_BUILDS) $(CONTRIB_FUNCTION_BUILDS) ## Build all function images. Variable 'TAG' is used to specify tag. 'dev' will be used if not set.
 
-.PHONY: $(FUNCTION_BUILDS)
-$(FUNCTION_BUILDS):
-	$(MAKE) CURRENT_FUNCTION=$(subst -BUILD,,$@) TAG=$(TAG) func-build
+.PHONY: $(CURATED_FUNCTION_BUILDS)
+$(CURATED_FUNCTION_BUILDS):
+	$(MAKE) CURRENT_FUNCTION=$(subst -CURATED-BUILD,,$@) TAG=$(TAG) DEFAULT_GCR=$(CURATED_GCR) func-build
 
-push: $(FUNCTION_PUSH) ## Push images to registry. WARN: This operation should only be done in CI environment.
+.PHONY: $(CONTRIB_FUNCTION_BUILDS)
+$(CONTRIB_FUNCTION_BUILDS):
+	$(MAKE) CURRENT_FUNCTION=$(subst -CONTRIB-BUILD,,$@) TAG=$(TAG) DEFAULT_GCR=$(CONTRIB_GCR) func-build
 
-.PHONY: $(FUNCTION_PUSH)
-$(FUNCTION_PUSH):
-	$(MAKE) CURRENT_FUNCTION=$(subst -PUSH,,$@) TAG=$(TAG) func-push
+push: $(CURATED_FUNCTION_PUSH) $(CONTRIB_FUNCTION_PUSH) ## Push images to registry. WARN: This operation should only be done in CI environment.
+
+.PHONY: $(CURATED_FUNCTION_PUSH)
+$(CURATED_FUNCTION_PUSH):
+	$(MAKE) CURRENT_FUNCTION=$(subst -CURATED-PUSH,,$@) TAG=$(TAG) DEFAULT_GCR=$(CURATED_GCR) func-push
+
+.PHONY: $(CONTRIB_FUNCTION_PUSH)
+$(CONTRIB_FUNCTION_PUSH):
+	$(MAKE) CURRENT_FUNCTION=$(subst -CONTRIB-PUSH,,$@) TAG=$(TAG) DEFAULT_GCR=$(CONTRIB_GCR) func-push
 
 check-licenses: $(FUNCTION_CHECKLICENSES) ## Run license checker for source files
 

--- a/functions/ts/helm-inflator/src/helm_inflator.ts
+++ b/functions/ts/helm-inflator/src/helm_inflator.ts
@@ -255,7 +255,7 @@ metadata:
   annotations:
     config.kubernetes.io/function: |
       container:
-        image: gcr.io/kpt-functions/helm-inflator
+        image: gcr.io/kpt-fn-contrib/helm-inflator:unstable
         network: true
     config.kubernetes.io/local-config: "true"
 data:
@@ -274,7 +274,7 @@ metadata:
   annotations:
     config.k8s.io/function: |
       container:
-        image: gcr.io/kpt-functions/helm-inflator
+        image: gcr.io/kpt-fn-contrib/helm-inflator:unstable
     config.kubernetes.io/local-config: "true"
 data:
   ${CHART_NAME}: my-chart

--- a/functions/ts/istioctl-analyze/src/istioctl_analyze.ts
+++ b/functions/ts/istioctl-analyze/src/istioctl_analyze.ts
@@ -140,7 +140,7 @@ metadata:
   annotations:
     config.k8s.io/function: |
       container:
-        image: gcr.io/kpt-functions/istioctl-analyze
+        image: gcr.io/kpt-fn-contrib/istioctl-analyze:unstable
     config.kubernetes.io/local-config: "true"
 data:
   "${FLAG_ARGS}": ["--recursive"]

--- a/functions/ts/sops/src/sops.ts
+++ b/functions/ts/sops/src/sops.ts
@@ -278,7 +278,7 @@ metadata:
   annotations:
     config.k8s.io/function: |
       container:
-        image: gcr.io/kpt-functions/sops
+        image: gcr.io/kpt-fn-contrib/sops:unstable
         envs:
         - SOPS_IMPORT_PGP
         - SOPS_PGP_FP
@@ -308,7 +308,7 @@ metadata:
   annotations:
     config.k8s.io/function: |
       container:
-        image: gcr.io/kpt-functions/sops
+        image: gcr.io/kpt-fn-contrib/sops:unstable
         envs:
         - SOPS_IMPORT_PGP
     config.kubernetes.io/local-config: "true"
@@ -378,7 +378,7 @@ metadata:
   annotations:
     config.k8s.io/function: |
       container:
-        image: gcr.io/kpt-functions/sops
+        image: gcr.io/kpt-fn-contrib/sops:unstable
         envs:
 	- SOPS_IMPORT_PGP
     config.kubernetes.io/local-config: "true"

--- a/scripts/go-function-release.sh
+++ b/scripts/go-function-release.sh
@@ -18,13 +18,14 @@
 # CURRENT_FUNCTION is the target kpt function. e.g. set-namespace.
 # TAG can be any valid docker tags. If the TAG is semver e.g. v1.2.3, shorter
 # version of this semver will be tagged too. e.g. v1.2 and v1.
-# GCR_REGISTRY is the desired container registry e.g. gcr.io/my-registry. This
-# is optional. If not set, the default value gcr.io/kpt-functions will be used.
+# DEFAULT_GCR is the desired container registry e.g. gcr.io/kpt-fn. This is
+# optional. If not set, the default value gcr.io/kpt-fn-contrib will be used.
+# If GCR_REGISTRY is set, it will override DEFAULT_GCR.
 # example 1:
-# Invocation: GCR_REGISTRY=gcr.io/kpt-fn CURRENT_FUNCTION=set-namespace TAG=v1.2.3 go-function-release.sh build
+# Invocation: DEFAULT_GCR=gcr.io/kpt-fn CURRENT_FUNCTION=set-namespace TAG=v1.2.3 go-function-release.sh build
 # It builds gcr.io/kpt-fn/set-namespace:v1.2.3, gcr.io/kpt-fn/set-namespace:v1.2
 # and gcr.io/kpt-fn/set-namespace:v1.
-# Invocation: GCR_REGISTRY=gcr.io/kpt-fn CURRENT_FUNCTION=set-namespace TAG=v1.2.3 go-function-release.sh push
+# Invocation: DEFAULT_GCR=gcr.io/kpt-fn CURRENT_FUNCTION=set-namespace TAG=v1.2.3 go-function-release.sh push
 # It pushes the above 3 images.
 # example 2:
 # Invocation: CURRENT_FUNCTION=set-namespace TAG=unstable go-function-release.sh build
@@ -43,7 +44,8 @@ source ${scripts_dir}/git-tag-parser.sh
 
 DEV_TAG=dev
 versions=$(get_versions "${TAG}")
-GCR_REGISTRY=${GCR_REGISTRY:-gcr.io/kpt-functions}
+DEFAULT_GCR=${DEFAULT_GCR:-gcr.io/kpt-fn-contrib}
+GCR_REGISTRY=${GCR_REGISTRY:-${DEFAULT_GCR}}
 
 cd "${scripts_dir}"/../functions/go
 

--- a/scripts/ts-function-release.sh
+++ b/scripts/ts-function-release.sh
@@ -18,13 +18,14 @@
 # CURRENT_FUNCTION is the target kpt function. e.g. kubeval.
 # TAG can be any valid docker tags. If the TAG is semver e.g. v1.2.3, shorter
 # versions of this semver will be tagged too. e.g. v1.2 and v1.
-# GCR_REGISTRY is the desired container registry e.g. gcr.io/my-registry. This
-# is optional. If not set, the default value gcr.io/kpt-functions will be used.
+# DEFAULT_GCR is the desired container registry e.g. gcr.io/kpt-fn. This is
+# optional. If not set, the default value gcr.io/kpt-fn-contrib will be used.
+# If GCR_REGISTRY is set, it will override DEFAULT_GCR.
 # example 1:
-# Invocation: GCR_REGISTRY=gcr.io/kpt-fn CURRENT_FUNCTION=kubeval TAG=v1.2.3 ts-function-release.sh build
+# Invocation: DEFAULT_GCR=gcr.io/kpt-fn CURRENT_FUNCTION=kubeval TAG=v1.2.3 ts-function-release.sh build
 # It builds gcr.io/kpt-fn/kubeval:v1.2.3, gcr.io/kpt-fn/kubeval:v1.2 and
 # gcr.io/kpt-fn/kubeval:v1.
-# Invocation: GCR_REGISTRY=gcr.io/kpt-fn CURRENT_FUNCTION=kubeval TAG=v1.2.3 ts-function-release.sh push
+# Invocation: DEFAULT_GCR=gcr.io/kpt-fn CURRENT_FUNCTION=kubeval TAG=v1.2.3 ts-function-release.sh push
 # It pushes the above 3 images.
 # example 2:
 # Invocation: CURRENT_FUNCTION=kubeval TAG=unstable ts-function-release.sh build
@@ -43,7 +44,8 @@ source ${scripts_dir}/git-tag-parser.sh
 
 DEV_TAG=dev
 versions=$(get_versions "${TAG}")
-GCR_REGISTRY=${GCR_REGISTRY:-gcr.io/kpt-functions}
+DEFAULT_GCR=${DEFAULT_GCR:-gcr.io/kpt-fn-contrib}
+GCR_REGISTRY=${GCR_REGISTRY:-${DEFAULT_GCR}}
 
 cd "${scripts_dir}/../functions/ts/${CURRENT_FUNCTION}"
 

--- a/tests/helm-inflator/fn-config.yaml
+++ b/tests/helm-inflator/fn-config.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     config.k8s.io/function: |
       container:
-        image: gcr.io/kpt-functions/helm-inflator:dev
+        image: gcr.io/kpt-fn-contrib/helm-inflator:dev
         network: true
     config.kubernetes.io/local-config: 'true'
 data:

--- a/tests/sops.sh
+++ b/tests/sops.sh
@@ -26,13 +26,13 @@ testcase "kpt_sops_imperative_expected_args"
 mkdir example-configs && curl -fsSL -o example-configs/example.yaml https://raw.githubusercontent.com/mozilla/sops/master/example.yaml || echo "couldn't create example.yaml"
 curl -fsSL -o key.asc https://raw.githubusercontent.com/mozilla/sops/master/pgp/sops_functional_tests_key.asc || echo "couldn't create key.asc"
 kpt fn source example-configs |
-  kpt fn run --env SOPS_IMPORT_PGP="$(cat key.asc)" --image gcr.io/kpt-functions/sops:"${TAG}" -- verbose=true >out.yaml
+  kpt fn run --env SOPS_IMPORT_PGP="$(cat key.asc)" --image gcr.io/kpt-fn-contrib/sops:"${TAG}" -- verbose=true >out.yaml
 assert_contains_string out.yaml "t00m4nys3cr3tzupdated"
 
 testcase "kpt_sops_declarative_example"
 # get examples from the current version of repo
 cp -r "$REPODIR"/examples/sops .
-sed -i 's|gcr.io/kpt-functions/sops|gcr.io/kpt-functions/sops:dev|' sops/local-configs/function.yaml
+sed -i.bak 's|gcr.io/kpt-fn-contrib/sops:unstable|gcr.io/kpt-fn-contrib/sops:dev|' sops/local-configs/function.yaml
 curl -fsSL -o key.asc https://raw.githubusercontent.com/mozilla/sops/master/pgp/sops_functional_tests_key.asc
 SOPS_IMPORT_PGP="$(cat key.asc)" kpt fn run sops/local-configs
 assert_contains_string sops/local-configs/to-decrypt.yaml "nnn-password: k8spassphrase"
@@ -47,7 +47,7 @@ metadata:
   annotations:
     config.k8s.io/function: |
       container:
-        image: gcr.io/kpt-functions/sops:${TAG}
+        image: gcr.io/kpt-fn-contrib/sops:${TAG}
     config.kubernetes.io/local-config: "true"
 data:
 EOF


### PR DESCRIPTION
We use `unstable` as image tag name until we have stable release for these kpt functions.
This PR also starts to use gcr.io/kpt-fn and gcr.io/kpt-fn-contrib repos for the functions that live in this repo.
