### PR TITLE
create-setters: handle multiple lines and substrings

### DIFF
--- a/examples/create-setters-simple/README.md
+++ b/examples/create-setters-simple/README.md
@@ -2,8 +2,7 @@
 
 ### Overview
 
-The `create-setters` KRM config function adds comments to resource fields
-with setter references.
+The `create-setters` KRM config function adds setter comments to resource fields to be parameterized.
 
 In this example, we will see how to add setter comments declaratively to
 resource fields using `create-setters` function.
@@ -38,7 +37,7 @@ roles:
 We use `ConfigMap` to configure the `create-setters` function.
 The desired setter values are provided as key-value pairs using `data` field.
 Here, key is the name of the setter which is used to set the comment and value
-is the field value to parameterize.
+is the field value to be parameterized.
 
 ```yaml
 # create-setters-fn-config.yaml
@@ -86,7 +85,7 @@ $ kpt fn render create-setters-simple
 
 ### Expected result
 
-`Comment` is added to the resources with the `Values` given below as they match the `Setters`.
+`Comment` is added to the resource with the `Value` given below as they match the `Setters`.
 
 | Setters                                    | Value                        | Comment                               |
 |--------------------------------------------|------------------------------|---------------------------------------|

--- a/examples/create-setters-simple/README.md
+++ b/examples/create-setters-simple/README.md
@@ -17,6 +17,7 @@ $ kpt pkg get https://github.com/GoogleContainerTools/kpt-functions-catalog.git/
 ```
 
 ```yaml
+# resources.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -40,6 +41,7 @@ Here, key is the name of the setter which is used to set the comment and value
 is the field value to parameterize.
 
 ```yaml
+# create-setters-fn-config.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -56,6 +58,7 @@ data:
 Invoking `create-setters` function would add the setter comments.
 
 ```yaml
+# resources.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/functions/go/create-setters/README.md
+++ b/functions/go/create-setters/README.md
@@ -20,7 +20,7 @@ parameterize the field values of resources using this function.
 We use `ConfigMap` to configure the `create-setters` function. The desired setter
 values are provided as key-value pairs using `data` field.
 Here, the key is the name of the setter used as a parameter and
-value is the field value to parameterize.
+value is the field value to be parameterized.
 
 ```yaml
 apiVersion: v1
@@ -40,8 +40,7 @@ On invoking `create-setters`, it performs the following steps:
    - For an array node, checks if all values match with any of the array setters.
 4. Adds comments to the fields matching the setter values using setter names as parameters.
 
->? Doesn't support adding comment to the scalar node whose value is split into multiple lines.
-If this function adds setter comments to fields for which you didn't intend to parameterize,
+>? If this function adds setter comments to fields for which you didn't intend to parameterize,
 you can simply review and delete/modify those comments manually.
 
 <!--mdtogo-->
@@ -71,7 +70,7 @@ spec:
 Declare the name of the setter with the value which need to be parameterized.
 
 ```yaml
-# create-setters-fn-config
+# create-setters-fn-config.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -83,10 +82,10 @@ data:
   tag: 1.1.2
 ```
 
-Render the declared values by invoking:
+Invoke the function using the input config:
 
 ```shell
-$ kpt fn eval --image gcr.io/kpt-fn/create-setters:unstable --fn-config ./create-setters-fn-config
+$ kpt fn eval --image gcr.io/kpt-fn/create-setters:unstable --fn-config ./create-setters-fn-config.yaml
 ```
 
 Alternatively, setter values can be passed as key-value pairs in the CLI
@@ -95,7 +94,7 @@ Alternatively, setter values can be passed as key-value pairs in the CLI
 $ kpt fn eval --image gcr.io/kpt-fn/create-setters:unstable -- deploy=ubuntu-deployment env=ubuntu image=nginx tag=1.1.2
 ```
 
-Rendered resource looks like the following:
+Modified resource looks like the following:
 
 ```yaml
 # resources.yaml
