### PR TITLE
by-file-path matcher for search-replace

### DIFF
--- a/functions/go/search-replace/README.md
+++ b/functions/go/search-replace/README.md
@@ -4,23 +4,24 @@
 
 <!--mdtogo:Short-->
 
-Search and optionally replace fields across all resources.
+Search and optionally replace field values.
+
+There is a spectrum of configuration customization techniques as described in
+[this document]. One of the most basic and simplest customization techniques is Search and Replace.
+The user fetches a package of resources, searches all the files for fields matching
+a criteria, and replaces their values.
 
 <!--mdtogo-->
 
 ### FunctionConfig
 
-There is a spectrum of configuration customization techniques as described in
-[this document].
-
 <!--mdtogo:Long-->
 
-One of the most basic and simplest customization techniques is Search and Replace.
-The user fetches a package of resources, searches all the files for fields matching
-a criteria, and replaces their values.
-
 Search matchers are provided with `by-` prefix. When multiple matchers
-are provided they are AND’ed together. `put-` matchers are mutually exclusive.
+are provided they are AND’ed together.
+
+Mutators are provided with `put-` prefix. When multiple mutators
+are provided they are all applied.
 
 #### Matchers
 
@@ -44,7 +45,11 @@ by-file-path
 Match by file path expression. Input must be OS-agnostic Slash(/) separated file path
 relative to the directory on which the function is invoked. Please note that the
 file path expressions are not regular expressions.
+```
 
+#### Mutators
+
+```
 put-value
 Set or update the value of the matching fields. Input can be a pattern for which
 the numbered capture groups are resolved using --by-value-regex input.

--- a/functions/go/search-replace/README.md
+++ b/functions/go/search-replace/README.md
@@ -87,7 +87,12 @@ $ kpt fn eval --image gcr.io/kpt-fn/search-replace:unstable -- 'by-path=metadata
 
 ### Field path patterns
 
