### PR TITLE
Add kpt logo to catalog site.

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>Home</title>
+    <title>kpt Functions Catalog</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta name="description" content="Description" />
     <meta
@@ -19,7 +19,7 @@
     />
     <link
       rel="icon"
-      href="https://raw.githubusercontent.com/GoogleContainerTools/kpt/master/site/static/favicons/favicon.ico"
+      href="https://raw.githubusercontent.com/GoogleContainerTools/kpt/next/site/static/images/logo.svg"
       type="image/x-icon"
     />
   </head>
@@ -27,7 +27,7 @@
     <div id="app"></div>
     <script>
       window.$docsify = {
-        name: "kpt",
+        name: `<img src="https://raw.githubusercontent.com/GoogleContainerTools/kpt/next/site/static/images/logo.svg" alt="kpt" />`,
         nameLink: "https://kpt.dev/?id=overview",
         search: {
           maxAge: 43200000,
@@ -157,7 +157,8 @@
       --search-result-keyword-background: unset;
       --search-result-keyword-margin: unset;
       --search-result-keyword-font-weight: 800;
-      --sidebar-background: #30638e;
+      --theme-color: #06689f;
+      --sidebar-background: #06689f;
       --sidebar-nav-link-color: rgba(255, 255, 255, 0.75);
       --sidebar-nav-link-color--active: white;
       --sidebar-name-color: white;
@@ -185,6 +186,9 @@
     }
     .sidebar > h1 {
       font-size: var(--sidebar-name-font-size);
+    }
+    .sidebar > h1 img {
+      height: 32px;
     }
     .sidebar-toggle {
       display: none;


### PR DESCRIPTION
Fixes https://github.com/GoogleContainerTools/kpt/issues/1717
![image](https://user-images.githubusercontent.com/31711490/118066729-140db700-b354-11eb-932a-a650c16bd927.png)
Brightens the color of the site theme to match the logo background.