### PR TITLE
chore: cancel old commit CI for PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,11 @@ on:
     - cron:  '0 17 * * *'
 
 concurrency:
+  # If a job with a concurrency group is running with cancel-in-progress, that job is cancelled when a new job with same concurrency group is started.
+  # In a workflow github.head_ref exists only for PRs while github.ref exists for the repo branches/tags.
+  # Concurrency group will be of form ${{ github.head_ref }}-ci when triggered via PR creating 1 group per PR. Older jobs are cancelled when new commits are pushed to that PR branch.
+  # Concurrency group will be of form ${{ github.ref }}-ci when triggered from repo branch or tag ref. Older jobs are cancelled when new jobs are triggered from that same branch/tag.
+  # `-ci` suffix is to namespace the concurrency group incase you want to add a group for another workflow in the future.
   group: '${{ github.head_ref || github.ref }}-ci'
   cancel-in-progress: true
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,10 @@ on:
   schedule:
     - cron:  '0 17 * * *'
 
+concurrency:
+  group: '${{ github.head_ref || github.ref }}-ci'
+  cancel-in-progress: true
+
 jobs:
   shell-ci:
     strategy:


### PR DESCRIPTION
GitHub Actions lets you cancel builds when new commits are pushed, similar to Prow. In most cases you probably want CI results for new commits and don't care about older commits. More details [here](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency) if you are interested.

I saw this while iterating on my other PR https://github.com/GoogleContainerTools/kpt-functions-catalog/pull/64 and multiple  CI jobs were running for +30m on old commits.