### PR TITLE
Empty values not allowed for apply-setters

### DIFF
--- a/functions/go/apply-setters/applysetters/apply_setters.go
+++ b/functions/go/apply-setters/applysetters/apply_setters.go
@@ -31,8 +31,8 @@ type Setter struct {
 
 // Filter implements Set as a yaml.Filter
 func (as ApplySetters) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
-	if len(as.Setters) == 0 {
-		return nodes, fmt.Errorf("failed to configure function: input setters list cannot be empty")
+	if err := as.validateInput(); err != nil {
+		return nodes, err
 	}
 	for i := range nodes {
 		err := accept(&as, nodes[i])
@@ -41,6 +41,19 @@ func (as ApplySetters) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
 		}
 	}
 	return nodes, nil
+}
+
+// validateInput validates the input setter values
+func (as *ApplySetters) validateInput() error {
+	if len(as.Setters) == 0 {
+		return fmt.Errorf("input setters list cannot be empty")
+	}
+	for _, setter := range as.Setters {
+		if setter.Value == "" {
+			return fmt.Errorf("found empty input value for setter: %q", setter.Name)
+		}
+	}
+	return nil
 }
 
 /*

--- a/functions/go/apply-setters/applysetters/apply_setters_test.go
+++ b/functions/go/apply-setters/applysetters/apply_setters_test.go
@@ -366,7 +366,7 @@ spec:
         - name: nginx
           image: nginx:1.7.9 # kpt-set: ${image}:${tag}
 `,
-			errMsg: `failed to configure function: input setters list cannot be empty`,
+			errMsg: `input setters list cannot be empty`,
 		},
 		{
 			name: "set empty values",
@@ -374,28 +374,17 @@ spec:
 kind: Service
 metadata:
   name: myService # kpt-set: ${app}
-  namespace: foo # kpt-set: ${ns}
-image: nginx:1.7.1 # kpt-set: ${image}:${tag}
-env: # kpt-set: ${env}
-  - foo
-  - bar
 `,
 			config: `
 data:
   app: ""
-  ns: ~
-  image: ''
-  env: ~
 `,
 			expectedResources: `apiVersion: v1
 kind: Service
 metadata:
-  name: # kpt-set: ${app}
-  namespace: # kpt-set: ${ns}
-image: :1.7.1 # kpt-set: ${image}:${tag}
-env: # kpt-set: ${env}
-  - null
+  name: myService # kpt-set: ${app}
 `,
+			errMsg: `found empty input value for setter: "app"`,
 		},
 	}
 	for i := range tests {


### PR DESCRIPTION
`apply-setters` function only accepts configMap as input. Empty values are illegal in configMap. So to be consistent, the function should not accept empty values as input from any source.