### PR TITLE
Fix offset border for GH widget.

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -257,8 +257,5 @@
     .sidebar > h1 img {
       height: 32px;
     }
-    .sidebar-toggle {
-      display: none;
-    }
   </style>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -82,14 +82,14 @@
                 "https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/site";
 
               const container = document.createElement("div");
-              container.classList.add(
-                "github-widget",
-                "docsify-pagination-container"
-              );
+              container.classList.add("github-widget");
               container.appendChild(createIssue);
               container.appendChild(editPage);
 
-              html += container.outerHTML;
+              const wrapper = document.createElement("div");
+              wrapper.classList.add("docsify-pagination-container");
+              wrapper.appendChild(container);
+              html += wrapper.outerHTML;
               next(html);
             }),
               hook.afterEach(async function (html, next) {
@@ -243,10 +243,8 @@
       justify-content: space-between;
     }
 
-    .github-widget {
+    .docsify-pagination-container {
       margin: 5em 0 1em;
-      padding-top: 2.5em;
-      width: 100%;
     }
 
     .sidebar {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31711490/121784536-39ffc480-cb69-11eb-8b02-480c5e4078a0.png)
Fixes https://github.com/GoogleContainerTools/kpt/issues/2076 by adding sidebar button back to mobile.