-`--by-path` matcher supports the following patterns:
+`by-path` matcher supports the following patterns:
+
+| Special Terms | Meaning                     |
+| ------------- | --------------------------- |
+| `*`           | matches exactly one field   |
+| `**`          | matches zero or more fields |
 
 ```yaml
 a.b.c
@@ -156,19 +161,18 @@ a:
 
 ### File path patterns
 
-`--by-file-path` matcher supports the following special terms in the patterns:
+`by-file-path` matcher supports the following special terms in the patterns:
 
 | Special Terms | Meaning                                                                                                   |
 | ------------- | --------------------------------------------------------------------------------------------------------- |
 | `*`           | matches any sequence of non-path-separators                                                               |
-| `/**/`        | matches zero or more directories                                                                          |
+| `**`          | matches zero or more directories                                                                          |
 | `?`           | matches any single non-path-separator character                                                           |
 | `[class]`     | matches any single non-path-separator character against a class of characters ([see "character classes"]) |
 | `{alt1,...}`  | matches a sequence of characters if one of the comma-separated alternatives matches                       |
 
 Any character with a special meaning can be escaped with a backslash (`\`).
 
-A doublestar (`**`) should appear surrounded by path separators such as `/**/`.
 A mid-pattern doublestar (`**`) behaves like bash's globstar option: a pattern
 such as `path/to/**.txt` would return the same results as `path/to/*.txt`. The
 pattern you're looking for is `path/to/**/*.txt`.
@@ -183,6 +187,43 @@ Character classes support the following:
 | `[a-z]`    | matches any single character in the range                     |
 | `[^class]` | matches any single character which does _not_ match the class |
 | `[!class]` | same as `^`: negates the class                                |
+
+```shell
+**/baz.yaml
+
+foo/bar/baz.yaml # Matches
+bar/baz.yaml # Matches
+baz.yaml # Matches
+foo/bar/bat.yaml
+```
+
+```shell
+foo/**/baz.yaml
+
+foo/bar/baz.yaml # Matches
+bar/baz.yaml
+baz.yaml
+foo/bar/bor/baz.yaml # Matches
+```
+
+```shell
+foo/*/baz.yaml
+
+foo/bar/baz.yaml # Matches
+bar/baz.yaml
+baz.yaml
+foo/bar/bat.yaml
+foo/bar/bor/bat.yaml
+```
+
+```shell
+foo/bar/*.yaml
+
+foo/bar/baz.yaml # Matches
+foo/bar/bat.yaml # Matches
+bar/baz.yaml
+baz.yaml
+```
 
 <!--mdtogo-->
 

--- a/functions/go/search-replace/README.md
+++ b/functions/go/search-replace/README.md
@@ -37,8 +37,13 @@ value of the field by default without requiring start (^) and end ($) characters
 
 by-path
 Match by path expression of a field. Path expressions are used to deeply navigate
-and match particular yaml nodes. Please note that the path expressions are not
+and match particular yaml nodes. Please note that the field path expressions are not
 regular expressions.
+
+by-file-path
+Match by file path expression. Input must be OS-agnostic Slash(/) separated file path
+relative to the directory on which the function is invoked. Please note that the
+file path expressions are not regular expressions.
 
 put-value
 Set or update the value of the matching fields. Input can be a pattern for which
@@ -75,7 +80,9 @@ Alternatively, data can be passed as key-value pairs in the CLI
 $ kpt fn eval --image gcr.io/kpt-fn/search-replace:unstable -- 'by-path=metadata.name' 'put-value=the-deployment'
 ```
 
-Supported Path expressions:
+### Field path patterns
+
+`--by-path` matcher supports the following patterns:
 
 ```yaml
 a.b.c
@@ -142,6 +149,36 @@ a:
     f: thingamabob
 ```
 
+### File path patterns
+
+`--by-file-path` matcher supports the following special terms in the patterns:
+
+| Special Terms | Meaning                                                                                                   |
+| ------------- | --------------------------------------------------------------------------------------------------------- |
+| `*`           | matches any sequence of non-path-separators                                                               |
+| `/**/`        | matches zero or more directories                                                                          |
+| `?`           | matches any single non-path-separator character                                                           |
+| `[class]`     | matches any single non-path-separator character against a class of characters ([see "character classes"]) |
+| `{alt1,...}`  | matches a sequence of characters if one of the comma-separated alternatives matches                       |
+
+Any character with a special meaning can be escaped with a backslash (`\`).
+
+A doublestar (`**`) should appear surrounded by path separators such as `/**/`.
+A mid-pattern doublestar (`**`) behaves like bash's globstar option: a pattern
+such as `path/to/**.txt` would return the same results as `path/to/*.txt`. The
+pattern you're looking for is `path/to/**/*.txt`.
+
+#### Character Classes
+
+Character classes support the following:
+
+| Class      | Meaning                                                       |
+| ---------- | ------------------------------------------------------------- |
+| `[abc]`    | matches any single character within the set                   |
+| `[a-z]`    | matches any single character in the range                     |
+| `[^class]` | matches any single character which does _not_ match the class |
+| `[!class]` | same as `^`: negates the class                                |
+
 <!--mdtogo-->
 
 ### Examples
@@ -174,6 +211,12 @@ $ kpt fn eval --image gcr.io/kpt-fn/search-replace:unstable -- by-path='metadata
 ```
 
 ```shell
+# Update the setter value "project-id" to value "new-project" in all "setters.yaml" files in the current directory tree:
+kpt fn eval --image gcr.io/kpt-fn/search-replace:unstable --include-meta-resources -- \
+by-value=project-id by-file-path='**/setters.yaml' put-value=new-project
+```
+
+```shell
 # Search and Set multiple values using regex numbered capture groups
 $ kpt fn eval --image gcr.io/kpt-fn/search-replace:unstable -- by-value-regex='something-(.*)' put-value='my-project-id-${1}'
 metadata:
@@ -203,3 +246,4 @@ metadata:
 <!--mdtogo-->
 
 [this document]: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture/declarative-application-management.md#declarative-configuration
+[see "character classes"]: #character-classes

--- a/functions/go/search-replace/go.mod
+++ b/functions/go/search-replace/go.mod
@@ -3,6 +3,7 @@ module github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/search
 go 1.16
 
 require (
+	github.com/bmatcuk/doublestar/v4 v4.0.2 // indirect
 	github.com/stretchr/testify v1.6.1
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	sigs.k8s.io/kustomize/kyaml v0.10.21

--- a/functions/go/search-replace/go.sum
+++ b/functions/go/search-replace/go.sum
@@ -12,6 +12,8 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
+github.com/bmatcuk/doublestar/v4 v4.0.2 h1:X0krlUVAVmtr2cRoTqR8aDMrDqnB36ht8wpWTiQ3jsA=
+github.com/bmatcuk/doublestar/v4 v4.0.2/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=

--- a/functions/go/search-replace/metadata.yaml
+++ b/functions/go/search-replace/metadata.yaml
@@ -1,5 +1,5 @@
 image: gcr.io/kpt-fn/search-replace
-description: Search and optionally replace fields across all resources.
+description: Search and optionally replace field values.
 tags:
   - mutator
 sourceURL: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/functions/go/search-replace

--- a/functions/go/search-replace/searchreplace/search_replace_test.go
+++ b/functions/go/search-replace/searchreplace/search_replace_test.go
@@ -106,7 +106,7 @@ func TestDecode(t *testing.T) {
 	if !assert.Error(t, err) {
 		t.FailNow()
 	}
-	expected := `invalid matcher "put-values", must be one of ["by-value" "by-value-regex" "by-path" "put-value" "put-comment"]`
+	expected := `invalid matcher "put-values", must be one of ["by-value" "by-file-path" "by-value-regex" "by-path" "put-value" "put-comment"]`
 	if !assert.Equal(t, expected, err.Error()) {
 		t.FailNow()
 	}

--- a/functions/go/search-replace/searchreplace/searchreplacecases_test.go
+++ b/functions/go/search-replace/searchreplace/searchreplacecases_test.go
@@ -728,7 +728,7 @@ spec:
 		errMsg: `only one of ["by-value", "by-value-regex"] can be provided`,
 	},
 	{
-		name: "error when none of the search matchers are provided",
+		name: "do not error when none of the search matchers are provided",
 		config: `
 data: ~
 `,
@@ -748,10 +748,11 @@ metadata:
 spec:
   replicas: 3
  `,
