### PR TITLE
Handle types in apply-setters

### DIFF
--- a/functions/go/apply-setters/apply_setters_test.go
+++ b/functions/go/apply-setters/apply_setters_test.go
@@ -285,6 +285,41 @@ spec:
 `,
 			errMsg: `invalid setter pattern for array node: "${images}:${tag}"`,
 		},
+		{
+			name: "setter type handling",
+			config: `
+data:
+  foo: false
+  bar: 20
+  baz: 21.22
+`,
+			input: `apiVersion: apps/v1
+kind: MyKind
+metadata:
+  annotations:
+    foo1: "true" # kpt-set: ${foo}
+    foo2: hello # kpt-set: ${foo}
+    bar: "10" # kpt-set: ${bar}
+    baz: "11.12" # kpt-set: ${baz}
+    bor: true-10-11.12 # kpt-set: ${foo}-${bar}-${baz}
+spec:
+  replicas1: "two" # kpt-set: ${bar}
+  replicas2: two # kpt-set: ${bar}
+`,
+			expectedResources: `apiVersion: apps/v1
+kind: MyKind
+metadata:
+  annotations:
+    foo1: "false" # kpt-set: ${foo}
+    foo2: false # kpt-set: ${foo}
+    bar: "20" # kpt-set: ${bar}
+    baz: "21.22" # kpt-set: ${baz}
+    bor: false-20-21.22 # kpt-set: ${foo}-${bar}-${baz}
+spec:
+  replicas1: "20" # kpt-set: ${bar}
+  replicas2: 20 # kpt-set: ${bar}
+`,
+		},
 	}
 	for i := range tests {
 		test := tests[i]

--- a/functions/go/apply-setters/apply_setters_test.go
+++ b/functions/go/apply-setters/apply_setters_test.go
@@ -453,3 +453,111 @@ func TestCurrentSetterValues(t *testing.T) {
 		}
 	}
 }
+
+type typeTest struct {
+	name    string
+	yamlTag string
+	value   string
+	isError bool
+}
+
+var validateTypeCases = []typeTest{
+	{
+		name:    "string can't be bool",
+		value:   "foo",
+		yamlTag: kyaml.NodeTagBool,
+		isError: true,
+	},
+	{
+		name:    "string can't be float",
+		value:   "foo",
+		yamlTag: kyaml.NodeTagFloat,
+		isError: true,
+	},
+	{
+		name:    "string can't be int",
+		value:   "foo",
+		yamlTag: kyaml.NodeTagInt,
+		isError: true,
+	},
+	{
+		name:    "string can't be sequence",
+		value:   "foo",
+		yamlTag: kyaml.NodeTagSeq,
+		isError: true,
+	},
+	{
+		name:    "string can't be map",
+		value:   "foo",
+		yamlTag: kyaml.NodeTagMap,
+		isError: true,
+	},
+	{
+		name:    "bool can't be int",
+		value:   "true",
+		yamlTag: kyaml.NodeTagInt,
+		isError: true,
+	},
+	{
+		name:    "int can't be float",
+		value:   "10",
+		yamlTag: kyaml.NodeTagFloat,
+		isError: true,
+	},
+	{
+		name:    "float can't be int",
+		value:   "10.1",
+		yamlTag: kyaml.NodeTagInt,
+		isError: true,
+	},
+	{
+		name:    "bool can be string",
+		value:   "true",
+		yamlTag: kyaml.NodeTagString,
+		isError: false,
+	},
+	{
+		name:    "float can be string",
+		value:   "1.22",
+		yamlTag: kyaml.NodeTagString,
+		isError: false,
+	},
+	{
+		name:    "int can be string",
+		value:   "1",
+		yamlTag: kyaml.NodeTagString,
+		isError: false,
+	},
+	{
+		name:    "sequence can be string",
+		value:   "[foo, bar]",
+		yamlTag: kyaml.NodeTagString,
+		isError: false,
+	},
+	{
+		name:    "map can be string",
+		value:   "a: b",
+		yamlTag: kyaml.NodeTagString,
+		isError: false,
+	},
+}
+
+func TestValidateType(t *testing.T) {
+	for _, tests := range [][]typeTest{validateTypeCases} {
+		for i := range tests {
+			test := tests[i]
+			t.Run(test.name, func(t *testing.T) {
+				err := validateType(test.yamlTag, test.value)
+				if test.isError {
+					if !assert.Error(t, err) {
+						t.FailNow()
+					}
+				} else {
+					if !assert.NoError(t, err) {
+						t.FailNow()
+					}
+				}
+			})
+		}
+	}
+}

--- a/functions/go/apply-setters/apply_setters_test.go
+++ b/functions/go/apply-setters/apply_setters_test.go
@@ -303,22 +303,40 @@ metadata:
     baz: "11.12" # kpt-set: ${baz}
     bor: true-10-11.12 # kpt-set: ${foo}-${bar}-${baz}
 spec:
-  replicas1: "two" # kpt-set: ${bar}
-  replicas2: two # kpt-set: ${bar}
+  replicas: 10 # kpt-set: ${bar}
 `,
 			expectedResources: `apiVersion: apps/v1
 kind: MyKind
 metadata:
   annotations:
     foo1: "false" # kpt-set: ${foo}
-    foo2: false # kpt-set: ${foo}
+    foo2: "false" # kpt-set: ${foo}
     bar: "20" # kpt-set: ${bar}
     baz: "21.22" # kpt-set: ${baz}
     bor: false-20-21.22 # kpt-set: ${foo}-${bar}-${baz}
 spec:
-  replicas1: "20" # kpt-set: ${bar}
-  replicas2: 20 # kpt-set: ${bar}
+  replicas: 20 # kpt-set: ${bar}
 `,
+		},
+		{
+			name: "error for incorrect input type",
+			config: `
+data:
+  replicas: two
+`,
+			input: `apiVersion: apps/v1
+kind: MyKind
+metadata:
+spec:
+  replicas: 10 # kpt-set: ${replicas}
+`,
+			expectedResources: `apiVersion: apps/v1
+kind: MyKind
+metadata:
+spec:
+  replicas: 10 # kpt-set: ${replicas}
+`,
+			errMsg: `input value "two" doesn't conform to node type "int"`,
 		},
 	}
 	for i := range tests {


### PR DESCRIPTION
This PR is to ensure that `apply-setters` function sets only the value of node(with setter comment) and doesn't change the type of node. If input value doesn't conform to the existing type of the node, the function should throw an error.

Since value of any type can interpreted as string, the function will not throw an error if node type is string.
e.g. If input value is `10` and node type is `string`, accept the value and yaml serializer will add quotes to it(`"10"`).
Conversely, if input value is `ten` and node type is `int`, the function throws an error.

cc @mortent @yhrn