### PR TITLE
use Entrypoint instead of CMD in Dockerfiles

### DIFF
--- a/functions/go/set-annotation/Dockerfile
+++ b/functions/go/set-annotation/Dockerfile
@@ -1,8 +1,15 @@
 FROM golang:1.15-alpine3.12
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
+
+COPY go.mod go.sum ./
+RUN go mod download
+
 COPY . .
 RUN go build -o /usr/local/bin/function ./
+
+#############################################
+
 FROM alpine:3.12
 COPY --from=0 /usr/local/bin/function /usr/local/bin/function
-CMD ["function"]
+ENTRYPOINT ["function"]

--- a/functions/go/set-label/Dockerfile
+++ b/functions/go/set-label/Dockerfile
@@ -1,8 +1,15 @@
 FROM golang:1.15-alpine3.12
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
+
+COPY go.mod go.sum ./
+RUN go mod download
+
 COPY . .
 RUN go build -o /usr/local/bin/function ./
+
+#############################################
+
 FROM alpine:3.12
 COPY --from=0 /usr/local/bin/function /usr/local/bin/function
-CMD ["function"]
+ENTRYPOINT ["function"]

--- a/functions/go/set-namespace/Dockerfile
+++ b/functions/go/set-namespace/Dockerfile
@@ -1,6 +1,10 @@
 FROM golang:1.15-alpine3.12
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
+
+COPY go.mod go.sum ./
+RUN go mod download
+
 COPY . .
 RUN go build -o /usr/local/bin/function ./
 
@@ -8,4 +12,4 @@ RUN go build -o /usr/local/bin/function ./
 
 FROM alpine:3.12
 COPY --from=0 /usr/local/bin/function /usr/local/bin/function
-CMD ["function"]
+ENTRYPOINT ["function"]

--- a/functions/go/starlark/Dockerfile
+++ b/functions/go/starlark/Dockerfile
@@ -1,15 +1,15 @@
 FROM golang:1.15-alpine3.12
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
-COPY go.mod go.mod
-COPY go.sum go.sum
+
+COPY go.mod go.sum ./
 RUN go mod download
-COPY main.go main.go
-COPY config.go config.go
+
+COPY . .
 RUN go build -o /usr/local/bin/star ./
 
 #############################################
 
 FROM alpine:3.12
 COPY --from=0 /usr/local/bin/star /usr/local/bin/star
-CMD ["star"]
+ENTRYPOINT ["star"]


### PR DESCRIPTION
Also tweak Dockerfile to speed up build speed by avoiding repeatly downloading go modules.

This will make implementing `kpt fn doc` command easier. We don't need to specify the CMD. It now becomes `docker run <image-name> --help`.