-		errMsg: `at least one of ["by-value", "by-value-regex", "by-path"] must be provided`,
+		out: `Matched 0 field(s)
+`,
 	},
 	{
-		name: "error when none of the required search matchers are provided",
+		name: "do not error when none of the required search matchers are provided",
 		config: `
 data:
   put-value: foo
@@ -772,6 +773,7 @@ metadata:
 spec:
   replicas: 3
  `,
-		errMsg: `at least one of ["by-value", "by-value-regex", "by-path"] must be provided`,
+		out: `Mutated 0 field(s)
+`,
 	},
 }

--- a/tests/search-replace/file-path-match/.expected/diff.patch
+++ b/tests/search-replace/file-path-match/.expected/diff.patch
@@ -1,13 +1,3 @@
-diff --git a/resources.yaml b/resources.yaml
-index 5ed432d..aafcb55 100644
---- a/resources.yaml
-+++ b/resources.yaml
-@@ -3,4 +3,4 @@ kind: Project
- metadata:
-   name: project-id
- spec:
--  project-id: project-id # kpt-set: ${project-id}
-+  project-id: new-project # kpt-set: ${project-id}
 diff --git a/setters.yaml b/setters.yaml
 index d9e8e53..56fcfb2 100644
 --- a/setters.yaml
@@ -18,16 +8,6 @@ index d9e8e53..56fcfb2 100644
  data:
 -  project-id: project-id
 +  project-id: new-project
-diff --git a/subpkg/resources.yaml b/subpkg/resources.yaml
-index 5ed432d..aafcb55 100644
---- a/subpkg/resources.yaml
-+++ b/subpkg/resources.yaml
-@@ -3,4 +3,4 @@ kind: Project
- metadata:
-   name: project-id
- spec:
--  project-id: project-id # kpt-set: ${project-id}
-+  project-id: new-project # kpt-set: ${project-id}
 diff --git a/subpkg/setters.yaml b/subpkg/setters.yaml
 index d9e8e53..56fcfb2 100644
 --- a/subpkg/setters.yaml