@@ -111,9 +110,11 @@ spec:
     - mac
 ```
 
+>? This function doesn't add comments to scalar nodes with multi-line values.
+
 Explanation for the changes:
 
-`Comment` is added to the `Resources` field value node when they match the `Scalar Setters`.
+`Comment` is added to the `Resource Field` value node when they match the `Scalar Setters`.
 
 | Scalar Setters            | Resource Field                | Comment                            | Description     |
 |---------------------------|---------------------------|------------------------------------|-----------------|
@@ -146,7 +147,7 @@ Declare the array values, wrapped into string. Here the order of the array value
 doesn't make a difference.
 
 ```yaml
-# create-setters-fn-config
+# create-setters-fn-config.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -160,7 +161,7 @@ data:
 Render the declared values by invoking:
 
 ```shell
-$ kpt fn eval --image gcr.io/kpt-fn/create-setters:unstable --fn-config ./create-setters-fn-config
+$ kpt fn eval --image gcr.io/kpt-fn/create-setters:unstable --fn-config ./create-setters-fn-config.yaml
 ```
 
 Rendered resource looks like the following:
@@ -174,13 +175,14 @@ metadata:
 environments: # kpt-set: ${env}
   - dev
   - stage
-role: [stage, dev] # kpt-set: ${env}
+role: # kpt-set: ${env}
+  - stage
+  - dev
 ```
 
 Explanation for the changes:
 - As all the values in `environments` match the setter values of `env`, `# kpt-set: ${env}` comment is added.
 Here, the comment is added to the key node as it is an array node with folded style.
-- As all the values in `role` match the setter values of `env`, `# kpt-set: ${env}` comment is added.
-Here, the order of the array values is not considered, and the comment is added to the key node as it 
-is an array node with flow style.
+- As all the values in `role` match the setter values of `env`, array node is converted to folded style and 
+`# kpt-set: ${env}` comment is added to the key node. Here, the order of the array values is not considered.
 <!--mdtogo-->

--- a/functions/go/create-setters/README.md
+++ b/functions/go/create-setters/README.md
@@ -11,8 +11,6 @@ Setters are a safer alternative to other substitution techniques which do not
 have the context of the structured data. Setter comments can be added to
 parameterize the field values of resources using this function.
 
->? Refer to `apply-setters` for easy understanding of setters.
-
 <!--mdtogo-->
 
 ### FunctionConfig

--- a/functions/go/create-setters/README.md
+++ b/functions/go/create-setters/README.md
@@ -11,7 +11,7 @@ Setters are a safer alternative to other substitution techniques which do not
 have the context of the structured data. Setter comments can be added to
 parameterize the field values of resources using this function.
 
