### PR TITLE
fix: avoid roundtriping when passing objects to starlark fn

### DIFF
--- a/functions/go/starlark/third_party/sigs.k8s.io/kustomize/kyaml/fn/runtime/starlark/starlark.go
+++ b/functions/go/starlark/third_party/sigs.k8s.io/kustomize/kyaml/fn/runtime/starlark/starlark.go
@@ -139,16 +139,11 @@ func (sf *Filter) readResourceList(reader io.Reader) (starlark.Value, error) {
 
 // rnodeToStarlarkValue converts a RNode to a starlark value.
 func rnodeToStarlarkValue(rn *yaml.RNode) (starlark.Value, error) {
-	b, err := yaml.Marshal(rn.Document()) // convert to bytes
+	m, err := rn.Map()
 	if err != nil {
 		return nil, errors.Wrap(err)
 	}
-	var in map[string]interface{}
-	err = yaml.Unmarshal(b, &in) // convert to map[string]interface{}
-	if err != nil {
-		return nil, errors.Wrap(err)
-	}
-	return util.Marshal(in) // convert to starlark value
+	return util.Marshal(m) // convert to starlark value
 }
 
 // starlarkValueToRNode converts the output of the starlark program to a RNode.

--- a/tests/starlark/map-key-inline-comment/.expected/diff.patch
+++ b/tests/starlark/map-key-inline-comment/.expected/diff.patch
@@ -1,0 +1,19 @@
+diff --git a/app.yaml b/app.yaml
+index 3f73a36..11e1b7c 100644
+--- a/app.yaml
++++ b/app.yaml
+@@ -2,6 +2,7 @@ apiVersion: v1
+ kind: ConfigMap
+ metadata: # kpt-merge: /my-cm
+   name: my-cm
++  namespace: prod
+ data:
+   some-key: some-value
+ ---
+@@ -9,5 +10,6 @@ apiVersion: foo.com/v1
+ kind: Bar
+ metadata: # kpt-merge: /my-bar
+   name: my-bar
++  namespace: prod
+ spec:
+   featureA: true

--- a/tests/starlark/map-key-inline-comment/.krmignore
+++ b/tests/starlark/map-key-inline-comment/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/tests/starlark/map-key-inline-comment/Kptfile
+++ b/tests/starlark/map-key-inline-comment/Kptfile
@@ -1,0 +1,8 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: example
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/starlark:unstable
+      configPath: fn-config.yaml

--- a/tests/starlark/map-key-inline-comment/app.yaml
+++ b/tests/starlark/map-key-inline-comment/app.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata: # kpt-merge: /my-cm
+  name: my-cm
+data:
+  some-key: some-value
+---
+apiVersion: foo.com/v1
+kind: Bar
+metadata: # kpt-merge: /my-bar
+  name: my-bar
+spec:
+  featureA: true

--- a/tests/starlark/map-key-inline-comment/fn-config.yaml
+++ b/tests/starlark/map-key-inline-comment/fn-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: fn.kpt.dev/v1alpha1
+kind: StarlarkRun
+metadata:
+  name: set-namespace-to-prod
+source: |
+  # set the namespace on all resources
+  def setnamespace(resources, namespace):
+    for resource in resources:
+      # mutate the resource
+      resource["metadata"]["namespace"] = namespace
+  setnamespace(ctx.resource_list["items"], "prod")


### PR DESCRIPTION
fixes: https://github.com/GoogleContainerTools/kpt/issues/2438