--- a/tests/search-replace/file-path-match/.expected/diff.patch
+++ b/tests/search-replace/file-path-match/.expected/diff.patch
@@ -1,0 +1,40 @@
+diff --git a/resources.yaml b/resources.yaml
+index 5ed432d..aafcb55 100644
+--- a/resources.yaml
++++ b/resources.yaml
+@@ -3,4 +3,4 @@ kind: Project
+ metadata:
+   name: project-id
+ spec:
+-  project-id: project-id # kpt-set: ${project-id}
++  project-id: new-project # kpt-set: ${project-id}
+diff --git a/setters.yaml b/setters.yaml
+index d9e8e53..56fcfb2 100644
+--- a/setters.yaml
++++ b/setters.yaml
+@@ -3,4 +3,4 @@ kind: ConfigMap
+ metadata:
+   name: setters
+ data:
+-  project-id: project-id
++  project-id: new-project
+diff --git a/subpkg/resources.yaml b/subpkg/resources.yaml
+index 5ed432d..aafcb55 100644
+--- a/subpkg/resources.yaml
++++ b/subpkg/resources.yaml
+@@ -3,4 +3,4 @@ kind: Project
+ metadata:
+   name: project-id
+ spec:
+-  project-id: project-id # kpt-set: ${project-id}
++  project-id: new-project # kpt-set: ${project-id}
+diff --git a/subpkg/setters.yaml b/subpkg/setters.yaml
+index d9e8e53..56fcfb2 100644
+--- a/subpkg/setters.yaml
++++ b/subpkg/setters.yaml
+@@ -3,4 +3,4 @@ kind: ConfigMap
+ metadata:
+   name: setters
+ data:
+-  project-id: project-id
++  project-id: new-project

--- a/tests/search-replace/file-path-match/.expected/exec.sh
+++ b/tests/search-replace/file-path-match/.expected/exec.sh
@@ -1,7 +1,5 @@
 #! /bin/bash
 
 # shellcheck disable=SC2016
-kpt fn eval --image gcr.io/kpt-fn/search-replace:unstable --include-meta-resources -- \
+kpt fn eval --image gcr.io/kpt-fn/search-replace:unstable --include-meta-resources --image-pull-policy=never -- \
 by-value=project-id by-file-path='**/setters.yaml' put-value=new-project
-
-kpt fn render

--- a/tests/search-replace/file-path-match/.expected/exec.sh
+++ b/tests/search-replace/file-path-match/.expected/exec.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+
+# shellcheck disable=SC2016
+kpt fn eval --image gcr.io/kpt-fn/search-replace:unstable --include-meta-resources -- \
+by-value=project-id by-file-path='**/setters.yaml' put-value=new-project
+
+kpt fn render

--- a/tests/search-replace/file-path-match/.krmignore
+++ b/tests/search-replace/file-path-match/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/tests/search-replace/file-path-match/Kptfile
+++ b/tests/search-replace/file-path-match/Kptfile
@@ -1,0 +1,8 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: example
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/apply-setters:unstable
+      configPath: setters.yaml

--- a/tests/search-replace/file-path-match/resources.yaml
+++ b/tests/search-replace/file-path-match/resources.yaml
@@ -1,0 +1,6 @@
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Project
+metadata:
+  name: project-id
+spec:
+  project-id: project-id # kpt-set: ${project-id}

--- a/tests/search-replace/file-path-match/setters.yaml
+++ b/tests/search-replace/file-path-match/setters.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: setters
+data:
+  project-id: project-id

--- a/tests/search-replace/file-path-match/subpkg/Kptfile
+++ b/tests/search-replace/file-path-match/subpkg/Kptfile
@@ -1,0 +1,8 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: subpkg
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/apply-setters:unstable
+      configPath: setters.yaml

--- a/tests/search-replace/file-path-match/subpkg/resources.yaml
+++ b/tests/search-replace/file-path-match/subpkg/resources.yaml
@@ -1,0 +1,6 @@
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Project
+metadata:
+  name: project-id
+spec:
+  project-id: project-id # kpt-set: ${project-id}

--- a/tests/search-replace/file-path-match/subpkg/setters.yaml
+++ b/tests/search-replace/file-path-match/subpkg/setters.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: setters
+data:
+  project-id: project-id


### PR DESCRIPTION
This PR does following things:

1. Adds `by-file-path` matcher to search-replace function. Using this option, users can target specific file(s).
2. Removes check for empty search criteria.
3. Update docs.

[golang](https://github.com/golang/go/issues/11862) [filepath.Match()](https://golang.org/pkg/path/filepath/#Match) doesn't support doublestar match. I used [doublestar](https://github.com/bmatcuk/doublestar) library for filepath expressions matching as it is popular in the community and is well documented. 
 
