### PR TITLE
enable some non-standard features in starlark

### DIFF
--- a/examples/starlark-inject-sidecar/fn-config.yaml
+++ b/examples/starlark-inject-sidecar/fn-config.yaml
@@ -14,7 +14,6 @@ source: |
         "image": "k8s.gcr.io/fluentd-gcp:1.30",
       }
       containers.append(sidecar)
-  def ensure_inject_sidecar(resources):
-    for resource in resources:
-      ensure_inject_sidecar_to_depl(resource)
-  ensure_inject_sidecar(ctx.resource_list["items"])
+
+  for resource in ctx.resource_list["items"]:
+    ensure_inject_sidecar_to_depl(resource)

--- a/examples/starlark-set-namespace/fn-config.yaml
+++ b/examples/starlark-set-namespace/fn-config.yaml
@@ -4,8 +4,6 @@ metadata:
   name: set-namespace-to-prod
 source: |
   # set the namespace on all resources
-  def setnamespace(resources, namespace):
-    for resource in resources:
-      # mutate the resource
-      resource["metadata"]["namespace"] = namespace
-  setnamespace(ctx.resource_list["items"], "prod")
+  for resource in ctx.resource_list["items"]:
+    # mutate the resource
+    resource["metadata"]["namespace"] = "prod"

--- a/examples/starlark-validation/fn-config.yaml
+++ b/examples/starlark-validation/fn-config.yaml
@@ -5,8 +5,6 @@ metadata:
 source: |
   def contains_private_key(r):
     return r["apiVersion"] == "v1" and r["kind"] == "ConfigMap" and r["data"]["private-key"]
-  def ensure_no_private_key(resource_list):
-    for resource in resource_list["items"]:
-      if contains_private_key(resource):
-        fail("it is prohibited to have private key in a configmap")
-  ensure_no_private_key(ctx.resource_list)
+  for resource in ctx.resource_list["items"]:
+    if contains_private_key(resource):
+      fail("it is prohibited to have private key in a configmap")

--- a/functions/go/starlark/third_party/sigs.k8s.io/kustomize/kyaml/fn/runtime/starlark/starlark.go
+++ b/functions/go/starlark/third_party/sigs.k8s.io/kustomize/kyaml/fn/runtime/starlark/starlark.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 
 	"github.com/qri-io/starlib/util"
+	"go.starlark.net/resolve"
 	"go.starlark.net/starlark"
 	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/fn/runtime/runtimeutil"
@@ -107,6 +108,12 @@ func (sf *Filter) Run(reader io.Reader, writer io.Writer) error {
 
 // runStarlark runs the starlark script
 func runStarlark(name, starlarkProgram string, resourceList starlark.Value) error {
+	// Enabled some non-standard starlark features (https://pkg.go.dev/go.starlark.net/resolve#pkg-variables).
+	// LoadBindsGlobally is not enabled, since it has been deprecated.
+	resolve.AllowSet = true
+	resolve.AllowGlobalReassign = true
+	resolve.AllowRecursion = true
+
 	// run the starlark as program as transformation function
 	thread := &starlark.Thread{Name: name, Load: load}
 

--- a/tests/starlark/non-standard-features/.expected/diff.patch
+++ b/tests/starlark/non-standard-features/.expected/diff.patch
@@ -1,0 +1,11 @@
+diff --git a/app.yaml b/app.yaml
+index cd38f61..6261189 100644
+--- a/app.yaml
++++ b/app.yaml
+@@ -2,5 +2,6 @@ apiVersion: v1
+ kind: ConfigMap
+ metadata:
+   name: my-cm
++  namespace: test
+ data:
+   some-key: some-value

--- a/tests/starlark/non-standard-features/.expected/results.yaml
+++ b/tests/starlark/non-standard-features/.expected/results.yaml
@@ -1,0 +1,11 @@
+apiVersion: kpt.dev/v1
+kind: FunctionResultList
+metadata:
+  name: fnresults
+exitCode: 0
+items:
+  - image: gcr.io/kpt-fn/starlark:unstable
+    stderr: |
+      set(["foo", "bar"])
+      2
+    exitCode: 0

--- a/tests/starlark/non-standard-features/.krmignore
+++ b/tests/starlark/non-standard-features/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/tests/starlark/non-standard-features/Kptfile
+++ b/tests/starlark/non-standard-features/Kptfile
@@ -1,0 +1,8 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: example
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/starlark:unstable
+      configPath: fn-config.yaml

--- a/tests/starlark/non-standard-features/app.yaml
+++ b/tests/starlark/non-standard-features/app.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-cm
+data:
+  some-key: some-value

--- a/tests/starlark/non-standard-features/fn-config.yaml
+++ b/tests/starlark/non-standard-features/fn-config.yaml
@@ -1,0 +1,19 @@
+apiVersion: fn.kpt.dev/v1alpha1
+kind: StarlarkRun
+metadata:
+  name: set-namespace-to-prod
+source: |
+  # Test set
+  x = set(["foo", "bar"])
+  print(x)
+
+  # Test recursion
+  def fib(n):
+    if n == 0 or n == 1:
+      return n
+    else:
+      return fib(n-1) + fib(n-2)
+  print(fib(3))
+
+  for resource in ctx.resource_list["items"]:
+    resource["metadata"]["namespace"] = "test"


### PR DESCRIPTION
Enabled set, global reassign, recursion

LoadBindsGlobally has been deprecated, and it is not enabled. Ref: https://pkg.go.dev/go.starlark.net/resolve#pkg-variables

fixes: https://github.com/GoogleContainerTools/kpt/issues/2429