->? Refer to [`apply-setters`](https://catalog.kpt.dev/apply-setters/v0.1/) for easy understanding of setters.
+>? Refer to `apply-setters` for easy understanding of setters.
 
 <!--mdtogo-->
 
@@ -63,7 +63,7 @@ kind: Deployment
 metadata:
   name: ubuntu-deployment 
 spec:
-  replicas: 3
+  image: ubuntu
   app: nginx:1.1.2
 ```
 
@@ -103,11 +103,14 @@ kind: Deployment
 metadata:
   name: ubuntu-deployment-1 # kpt-set: ${deploy}-1
 spec:
+  image: ubuntu # kpt-set: ${env}
   app: nginx:1.1.2 # kpt-set: ${image}:${tag}
 ```
+
 Explanation for the changes:
 - Value of `metadata.name` matches with setter values of `env` and `deploy` which have same substring `ubuntu`.
 As `ubuntu-deployment` has the longest length match, `# kpt-set: ${deploy}-1` comment is added.
+- As value of `image` matches with the setter value of `env`, `# kpt-set: ${env}` comment is added.
 - As value of `app` matches with setter values of `image` and `tag`, `# kpt-set: ${image}:${tag}` comment is added.
 
 ### Setting comments for array values
@@ -163,7 +166,9 @@ environments: # kpt-set: ${env}
   - dev # kpt-set: ${role}
   - stage
 ```
+
 Explanation for the changes:
 - As all the values in `environments` matches the setter values of `env`, `# kpt-set: ${env}` comment is added.
 - As the array value `dev` matches with the setter value of `role`, `# kpt-set: ${role}` comment is added.
+
 <!--mdtogo-->

--- a/functions/go/create-setters/README.md
+++ b/functions/go/create-setters/README.md
@@ -184,5 +184,5 @@ Explanation for the changes:
 - As all the values in `environments` match the setter values of `env`, `# kpt-set: ${env}` comment is added.
 Here, the comment is added to the key node as it is an array node with folded style.
 - As all the values in `role` match the setter values of `env`, array node is converted to folded style and 
-`# kpt-set: ${env}` comment is added to the key node. Here, the order of the array values is not considered.
+`# kpt-set: ${env}` comment is added to the key node. Here, the order of the array values doesn't matter.
 <!--mdtogo-->

--- a/functions/go/create-setters/createsetters/create_setters.go
+++ b/functions/go/create-setters/createsetters/create_setters.go
@@ -19,6 +19,9 @@ type CreateSetters struct {
 	// ScalarSetters holds the user provided values for simple scalar setters
 	ScalarSetters []ScalarSetter
 
+	// Replacer is used to replace the setter values
+	Replacer *strings.Replacer
+
 	// ArraySetters holds the user provided values for array setters
 	ArraySetters []ArraySetter
 
@@ -69,10 +72,9 @@ func (a CompareSetters) Len() int {
 	return len(a)
 }
 
-// checks if the jth node's Name is a substring of ith node's Value
-// jth node is sorted first if the condition statisfies
+// node with value of maximum length is placed first
 func (a CompareSetters) Less(i, j int) bool {
-	return !strings.Contains(a[i].Value, a[j].Name)
+	return len(a[i].Value) > len(a[j].Value)
 }
 
 func (a CompareSetters) Swap(i, j int) {
@@ -223,7 +225,12 @@ func (cs *CreateSetters) visitScalar(object *yaml.RNode, path string) error {
 		return nil
 	}
 
-	linecomment, valueMatch := getLineComment(object.YNode().Value, cs.ScalarSetters)
+	// doesn't add the comment to the nodes with multiple line values
+	if hasMultipleLines(object.YNode().Value) {
+		return nil
+	}
+
+	linecomment, valueMatch := getLineComment(object.YNode().Value, cs.Replacer)
 
 	// sets the linecomment if the match is found
 	if valueMatch {
@@ -270,6 +277,10 @@ func getArraySetter(input *yaml.RNode) []string {
 	return output
 }
 
+func hasMultipleLines(value string) bool {
+	return strings.Contains(value, "\n")
+}
+
 // hasMatchValue checks if any of the ScalarSetter value matches with the node value
 func hasMatchValue(nodeValues []string, setters []ScalarSetter) bool {
 	for _, value := range nodeValues {
@@ -298,19 +309,15 @@ apiVersion: v1
 ...
 image: nginx:1.7.1 # kpt-set: ${image}:${tag}
 */
-func getLineComment(nodeValue string, setters []ScalarSetter) (string, bool) {
+func getLineComment(nodeValue string, replacer *strings.Replacer) (string, bool) {
 	output := nodeValue
 	valueMatch := false
 
-	for _, setter := range setters {
-		if strings.Contains(nodeValue, setter.Value) {
-			valueMatch = true
-			output = strings.ReplaceAll(
-				output,
-				setter.Value,
-				fmt.Sprintf("${%s}", setter.Name),
-			)
-		}
+	// replaces the strings simulataneously
+	output = replacer.Replace(nodeValue)
+
+	if output != nodeValue {
+		valueMatch = true
 	}
 
 	return output, valueMatch
@@ -322,16 +329,16 @@ places the setter either in ScalarSetters or ArraySetters
 sorts the ScalarSetters using CompareSetters
 
 e.g.for input ScalarSetters
-	[[name: image, value: nginx], [name: ubuntu, value: image]]
+    [[name: image, value: nginx], [name: ubuntu, value: nginx-abc]]
 
 for scalar node:
-	spec: nginx-development
+    spec: nginx-development
 
-Sorts the ScalarSetters to avoid following case
-	spec: nginx-development # kpt-set: ${ubuntu}-development
+Sorts the ScalarSetters to avoid following case of substrings
+    spec: nginx-abc-development # kpt-set: ${image}-abc-development
 
 ScalarSetters array is transformed to
-	[[name: ubuntu, value: image], [name: image, value: nginx]]
+    [[name: ubuntu, value: nginx-abc], [name: image, value: nginx]]
 */
 func Decode(rn *yaml.RNode, fcd *CreateSetters) error {
 	if len(rn.GetDataMap()) == 0 {
@@ -354,5 +361,13 @@ func Decode(rn *yaml.RNode, fcd *CreateSetters) error {
 
 	// sorts all the Setters
 	sort.Sort(CompareSetters(fcd.ScalarSetters))
+
+	// replacerArgs contains the setter values with parameter
+	replacerArgs := []string{}
+	for _, setter := range fcd.ScalarSetters {
+		replacerArgs = append(replacerArgs, setter.Value)
+		replacerArgs = append(replacerArgs, fmt.Sprintf("${%s}", setter.Name))
+	}
+	fcd.Replacer = strings.NewReplacer(replacerArgs...)
 	return nil
 }

--- a/functions/go/create-setters/createsetters/create_setters.go
+++ b/functions/go/create-setters/createsetters/create_setters.go
@@ -310,16 +310,13 @@ apiVersion: v1
 image: nginx:1.7.1 # kpt-set: ${image}:${tag}
 */
 func getLineComment(nodeValue string, replacer *strings.Replacer) (string, bool) {
-	output := nodeValue
 	valueMatch := false
 
-	// replaces the strings
-	output = replacer.Replace(nodeValue)
-
+	// replaces the substrings in nodeValue with setter parameters
+	output := replacer.Replace(nodeValue)
 	if output != nodeValue {
 		valueMatch = true
 	}
-
 	return output, valueMatch
 }
 

--- a/functions/go/create-setters/createsetters/create_setters.go
+++ b/functions/go/create-setters/createsetters/create_setters.go
@@ -108,7 +108,7 @@ Using strings.NewReplacer and the args, creates *strings.Replacer
 */
 func (cs *CreateSetters) preProcessScalarSetters() {
 	// replacerArgs contains the setter values with parameter as pairs
-	replacerArgs := []string{}
+	var replacerArgs []string
 	for _, setter := range cs.ScalarSetters {
 		replacerArgs = append(replacerArgs, setter.Value)
 		replacerArgs = append(replacerArgs, fmt.Sprintf("${%s}", setter.Name))
@@ -280,7 +280,7 @@ func checkEqual(nodeValues []string, arraySetters []string) bool {
 
 // getArraySetter parses the input and returns array setters
 func getArraySetter(input *yaml.RNode) []string {
-	output := []string{}
+	var output []string
 
 	elements, err := input.Elements()
 	if err != nil {

--- a/functions/go/create-setters/createsetters/create_setters.go
+++ b/functions/go/create-setters/createsetters/create_setters.go
@@ -84,14 +84,13 @@ func (a CompareSetters) Swap(i, j int) {
 
 // Filter implements CreatSetters as a yaml.Filter
 func (cs *CreateSetters) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
-
+	cs.preProcessScalarSetters()
 	for i := range nodes {
 		filePath, _, err := kioutil.GetFileAnnotations(nodes[i])
 		if err != nil {
 			return nodes, err
 		}
 		cs.filePath = filePath
-		cs.preProcessScalarSetters()
 		err = accept(cs, nodes[i])
 		if err != nil {
 			return nil, errors.Wrap(err)

--- a/functions/go/create-setters/createsetters/create_setters.go
+++ b/functions/go/create-setters/createsetters/create_setters.go
@@ -313,7 +313,7 @@ func getLineComment(nodeValue string, replacer *strings.Replacer) (string, bool)
 	output := nodeValue
 	valueMatch := false
 
-	// replaces the strings simulataneously
+	// replaces the strings
 	output = replacer.Replace(nodeValue)
 
 	if output != nodeValue {
@@ -362,7 +362,7 @@ func Decode(rn *yaml.RNode, fcd *CreateSetters) error {
 	// sorts all the Setters
 	sort.Sort(CompareSetters(fcd.ScalarSetters))
 
-	// replacerArgs contains the setter values with parameter
+	// replacerArgs contains the setter values with parameter as pairs
 	replacerArgs := []string{}
 	for _, setter := range fcd.ScalarSetters {
 		replacerArgs = append(replacerArgs, setter.Value)

--- a/functions/go/create-setters/createsetters/create_setters_test.go
+++ b/functions/go/create-setters/createsetters/create_setters_test.go
@@ -389,27 +389,6 @@ metadata:
 `,
 		},
 		{
-			name: "array setter with flow style donot match",
-			config: `
-data:
-  env: |
-    [foo, bar, pro]
-  name: nginx
-`,
-			input: `apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: nginx-deployment
-  env: [foo, bar]
- `,
-			expectedResources: `apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: nginx-deployment # kpt-set: ${name}-deployment
-  env: [foo, bar]
-`,
-		},
-		{
 			name: "setters donot match",
 			config: `
 data:

--- a/functions/go/create-setters/createsetters/create_setters_test.go
+++ b/functions/go/create-setters/createsetters/create_setters_test.go
@@ -92,6 +92,38 @@ env: # kpt-set: ${env}
   - bar
 `,
 		},
+		{
+			name: "all scalar cases",
+			input: `apiVersion: v1
+kind: Deployment
+metadata:
+  name: ubuntu-deployment-1
+spec:
+  image: ubuntu
+  app: "nginx:1.1.2"
+  os:
+    - ubuntu
+    - mac
+`,
+			config: `
+data:
+  deploy: ubuntu-deployment
+  env: ubuntu
+  image: ngnix
+  tag: 1.1.2
+`,
+			expectedResources: `apiVersion: v1
+kind: Deployment
+metadata:
+  name: ubuntu-deployment-1 # kpt-set: ${deploy}-1
+spec:
+  image: ubuntu # kpt-set: ${env}
+  app: "nginx:1.1.2" # kpt-set: nginx:${tag}
+  os:
+    - ubuntu # kpt-set: ${env}
+    - mac
+`,
+		},
 
 		{
 			name: "scalar setter donot match",
@@ -594,17 +626,17 @@ type lineCommentTest struct {
 
 var resolveLineCommentCases = []lineCommentTest{
 	{
-		name:    "matches multiple setters",
+		name:    "value matches multiple setters",
 		value:   "foo-dev-bar-us-east-baz",
 		comment: `foo-${role}-bar-${region}-baz`,
 	},
 	{
-		name:    "matches part of a string",
+		name:    "setter matches part of a string",
 		value:   "nginx:1.2.1",
 		comment: `${app}:1.2.1`,
 	},
 	{
-		name:    "matches multiple setters",
+		name:    "value matches multiple setters",
 		value:   "nginx:1.1.2",
 		comment: `${app}:${tag}`,
 	},
@@ -619,7 +651,7 @@ var resolveLineCommentCases = []lineCommentTest{
 		comment: ``,
 	},
 	{
-		name:    "matches the maximum length setter",
+		name:    "longest length match",
 		value:   "nginx-abc",
 		comment: `${image}`,
 	},
@@ -629,7 +661,7 @@ var resolveLineCommentCases = []lineCommentTest{
 		comment: `${app}-base`,
 	},
 	{
-		name:    "overlap case",
+		name:    "overlap case of setters",
 		value:   "dev",
 		comment: `${role}`,
 	},


### PR DESCRIPTION
This pr adds the following changes to `create-setters`
* Doesn't add the comments to the scalar values with multiple lines.
* Matches the longest length matched setter value to set the comment if two or more setter values have the same substrings.
e.g., Input resource
  ```yaml
  apiVersion: v1
  kind: Deployment
  metadata:
    namespace: nginx-space
  ```
  ConfigMap
  ```yaml
  apiVersion: v1
  kind: ConfigMap
  data:
    name: nginx
    dev: nginx-space
   ```
  Transformed resource
  ```yaml
  apiVersion: v1
  kind: Deployment
  metadata:
    namespace: nginx-space # kpt-set: ${dev}
  ```

* Updates the create-setters docs accordingly.