### PR TITLE
Update apply-setters from v0.1 to v0.2

### DIFF
--- a/examples/fix-simple/.expected/diff.patch
+++ b/examples/fix-simple/.expected/diff.patch
@@ -36,7 +36,7 @@ index a8e7f27..a10b4df 100644
 +  description: describe this package
 +pipeline:
 +  mutators:
-+  - image: gcr.io/kpt-fn/apply-setters:v0.1
++  - image: gcr.io/kpt-fn/apply-setters:v0.2
 +    configPath: setters.yaml
 diff --git a/resources.yaml b/resources.yaml
 index 9e30767..dae3005 100644

--- a/examples/fix-simple/.expected/diff.patch
+++ b/examples/fix-simple/.expected/diff.patch
@@ -1,5 +1,5 @@
 diff --git a/Kptfile b/Kptfile
-index a8e7f27..a10b4df 100644
+index a8e7f27..30e5250 100644
 --- a/Kptfile
 +++ b/Kptfile
 @@ -1,20 +1,24 @@

--- a/examples/fix-simple/README.md
+++ b/examples/fix-simple/README.md
@@ -1,7 +1,7 @@
 # fix: Simple Example
 
 In this example, we will fix a simple package which is compatible with v0.X version of kpt,
-and make it compatible with kpt 1.0 
+and make it compatible with kpt 1.0
 
 ### Fetch the example package
 
@@ -82,7 +82,7 @@ info:
   description: describe this package
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/apply-setters:v0.1
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
       configPath: setters.yaml
 ```
 

--- a/examples/set-project-id-advanced/.expected/diff.patch
+++ b/examples/set-project-id-advanced/.expected/diff.patch
@@ -29,7 +29,7 @@ index c96b2cd..2643351 100644
    name: subpkg
 +pipeline:
 +  mutators:
-+  - image: gcr.io/kpt-fn/apply-setters:v0.1
++  - image: gcr.io/kpt-fn/apply-setters:v0.2
 +    configMap:
 +      project-id: foo
 diff --git a/subpkg/resources.yaml b/subpkg/resources.yaml

--- a/examples/set-project-id-advanced/.expected/diff.patch
+++ b/examples/set-project-id-advanced/.expected/diff.patch
@@ -20,7 +20,7 @@ index 1702bac..06515a7 100644
    storage-class: standard
 +  project-id: foo
 diff --git a/subpkg/Kptfile b/subpkg/Kptfile
-index c96b2cd..2643351 100644
+index c96b2cd..52b8640 100644
 --- a/subpkg/Kptfile
 +++ b/subpkg/Kptfile
 @@ -2,3 +2,8 @@ apiVersion: kpt.dev/v1

--- a/examples/set-project-id-advanced/Kptfile
+++ b/examples/set-project-id-advanced/Kptfile
@@ -4,5 +4,5 @@ metadata:
   name: test-blueprint
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/apply-setters:v0.1
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
       configPath: setters.yaml

--- a/examples/set-project-id-simple/Kptfile
+++ b/examples/set-project-id-simple/Kptfile
@@ -4,5 +4,5 @@ metadata:
   name: test-blueprint
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/apply-setters:v0.1
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
       configPath: setters.yaml

--- a/functions/go/fix/README.md
+++ b/functions/go/fix/README.md
@@ -108,7 +108,7 @@ metadata:
   name: nginx
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/apply-setters:v0.1
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
       configMap:
         replicas: "3"
 ```

--- a/functions/go/fix/fixpkg/fix.go
+++ b/functions/go/fix/fixpkg/fix.go
@@ -277,11 +277,11 @@ func (s *Fix) FixKptfile(node *yaml.RNode, functions []v1.Function) (*yaml.RNode
 			return node, err
 		}
 
