### PR TITLE
Fix miscellaneous styling issues.

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -29,6 +29,8 @@
           maxAge: 43200000,
           placeholder: "Search",
         },
+        crossOriginLinks: ["https://kpt.dev/"],
+        externalLinkTarget: "_self",
         alias: {
           "/.*/sidebar.md": "/sidebar.md",
         },
@@ -110,13 +112,13 @@
                 // Change the GH icon to point to the current example if it exists.
                 if (currentEx) {
                   ghElement.href = examples[currentEx].RemoteExamplePath;
-                } 
+                }
                 // If not on an example, change the GH icon to point to the current version if it exists.
                 else if (versionName) {
                   const exampleSuffix = /examples\/.+/;
                   ghElement.href = examples[exampleNames[0]].RemoteSourcePath;
                 }
-                // On every other page, point to the main catalog repo. 
+                // On every other page, point to the main catalog repo.
                 else {
                   ghElement.href = window.$docsify.corner.url;
                 }

--- a/site/index.html
+++ b/site/index.html
@@ -28,12 +28,12 @@
     <script>
       window.$docsify = {
         name: "kpt",
-        nameLink: "https://kpt.dev/",
+        nameLink: "https://kpt.dev/?id=overview",
         search: {
           maxAge: 43200000,
           placeholder: "Search",
         },
-        crossOriginLinks: ["https://kpt.dev/"],
+        crossOriginLinks: ["https://kpt.dev/?id=overview"],
         externalLinkTarget: "_self",
         alias: {
           "/.*/sidebar.md": "/sidebar.md",

--- a/site/index.html
+++ b/site/index.html
@@ -11,11 +11,11 @@
     />
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple.css"
+      href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css"
     />
     <link
       rel="stylesheet"
-      href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css"
+      href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple.css"
     />
     <link
       rel="icon"
@@ -164,8 +164,13 @@
       --sidebar-toggle-offset-top: unset;
       --sidebar-width: 20rem;
     }
-    .body {
-      line-height: var(--base-line-height) !important;
+    body {
+      line-height: unset;
+      font-family: unset;
+      font-size: unset;
+    }
+    h1 {
+      line-height: unset;
     }
 
     .dropdown-container {

--- a/site/index.html
+++ b/site/index.html
@@ -17,7 +17,11 @@
       rel="stylesheet"
       href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css"
     />
-    <link rel="icon" href="/favicon.ico" type="image/x-icon" />
+    <link
+      rel="icon"
+      href="https://raw.githubusercontent.com/GoogleContainerTools/kpt/master/site/static/favicons/favicon.ico"
+      type="image/x-icon"
+    />
   </head>
   <body>
     <div id="app"></div>

--- a/site/sidebar.md
+++ b/site/sidebar.md
@@ -1,7 +1,7 @@
 <!-- TODO: Generate this in a build step before deploying. -->
-- [Installation](https://kpt.dev/installation/)
-- [Book](https://kpt.dev/book/)
-- [Reference](https://kpt.dev/reference/)
+- [Installation](https://kpt.dev/installation/ ':crossorgin')
+- [Book](https://kpt.dev/book/ ':crossorgin')
+- [Reference](https://kpt.dev/reference/ ':crossorgin')
 - [Functions Catalog](/)
-- [FAQ](https://kpt.dev/faq/)
-- [Contact](https://kpt.dev/contact/)
+- [FAQ](https://kpt.dev/faq/ ':crossorgin')
+- [Contact](https://kpt.dev/contact/ ':crossorgin')


### PR DESCRIPTION
Addresses https://github.com/GoogleContainerTools/kpt/issues/1717 and https://github.com/GoogleContainerTools/kpt/issues/1825 for catalog.kpt.dev
Add favicon.
Top `kpt` links to overview page.
External links open to kpt.dev
Match styling to kpt.dev