### PR TITLE
Fix master branch CI

### DIFF
--- a/functions/ts/generate-folders/metadata.yaml
+++ b/functions/ts/generate-folders/metadata.yaml
@@ -3,6 +3,7 @@ description: Transform the ResourceHierarchy custom resource into Folder custom 
 tags:
   - mutator
   - GCP
+sourceURL: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/generate-folders/v0.1/functions/ts/generate-folders
 examplePackageURLs:
   - https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/generate-folders/v0.1/examples/generate-folders-resourcehierarchy-v3
   - https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/generate-folders/v0.1/examples/generate-folders-resourcehierarchy-v2


### PR DESCRIPTION
CI was failing with error `http://localhost:3001/master//README.md [x1] {404}`
That was because scripts/generate_catalog/generate_catalog.go generates site/catalog.json
without RemoteSourcePath for that function and in that case index.html generates
href = localhost:3001/master//README.md for the button 'Edit this page'.
This patch adds sourceURL, so now catalog.json should contain correct data.