### PR TITLE
[DO-NOT-MERGE] use starlark.SimpleFilter to not touch the id annotations

### DIFF
--- a/functions/go/starlark/config.go
+++ b/functions/go/starlark/config.go
@@ -6,7 +6,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/kustomize/kyaml/fn/framework"
-	"sigs.k8s.io/kustomize/kyaml/fn/runtime/runtimeutil"
 	"sigs.k8s.io/kustomize/kyaml/fn/runtime/starlark"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 	k8syaml "sigs.k8s.io/yaml"
@@ -131,14 +130,11 @@ func (sfc *StarlarkFnConfig) Transform(rl *framework.ResourceList) error {
 		return err
 	}
 
-	starFltr := &starlark.Filter{
+	starFltr := &starlark.SimpleFilter{
 		Name:    sfc.GetName(),
 		Program: sfc.GetSource(),
-		FunctionFilter: runtimeutil.FunctionFilter{
-			FunctionConfig: rl.FunctionConfig,
-		},
 	}
-	rl.Items, err = starFltr.Filter(rl.Items)
+	rl.Items, err = starFltr.FunctionConfig(rl.FunctionConfig).Filter(rl.Items)
 	return err
 }
 

--- a/functions/go/starlark/go.mod
+++ b/functions/go/starlark/go.mod
@@ -9,3 +9,6 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.10.21
 	sigs.k8s.io/yaml v1.2.0
 )
+
+//replace sigs.k8s.io/kustomize/kyaml v0.10.21 => ../../../../../../sigs.k8s.io/kustomize/kyaml
+replace sigs.k8s.io/kustomize/kyaml v0.10.21 => github.com/mengqiy/kustomize/kyaml v0.0.0-20210712171606-e996e89862f1

--- a/functions/go/starlark/go.sum
+++ b/functions/go/starlark/go.sum
@@ -125,6 +125,8 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.0 h1:aizVhC/NAAcKWb+5QsU1iNOZb4Yws5UO2I+aIprQITM=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/mengqiy/kustomize/kyaml v0.0.0-20210712171606-e996e89862f1 h1:XI2knFSKiYiOez2ZAlwhZ1WMXKq5IkHlt57k0XPWh6w=
+github.com/mengqiy/kustomize/kyaml v0.0.0-20210712171606-e996e89862f1/go.mod h1:GNMwjim4Ypgp/MueD3zXHLRJEjz7RvtPae0AwlvEMFM=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
@@ -329,8 +331,6 @@ k8s.io/klog/v2 v2.8.0/go.mod h1:hy9LJ/NvuK+iVyP4Ehqva4HxZG/oXyIS3n3Jmire4Ec=
 k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7/go.mod h1:wXW5VT87nVfh/iLV8FpR2uDvrFyomxbtb1KivDbvPTE=
 k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e h1:KLHHjkdQFomZy8+06csTWZ0m1343QqxZhR2LJ1OxCYM=
 k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e/go.mod h1:vHXdDvt9+2spS2Rx9ql3I8tycm3H9FDfdUoIuKCefvw=
-sigs.k8s.io/kustomize/kyaml v0.10.21 h1:KdoEgz3HzmcaLUTFqs6aaqFpsaA9MVRIwOZbi8vMaD0=
-sigs.k8s.io/kustomize/kyaml v0.10.21/go.mod h1:TYWhGwW9vjoRh3rWqBwB/ZOXyEGRVWe7Ggc3+KZIO+c=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.0 h1:C4r9BgJ98vrKnnVCjwCSXcWjWe0NKcUQkmzDXZXGwH8=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.0/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=


### PR DESCRIPTION
Depending on https://github.com/kubernetes-sigs/kustomize/pull/4059

fixes: https://github.com/GoogleContainerTools/kpt/issues/2382
