### PR TITLE
Results for apply-setters

### DIFF
--- a/examples/apply-setters/simple/.expected/results.yaml
+++ b/examples/apply-setters/simple/.expected/results.yaml
@@ -1,6 +1,0 @@
-name: apply-setters
-items:
-- message: 'set field value to "my-new-map" in file "resources.yaml" in field "metadata.name"'
-  severity: info
-- message: 'set field value to "- prod\n- stage\n" in file "resources.yaml" in field "environments"'
-  severity: info

--- a/examples/apply-setters/simple/.expected/results.yaml
+++ b/examples/apply-setters/simple/.expected/results.yaml
@@ -1,0 +1,6 @@
+name: apply-setters
+items:
+- message: 'set field value to "my-new-map" in file "resources.yaml" in field "metadata.name"'
+  severity: info
+- message: 'set field value to "- prod\n- stage\n" in file "resources.yaml" in field "environments"'
+  severity: info

--- a/functions/go/apply-setters/applysetters/apply_setters.go
+++ b/functions/go/apply-setters/applysetters/apply_setters.go
@@ -19,10 +19,10 @@ var _ kio.Filter = &ApplySetters{}
 // by the setter reference comments
 type ApplySetters struct {
 	// Setters holds the user provided values for all the setters
-	Setters []Setter `json:"setters,omitempty" yaml:"setters,omitempty"`
+	Setters []Setter
 
 	// Results are the results of applying setter values
-	Results []*Result `json:"results,omitempty" yaml:"results,omitempty"`
+	Results []*Result
 
 	// filePath file path of resource
 	filePath string
@@ -30,10 +30,10 @@ type ApplySetters struct {
 
 type Setter struct {
 	// Name is the name of the setter
-	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	Name string
 
 	// Value is the input value for setter
-	Value string `json:"value,omitempty" yaml:"value,omitempty"`
+	Value string
 }
 
 // Result holds result of search and replace operation

--- a/functions/go/apply-setters/applysetters/apply_setters.go
+++ b/functions/go/apply-setters/applysetters/apply_setters.go
@@ -51,7 +51,7 @@ type Result struct {
 // Filter implements Set as a yaml.Filter
 func (as *ApplySetters) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
 	if len(as.Setters) == 0 {
-		return nodes, fmt.Errorf("failed to configure function: input setters list cannot be empty")
+		return nodes, fmt.Errorf("input setters list cannot be empty")
 	}
 	for i := range nodes {
 		filePath, _, err := kioutil.GetFileAnnotations(nodes[i])

--- a/functions/go/apply-setters/applysetters/apply_setters_test.go
+++ b/functions/go/apply-setters/applysetters/apply_setters_test.go
@@ -366,7 +366,7 @@ spec:
         - name: nginx
           image: nginx:1.7.9 # kpt-set: ${image}:${tag}
 `,
-			errMsg: `failed to configure function: input setters list cannot be empty`,
+			errMsg: `input setters list cannot be empty`,
 		},
 		{
 			name: "set empty values",

--- a/functions/go/apply-setters/applysetters/walk.go
+++ b/functions/go/apply-setters/applysetters/walk.go
@@ -1,6 +1,9 @@
 package applysetters
 
 import (
+	"fmt"
+
+	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
@@ -9,40 +12,58 @@ import (
 type visitor interface {
 	// visitScalar is called for each scalar field value on a resource
 	// node is the scalar field value
-	visitScalar(node *yaml.RNode) error
+	// path is the path to the field; path elements are separated by '.'
+	visitScalar(node *yaml.RNode, path string) error
 
 	// visitMapping is called for each Mapping field value on a resource
 	// node is the mapping field value
-	visitMapping(node *yaml.RNode) error
+	// path is the path to the field
+	visitMapping(node *yaml.RNode, path string) error
 }
 
 // accept invokes the appropriate function on v for each field in object
 func accept(v visitor, object *yaml.RNode) error {
-	return acceptImpl(v, object)
+	// get the OpenAPI for the type if it exists
+	return acceptImpl(v, object, "")
 }
 
 // acceptImpl implements accept using recursion
-func acceptImpl(v visitor, object *yaml.RNode) error {
+func acceptImpl(v visitor, object *yaml.RNode, p string) error {
 	switch object.YNode().Kind {
 	case yaml.DocumentNode:
 		// Traverse the child of the document
-		return accept(v, object)
+		return accept(v, yaml.NewRNode(object.YNode()))
 	case yaml.MappingNode:
-		if err := v.visitMapping(object); err != nil {
+		if err := v.visitMapping(object, p); err != nil {
 			return err
 		}
 		return object.VisitFields(func(node *yaml.MapNode) error {
 			// Traverse each field value
-			return acceptImpl(v, node.Value)
+			return acceptImpl(v, node.Value, p+"."+node.Key.YNode().Value)
 		})
 	case yaml.SequenceNode:
-		return object.VisitElements(func(node *yaml.RNode) error {
+		return VisitElements(object, func(node *yaml.RNode, i int) error {
 			// Traverse each list element
-			return acceptImpl(v, node)
+			return acceptImpl(v, node, p+fmt.Sprintf("[%d]", i))
 		})
 	case yaml.ScalarNode:
 		// Visit the scalar field
-		return v.visitScalar(object)
+		return v.visitScalar(object, p)
+	}
+	return nil
+}
+
+// VisitElements calls fn for each element in a SequenceNode.
+// Returns an error for non-SequenceNodes
+func VisitElements(rn *yaml.RNode, fn func(node *yaml.RNode, i int) error) error {
+	elements, err := rn.Elements()
+	if err != nil {
+		return errors.Wrap(err)
+	}
+	for i := range elements {
+		if err := fn(elements[i], i); err != nil {
+			return errors.Wrap(err)
+		}
 	}
 	return nil
 }

--- a/functions/go/apply-setters/main.go
+++ b/functions/go/apply-setters/main.go
@@ -16,9 +16,6 @@ func main() {
 	resourceList.FunctionConfig = map[string]interface{}{}
 
 	cmd := framework.Command(resourceList, func() error {
-		resourceList.Result = &framework.Result{
-			Name: "apply-setters",
-		}
 		s, err := getSetters(resourceList.FunctionConfig)
 		if err != nil {
 			return fmt.Errorf("failed to parse function config: %w", err)
@@ -27,7 +24,10 @@ func main() {
 		if err != nil {
 			return fmt.Errorf("failed to apply setters: %w", err)
 		}
-		resourceList.Result.Items = resultsToItems(s)
+		resourceList.Result = &framework.Result{
+			Name: "apply-setters",
+			Items: resultsToItems(s),
+		}
 		return nil
 	})
 

--- a/tests/apply-setters/no-matches-error/.expected/config.yaml
+++ b/tests/apply-setters/no-matches-error/.expected/config.yaml
@@ -1,0 +1,2 @@
+runCount: 2
+exitCode: 1

--- a/tests/apply-setters/no-matches-error/.expected/results.yaml
+++ b/tests/apply-setters/no-matches-error/.expected/results.yaml
@@ -1,0 +1,4 @@
+name: apply-setters
+items:
+- message: 'failed to apply setters: no matches for the input list of setters'
+  severity: error

--- a/tests/apply-setters/no-matches-error/.krmignore
+++ b/tests/apply-setters/no-matches-error/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/tests/apply-setters/no-matches-error/fn-config.yaml
+++ b/tests/apply-setters/no-matches-error/fn-config.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: apply-setters-fn-config
+  annotations:
+    config.k8s.io/function: |
+      container:
+        image: gcr.io/kpt-fn/apply-setters:unstable
+data:
+  name: my-new-map
+  env: |
+    - prod
+    - stage

--- a/tests/apply-setters/no-matches-error/resources.yaml
+++ b/tests/apply-setters/no-matches-error/resources.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: the-map # kpt-set: ${non-matching-name}
+data:
+  some-key: some-value
+---
+apiVersion: v1
+kind: MyKind
+metadata:
+  name: ns
+environments: # kpt-set: ${non-matching-env}
+- dev
+- stage


### PR DESCRIPTION
This PR is to add results for `apply-setters` function.

```
➜  simple k fn eval --image gcr.io/kpt-fn/apply-setters:unstable --fn-config ./fn-config.yaml
[RUNNING] "gcr.io/kpt-fn/apply-setters:unstable"
[PASS] "gcr.io/kpt-fn/apply-setters:unstable"
  Results:
    [INFO] Set field value to "my-new-map" in file "resources.yaml" in field "metadata.name"
    [INFO] Set field value to "- prod\n- stage\n" in file "resources.yaml" in field "environments"
```