### PR TITLE
feat: Emit changed files in set-annotations output

### DIFF
--- a/functions/go/set-annotations/annotations_transformer_test.go
+++ b/functions/go/set-annotations/annotations_transformer_test.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 )
 
@@ -188,6 +189,65 @@ spec:
 		fmt.Println("===")
 		fmt.Println("Expected:")
 		fmt.Println(expected)
+		t.Fatalf("Actual doesn't equal to expected")
+	}
+}
+
+func TestAnnotationsTransformerResults(t *testing.T) {
+	config := `
+annotations:
+  app: myApp
+`
+	input := `
+apiVersion: v1
+kind: Service
+metadata:
+  name: myService
+spec:
+  ports:
+  - port: 7002
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mungebot
+  labels:
+    app: mungebot
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: mungebot
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+`
+	expectedResults := []*Result{
+		{
+			FilePath: "",
+			FieldPath: "metadata.annotations.app",
+			Value: "myApp",
+		},
+		{
+			FilePath: "",
+			FieldPath: "metadata.annotations.app",
+			Value: "myApp",
+		},
+		{
+			FilePath: "",
+			FieldPath: "spec.template.metadata.annotations.app",
+			Value: "myApp",
+		},
+	}
+	runAnnotationTransformer(t, config, input)
+	if !reflect.DeepEqual(KustomizePlugin.Results, expectedResults) {
+		fmt.Println("Actual:")
+		fmt.Println(KustomizePlugin.Results)
+		fmt.Println("===")
+		fmt.Println("Expected:")
+		fmt.Println(expectedResults)
 		t.Fatalf("Actual doesn't equal to expected")
 	}
 }


### PR DESCRIPTION
This adds functionality to include the filepath, fieldpath, and
value for each set-annotation in the output. This behavior is
modeled after the behavior of apply-setters.

The incumbent set-annotations implementation leverages kustomize
filters, which does not offer a straightforward way to track
fields that are updated by the filter. This implementation uses
a custom setEntry method to track updated annotations.

Issues: GoogleContainerTools/kpt#2448