### PR TITLE
apply-setters: Do not error for empty input and no matches

### DIFF
--- a/functions/go/apply-setters/applysetters/apply_setters.go
+++ b/functions/go/apply-setters/applysetters/apply_setters.go
@@ -50,9 +50,6 @@ type Result struct {
 
 // Filter implements Set as a yaml.Filter
 func (as *ApplySetters) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
-	if len(as.Setters) == 0 {
-		return nodes, fmt.Errorf("input setters list cannot be empty")
-	}
 	for i := range nodes {
 		filePath, _, err := kioutil.GetFileAnnotations(nodes[i])
 		if err != nil {

--- a/functions/go/apply-setters/applysetters/apply_setters_test.go
+++ b/functions/go/apply-setters/applysetters/apply_setters_test.go
@@ -338,7 +338,7 @@ spec:
 `,
 		},
 		{
-			name: "error: no input",
+			name: "do not error if no input",
 			config: `
 data: {}
 `,
@@ -366,7 +366,6 @@ spec:
         - name: nginx
           image: nginx:1.7.9 # kpt-set: ${image}:${tag}
 `,
-			errMsg: `input setters list cannot be empty`,
 		},
 		{
 			name: "set empty values",

--- a/functions/go/apply-setters/main.go
+++ b/functions/go/apply-setters/main.go
@@ -69,7 +69,10 @@ func getSetters(fc *kyaml.RNode) (applysetters.ApplySetters, error) {
 func resultsToItems(sr applysetters.ApplySetters) ([]framework.ResultItem, error) {
 	var items []framework.ResultItem
 	if len(sr.Results) == 0 {
-		return nil, fmt.Errorf("no matches for the input list of setters")
+		items = append(items, framework.ResultItem{
+			Message: "no matches for input setter(s)",
+		})
+		return items, nil
 	}
 	for _, res := range sr.Results {
 		items = append(items, framework.ResultItem{

--- a/tests/apply-setters/no-matches-error/.expected/config.yaml
+++ b/tests/apply-setters/no-matches-error/.expected/config.yaml
@@ -1,2 +1,2 @@
 runCount: 2
-exitCode: 1
+exitCode: 0

--- a/tests/apply-setters/no-matches-error/.expected/results.yaml
+++ b/tests/apply-setters/no-matches-error/.expected/results.yaml
@@ -2,12 +2,9 @@ apiVersion: kpt.dev/v1
 kind: FunctionResultList
 metadata:
   name: fnresults
-exitCode: 1
+exitCode: 0
 items:
   - image: gcr.io/kpt-fn/apply-setters:unstable
-    stderr: |
-      no matches for the input list of settersno matches for the input list of setters
-    exitCode: 1
+    exitCode: 0
     results:
-      - message: 'failed to apply setters: no matches for the input list of setters'
-        severity: error
+      - message: no matches for input setter(s)


### PR DESCRIPTION
Similar to search-replace, apply-setters function should not throw error for no input or no matches for setters. It should just log the message and exit.