### PR TITLE
Remove async afterEach usage.

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -56,180 +56,171 @@
         },
         plugins: [
           function (hook, vm) {
-            hook.afterEach(async function (html, next) {
+            hook.afterEach(function (html, next) {
               const container = document.createElement("div");
               container.id = "examples-section";
               html += container.outerHTML;
               next(html);
-            }),
-              hook.afterEach(async function (html, next) {
-                const issueIcon = document.createElement("span");
-                issueIcon.innerText = "bug_report";
-                issueIcon.classList.add("material-icons-outlined");
-                const createIssue = document.createElement("a");
-                createIssue.target = "_blank";
-                createIssue.title = "Create documentation issue";
-                createIssue.id = "create-issue";
-                createIssue.appendChild(issueIcon);
+            });
 
-                const editIcon = document.createElement("span");
-                editIcon.innerText = "edit";
-                editIcon.classList.add("material-icons-outlined");
-                const editPage = document.createElement("a");
-                editPage.target = "_blank";
-                editPage.title = "Edit this page";
-                editPage.id = "edit-page";
-                editPage.appendChild(editIcon);
+            hook.afterEach(function (html, next) {
+              const issueIcon = document.createElement("span");
+              issueIcon.innerText = "bug_report";
+              issueIcon.classList.add("material-icons-outlined");
+              const createIssue = document.createElement("a");
+              createIssue.target = "_blank";
+              createIssue.title = "Create documentation issue";
+              createIssue.id = "create-issue";
+              createIssue.appendChild(issueIcon);
 
-                // Fallback links for generated pages.
-                createIssue.href = `https://github.com/GoogleContainerTools/kpt/issues/new?labels=documentation&title=Docs: Functions Catalog`;
-                editPage.href =
-                  "https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/site";
+              const editIcon = document.createElement("span");
+              editIcon.innerText = "edit";
+              editIcon.classList.add("material-icons-outlined");
+              const editPage = document.createElement("a");
+              editPage.target = "_blank";
+              editPage.title = "Edit this page";
+              editPage.id = "edit-page";
+              editPage.appendChild(editIcon);
 
-                const container = document.createElement("div");
-                container.classList.add("github-widget");
-                container.appendChild(createIssue);
-                container.appendChild(editPage);
+              // Fallback links for generated pages.
+              createIssue.href = `https://github.com/GoogleContainerTools/kpt/issues/new?labels=documentation&title=Docs: Functions Catalog`;
+              editPage.href =
+                "https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/site";
 
-                const wrapper = document.createElement("div");
-                wrapper.classList.add("docsify-pagination-container");
-                wrapper.appendChild(container);
-                html += wrapper.outerHTML;
-                next(html);
-              }),
-              hook.afterEach(async function (html, next) {
-                const functionName = vm.route.path.split("/")[1];
-                if (!functionName) {
-                  next(html);
-                  return;
-                }
+              const container = document.createElement("div");
+              container.classList.add("github-widget");
+              container.appendChild(createIssue);
+              container.appendChild(editPage);
 
-                try {
-                  const catalogResponse = await window.Docsify.get(
-                    `/catalog.json`
-                  );
-                  const catalog = JSON.parse(catalogResponse);
-                  const versions = catalog[functionName];
-                  let versionDropdown = "";
+              const wrapper = document.createElement("div");
+              wrapper.classList.add("docsify-pagination-container");
+              wrapper.appendChild(container);
+              html += wrapper.outerHTML;
+              next(html);
+            });
 
-                  const versionName = vm.route.path.split("/")[2];
-                  const currentVersion = versionName.replaceAll("v", "");
-                  const sortedSemvers = Object.keys(versions)
-                    .sort((a, b) => compareVersions(a, b))
-                    .reverse();
-                  versionDropdown += `
+            hook.doneEach(function () {
+              const functionName = vm.route.path.split("/")[1];
+              if (!functionName) {
+                return;
+              }
+
+              window.Docsify.get(`/catalog.json`).then(function (
+                catalogResponse
+              ) {
+                const catalog = JSON.parse(catalogResponse);
+                const versions = catalog[functionName];
+                let versionDropdown = "";
+
+                const versionName = vm.route.path.split("/")[2];
+                const currentVersion = versionName.replaceAll("v", "");
+                const sortedSemvers = Object.keys(versions)
+                  .sort((a, b) => compareVersions(a, b))
+                  .reverse();
+                versionDropdown += `
               <div class="dropdown">
                 <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown">Version: ${currentVersion}
                 <span class="caret"></span></button>
                 <ol class="dropdown-menu">`;
-                  sortedSemvers.forEach(
-                    (ver, ix) =>
-                      (versionDropdown += `<li><a href="/${functionName}/${ver}/">${ver.replace(
-                        "v",
-                        ""
-                      )}${ix ? "" : " (latest)"}</a></li>`)
-                  );
-                  versionDropdown += `
+                sortedSemvers.forEach(
+                  (ver, ix) =>
+                    (versionDropdown += `<li><a href="/${functionName}/${ver}/">${ver.replace(
+                      "v",
+                      ""
+                    )}${ix ? "" : " (latest)"}</a></li>`)
+                );
+                versionDropdown += `
                 </ol>
               </div>`;
 
-                  const examples = catalog[functionName][versionName];
-                  const ghElement = document
-                    .getElementsByClassName("github-corner")
-                    .item(0);
-                  const exampleNames = Object.keys(examples).sort();
-                  const currentEx = vm.route.path.split("/")[3];
-                  // Change the GH icon to point to the current example if it exists.
-                  if (currentEx) {
-                    ghElement.href = examples[currentEx].RemoteExamplePath;
-                  }
-                  // If not on an example, change the GH icon to point to the current version if it exists.
-                  else if (versionName) {
-                    const exampleSuffix = /examples\/.+/;
-                    ghElement.href = examples[exampleNames[0]].RemoteSourcePath;
-                  }
-                  // On every other page, point to the main catalog repo.
-                  else {
-                    ghElement.href = window.$docsify.corner.url;
-                  }
+                const examples = catalog[functionName][versionName];
+                const ghElement = document
+                  .getElementsByClassName("github-corner")
+                  .item(0);
+                const exampleNames = Object.keys(examples).sort();
+                const currentEx = vm.route.path.split("/")[3];
+                // Change the GH icon to point to the current example if it exists.
+                if (currentEx) {
+                  ghElement.href = examples[currentEx].RemoteExamplePath;
+                }
+                // If not on an example, change the GH icon to point to the current version if it exists.
+                else if (versionName) {
+                  const exampleSuffix = /examples\/.+/;
+                  ghElement.href = examples[exampleNames[0]].RemoteSourcePath;
+                }
+                // On every other page, point to the main catalog repo.
+                else {
+                  ghElement.href = window.$docsify.corner.url;
+                }
 
-                  // Write Examples section to add to the bottom of every markdown page.
-                  let exampleItems = "";
-                  exampleNames.forEach((ex, _) => {
-                    if (currentEx != ex) {
-                      exampleItems += `<li><a href="${examples[ex].LocalExamplePath}/">
+                // Write Examples section to add to the bottom of every markdown page.
+                let exampleItems = "";
+                exampleNames.forEach((ex, _) => {
+                  if (currentEx != ex) {
+                    exampleItems += `<li><a href="${examples[ex].LocalExamplePath}/">
                       ${ex}</a></li>`;
-                    }
-                  });
-                  let examplesInlineListSection = exampleItems
-                    ? `
+                  }
+                });
+                let examplesInlineListSection = exampleItems
+                  ? `
                   <h3 id="examples">${
                     currentEx ? "More Examples" : "Examples"
                   }</h3>
                   <ul>
                   ${exampleItems}
                   </ul>`
-                    : "";
+                  : "";
 
-                  let examplesDropdown = `
+                let examplesDropdown = `
               <div class="dropdown">
                 <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown">Examples
                 <span class="caret"></span></button>
                 <ol class="dropdown-menu">`;
-                  exampleNames.forEach(
-                    (ex, _) =>
-                      (examplesDropdown += `<li><a href="${examples[ex].LocalExamplePath}/">
+                exampleNames.forEach(
+                  (ex, _) =>
+                    (examplesDropdown += `<li><a href="${examples[ex].LocalExamplePath}/">
                       ${ex}</a></li>`)
-                  );
-                  examplesDropdown += `
+                );
+                examplesDropdown += `
                 </ol>
               </div>`;
 
-                  const dropdowns =
-                    `<div class="dropdown-container">` +
-                    versionDropdown +
-                    examplesDropdown +
-                    "</div>";
+                const dropdowns =
+                  `<div class="dropdown-container">` +
+                  versionDropdown +
+                  examplesDropdown +
+                  "</div>";
 
-                  html = dropdowns + html;
-
-                  const doc = new DOMParser().parseFromString(
-                    html,
-                    "text/html"
-                  );
-
-                  // Update title of page to title of document.
-                  const title = doc
-                    .getElementsByTagName("h1")
-                    .item(0)?.textContent;
-                  if (title) {
-                    document.title = title;
-                  }
-
-                  // Update examples.
-                  doc.getElementById("examples-section").outerHTML =
-                    examplesInlineListSection;
-
-                  // Update buttons.
-                  doc.getElementById(
-                    "create-issue"
-                  ).href = `https://github.com/GoogleContainerTools/kpt/issues/new?labels=documentation&title=Docs: Function Catalog - ${document.title}`;
-                  doc.getElementById("edit-page").href =
-                    ghElement.href
-                      .replace(
-                        "kpt-functions-catalog/tree",
-                        "kpt-functions-catalog/edit"
-                      )
-                      .replace(`${functionName}/${versionName}`, "master") +
-                    "/README.md";
-
-                  html = doc.body.innerHTML;
-                } catch (err) {
-                  console.error(err);
+                const dropdownContainer = document.createElement("div");
+                const content = document.getElementsByClassName("markdown-section").item(0);
+                content.prepend(dropdownContainer);
+                dropdownContainer.outerHTML = dropdowns;
+                // Update title of page to title of document.
+                const title = document
+                  .getElementsByTagName("h1")
+                  .item(0)?.textContent;
+                if (title) {
+                  document.title = title;
                 }
 
-                next(html);
+                // Update examples.
+                document.getElementById("examples-section").outerHTML =
+                  examplesInlineListSection;
+
+                // Update buttons.
+                document.getElementById(
+                  "create-issue"
+                ).href = `https://github.com/GoogleContainerTools/kpt/issues/new?labels=documentation&title=Docs: Function Catalog - ${document.title}`;
+                document.getElementById("edit-page").href =
+                  ghElement.href
+                    .replace(
+                      "kpt-functions-catalog/tree",
+                      "kpt-functions-catalog/edit"
+                    )
+                    .replace(`${functionName}/${versionName}`, "master") +
+                  "/README.md";
               });
+            });
           },
         ],
       };


### PR DESCRIPTION
Async usage breaks doneEach plugins like they copy buttons.
Fixes https://github.com/GoogleContainerTools/kpt/issues/2329