-		// apply-setters function input should be moved to configPath option as it the
-		// best practice
+		// apply-setters function input should be moved to configPath option as it
+		// is the best practice
 		if kf.Pipeline != nil {
 			for i, fn := range kf.Pipeline.Mutators {
-				if strings.Contains(fn.Image, "apply-setters:v0.1") && len(fn.ConfigMap) > 0 {
+				if strings.Contains(fn.Image, "gcr.io/kpt-fn/apply-setters:") && len(fn.ConfigMap) > 0 {
 					settersConfig, err := SettersNodeFromSetters(kf.Pipeline.Mutators[0].ConfigMap, settersConfigFilePath)
 					if err != nil {
 						return node, err
@@ -395,7 +395,7 @@ func (s *Fix) FixKptfile(node *yaml.RNode, functions []v1.Function) (*yaml.RNode
 
 	if len(setters) > 0 {
 		fn := v1.Function{
-			Image:      "gcr.io/kpt-fn/apply-setters:v0.1",
+			Image:      "gcr.io/kpt-fn/apply-setters:v0.2",
 			ConfigPath: SettersConfigFileName,
 		}
 		settersConfig, err := SettersNodeFromSetters(setters, settersConfigFilePath)

--- a/functions/go/fix/generated/docs.go
+++ b/functions/go/fix/generated/docs.go
@@ -87,7 +87,7 @@ Here is the transformed ` + "`" + `v1` + "`" + ` Kptfile:
     name: nginx
   pipeline:
     mutators:
-      - image: gcr.io/kpt-fn/apply-setters:v0.1
+      - image: gcr.io/kpt-fn/apply-setters:v0.2
         configMap:
           replicas: "3"
 `

--- a/functions/go/list-setters/listsetters/list_setters_test.go
+++ b/functions/go/list-setters/listsetters/list_setters_test.go
@@ -42,7 +42,7 @@ metadata:
   name: test
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/apply-setters:v0.1
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
       configMap:
         app: my-app
 `, "test.yaml": `apiVersion: v1
@@ -133,7 +133,7 @@ metadata:
   name: test
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/apply-setters:v0.1
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
 `, "test.yaml": `apiVersion: v1
 kind: Service
 metadata:
@@ -156,7 +156,7 @@ metadata:
   name: test
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/apply-setters:v0.1
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
       configPath: setters.yaml
 `, "test.yaml": `apiVersion: v1
 kind: Service
@@ -180,7 +180,7 @@ metadata:
   name: test
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/apply-setters:v0.1
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
       configMap:
         app: my-app
         foo: bar
@@ -194,7 +194,7 @@ kind: Deployment
 metadata:
   labels:
     app: my-app # kpt-set: ${app}
-  name: mungebot			
+  name: mungebot
 `},
 			expectedResult: []*Result{{Name: "app", Value: "my-app", Count: 2, Type: "str"}, {Name: "foo", Value: "bar", Count: 0, Type: "str"}},
 		},
@@ -206,11 +206,11 @@ metadata:
   name: test
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/apply-setters:v0.1
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
       configMap:
         app: my-app-old
         foo: bar
-    - image: gcr.io/kpt-fn/apply-setters:v0.1
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
       configMap:
         app: my-app
         baz: qux
@@ -224,7 +224,7 @@ kind: Deployment
 metadata:
   labels:
     app: my-app # kpt-set: ${app}
-  name: mungebot			
+  name: mungebot
 `},
 			expectedResult: []*Result{{Name: "app", Value: "my-app", Count: 2, Type: "str"}, {Name: "foo", Value: "bar", Count: 0, Type: "str"}, {Name: "baz", Value: "qux", Count: 0, Type: "str"}},
 		},
@@ -250,7 +250,7 @@ metadata:
   name: test
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/apply-setters:v0.1
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
       configPath: setters.yaml
 `, "setters.yaml": `apiVersion: v1
 kind: ConfigMap
@@ -279,9 +279,9 @@ metadata:
   name: test
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/apply-setters:v0.1
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
       configPath: setters.yaml
-    - image: gcr.io/kpt-fn/apply-setters:v0.1
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
       configMap:
         baz: qux
 `, "setters.yaml": `apiVersion: v1
@@ -342,7 +342,7 @@ metadata:
   name: project-package
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/apply-setters:v0.1
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
       configPath: setters.yaml
 `, "setters.yaml": `apiVersion: v1
 kind: ConfigMap
@@ -393,7 +393,7 @@ metadata:
   name: vpc-package
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/apply-setters:v0.1
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
       configPath: setters.yaml
 `},
 			expectedResult: []*Result{

--- a/functions/go/set-project-id/README.md
+++ b/functions/go/set-project-id/README.md
@@ -5,7 +5,7 @@
 <!--mdtogo:Short-->
 
 The `set-project-id` function sets 'project-id'
-[setter](https://catalog.kpt.dev/apply-setters/v0.1/?id=definitions) and
+[setter](https://catalog.kpt.dev/apply-setters/v0.2/?id=definitions) and
 `cnrm.cloud.google.com/project-id` annotation to the provided project ID, only
 if they are not already set.
 
@@ -75,7 +75,7 @@ metadata:
   name: example-package
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/apply-setters:v0.1
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
       configMap:
         project-id: foo
 ```

--- a/functions/go/set-project-id/generated/docs.go
+++ b/functions/go/set-project-id/generated/docs.go
@@ -4,7 +4,7 @@
 package generated
 
 var SetProjectIdShort = `The ` + "`" + `set-project-id` + "`" + ` function sets 'project-id'
-[setter](https://catalog.kpt.dev/apply-setters/v0.1/?id=definitions) and
+[setter](https://catalog.kpt.dev/apply-setters/v0.2/?id=definitions) and
 ` + "`" + `cnrm.cloud.google.com/project-id` + "`" + ` annotation to the provided project ID, only
 if they are not already set.`
 var SetProjectIdLong = `
@@ -58,7 +58,7 @@ Kptfile will be updated to the following:
     name: example-package
   pipeline:
     mutators:
-      - image: gcr.io/kpt-fn/apply-setters:v0.1
+      - image: gcr.io/kpt-fn/apply-setters:v0.2
         configMap:
           project-id: foo
 `

--- a/functions/go/set-project-id/main.go
+++ b/functions/go/set-project-id/main.go
@@ -108,7 +108,7 @@ func setSettersOnKptfile(nodes []*yaml.RNode, kf *kptfilev1.KptFile, projectID s
 	}
 
 	fn := kptfilev1.Function{
-		Image: "gcr.io/kpt-fn/apply-setters:v0.1",
+		Image: "gcr.io/kpt-fn/apply-setters:v0.2",
 		ConfigMap: map[string]string{
 			projectIDSetterName: projectID,
 		},

--- a/testdata/fix/nginx-v1/Kptfile
+++ b/testdata/fix/nginx-v1/Kptfile
@@ -28,7 +28,7 @@ info:
   man: nginx man text
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/apply-setters:v0.1
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
       configPath: setters.yaml
     - image: gcr.io/kpt-fn/set-annotations:v0.1
       configPath: my-annotations.yaml

--- a/testdata/fix/nginx-v1/hello-world/Kptfile
+++ b/testdata/fix/nginx-v1/hello-world/Kptfile
@@ -20,7 +20,7 @@ info:
   description: kpt example
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/apply-setters:v0.1
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
       configPath: setters.yaml
     - image: gcr.io/kpt-fn/set-annotations:v0.1
       configPath: set-annotations.yaml

--- a/testdata/fix/nginx-v1alpha2/Kptfile
+++ b/testdata/fix/nginx-v1alpha2/Kptfile
@@ -28,7 +28,7 @@ info:
   man: nginx man text
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/apply-setters:v0.1
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
       configMap:
         image: nginx
         list: '[dev, stage]'

--- a/testdata/fix/nginx-v1alpha2/hello-world/Kptfile
+++ b/testdata/fix/nginx-v1alpha2/hello-world/Kptfile
@@ -20,7 +20,7 @@ info:
   description: kpt example
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/apply-setters:v0.1
+    - image: gcr.io/kpt-fn/apply-setters:v0.2
       configMap:
         http-port: "80"
         image-tag: v0.3.0


### PR DESCRIPTION
Now that #546 has been merged, we should update `set-project-id` to use the new version of `apply-setters` so that the following repro steps won't produce an error:

```sh
# Get the empty blueprint
kpt pkg get https://github.com/GoogleCloudPlatform/blueprints@v0.3.0
cd blueprints/catalog/empty

# Run set-project-id
kpt fn eval ./ --image gcr.io/kpt-fn/set-project-id:v0.1.0 --include-meta-resources -- 'project-id=some-value'

# Run apply-setters
kpt fn render ./
```