### PR TITLE
Fix ensure-name-substring imperative example

### DIFF
--- a/examples/ensure-name-substring-imperative/README.md
+++ b/examples/ensure-name-substring-imperative/README.md
@@ -18,7 +18,7 @@ $ kpt pkg get https://github.com/GoogleContainerTools/kpt-functions-catalog.git/
 Invoke the function by running the following commands:
 
 ```shell
-$ kpt fn eval ensure-name-substring-imperative --image gcr.io/kpt-fn/ensure-name-substring:unstable -- prepend=prod
+$ kpt fn eval ensure-name-substring-imperative --image gcr.io/kpt-fn/ensure-name-substring:unstable -- prepend=prod-
 ```
 
 The key-value pair(s) provided after `--` will be converted to `ConfigMap` by


### PR DESCRIPTION
This addresses a mismatch between the argument to the function and the expected result.