### PR TITLE
Add "open an issue" link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 [Documentation]
 
+[Open an Issue]
+
 [Contributor Guide]
 
 [Release Process]
@@ -14,3 +16,4 @@
 [Contributor Guide]: CONTRIBUTING.md
 [Code of Conduct]: CODE_OF_CONDUCT.md
 [Release Process]: RELEASING.md
+[Open an Issue]: https://github.com/GoogleContainerTools/kpt/issues


### PR DESCRIPTION
This adds an "Open an Issue" link to the function catalog README. Issues can not be opened against this project so a link is provided to help direct people to an area for raising issues and creating work items for the project.