### PR TITLE
Set annotations changed files output

### DIFF
--- a/functions/go/set-annotations/annotations_transformer_test.go
+++ b/functions/go/set-annotations/annotations_transformer_test.go
@@ -205,6 +205,7 @@ kind: Service
 metadata:
   annotations:
     internal.config.kubernetes.io/path: foo.yaml
+    internal.config.kubernetes.io/index: 0
   name: myService
 spec:
   ports:
@@ -215,6 +216,7 @@ kind: Deployment
 metadata:
   annotations:
     internal.config.kubernetes.io/path: bar.yaml
+    internal.config.kubernetes.io/index: 1
   name: mungebot
   labels:
     app: mungebot
@@ -229,22 +231,22 @@ spec:
       - name: nginx
         image: nginx
 `
-	expectedResults := []*Result{
+	expectedResults := AnnotationResults{
 		{
 			FilePath:  "foo.yaml",
-			FieldPath: "metadata.annotations.app",
-			Value:     "myApp",
-		},
+			FileIndex: "0",
+			FieldPath: "metadata.annotations",
+		}: {"app": "myApp"},
 		{
 			FilePath:  "bar.yaml",
-			FieldPath: "metadata.annotations.app",
-			Value:     "myApp",
-		},
+			FileIndex: "1",
+			FieldPath: "metadata.annotations",
+		}: {"app": "myApp"},
 		{
 			FilePath:  "bar.yaml",
-			FieldPath: "spec.template.metadata.annotations.app",
-			Value:     "myApp",
-		},
+			FileIndex: "1",
+			FieldPath: "spec.template.metadata.annotations",
+		}: {"app": "myApp"},
 	}
 	runAnnotationTransformer(t, config, input)
 	if !reflect.DeepEqual(KustomizePlugin.Results, expectedResults) {

--- a/functions/go/set-annotations/annotations_transformer_test.go
+++ b/functions/go/set-annotations/annotations_transformer_test.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 )
 
@@ -16,6 +17,7 @@ func runAnnotationTransformerE(config, input string) (string, error) {
 	}
 
 	var plugin *plugin = &KustomizePlugin
+	plugin.Results = nil
 	err = plugin.Config(nil, []byte(config))
 	if err != nil {
 		return "", err
@@ -188,6 +190,69 @@ spec:
 		fmt.Println("===")
 		fmt.Println("Expected:")
 		fmt.Println(expected)
+		t.Fatalf("Actual doesn't equal to expected")
+	}
+}
+
+func TestAnnotationsTransformerResults(t *testing.T) {
+	config := `
+annotations:
+  app: myApp
+`
+	input := `
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    internal.config.kubernetes.io/path: foo.yaml
+  name: myService
+spec:
+  ports:
+  - port: 7002
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    internal.config.kubernetes.io/path: bar.yaml
+  name: mungebot
+  labels:
+    app: mungebot
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: mungebot
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+`
+	expectedResults := []*Result{
+		{
+			FilePath:  "foo.yaml",
+			FieldPath: "metadata.annotations.app",
+			Value:     "myApp",
+		},
+		{
+			FilePath:  "bar.yaml",
+			FieldPath: "metadata.annotations.app",
+			Value:     "myApp",
+		},
+		{
+			FilePath:  "bar.yaml",
+			FieldPath: "spec.template.metadata.annotations.app",
+			Value:     "myApp",
+		},
+	}
+	runAnnotationTransformer(t, config, input)
+	if !reflect.DeepEqual(KustomizePlugin.Results, expectedResults) {
+		fmt.Println("Actual:")
+		fmt.Println(KustomizePlugin.Results)
+		fmt.Println("===")
+		fmt.Println("Expected:")
+		fmt.Println(expectedResults)
 		t.Fatalf("Actual doesn't equal to expected")
 	}
 }

--- a/functions/go/set-annotations/go.mod
+++ b/functions/go/set-annotations/go.mod
@@ -3,7 +3,7 @@ module github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/set-an
 go 1.16
 
 require (
-	sigs.k8s.io/kustomize/api v0.10.1
-	sigs.k8s.io/kustomize/kyaml v0.13.0
+	sigs.k8s.io/kustomize/api v0.10.2-0.20211130022056-a3e1c999154c
+	sigs.k8s.io/kustomize/kyaml v0.13.1-0.20211130022056-a3e1c999154c
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/functions/go/set-annotations/go.mod
+++ b/functions/go/set-annotations/go.mod
@@ -3,7 +3,7 @@ module github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/set-an
 go 1.16
 
 require (
-	sigs.k8s.io/kustomize/api v0.10.2-0.20211130022056-a3e1c999154c
-	sigs.k8s.io/kustomize/kyaml v0.13.1-0.20211130022056-a3e1c999154c
+	sigs.k8s.io/kustomize/api v0.10.2-0.20211202184144-fe551be87b8d
+	sigs.k8s.io/kustomize/kyaml v0.13.1-0.20211202184144-fe551be87b8d
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/functions/go/set-annotations/go.sum
+++ b/functions/go/set-annotations/go.sum
@@ -226,10 +226,11 @@ k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e h1:KLHHjkdQFomZy8+06csTWZ0m1343QqxZhR2LJ1OxCYM=
 k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e/go.mod h1:vHXdDvt9+2spS2Rx9ql3I8tycm3H9FDfdUoIuKCefvw=
-sigs.k8s.io/kustomize/api v0.10.1 h1:KgU7hfYoscuqag84kxtzKdEC3mKMb99DPI3a0eaV1d0=
-sigs.k8s.io/kustomize/api v0.10.1/go.mod h1:2FigT1QN6xKdcnGS2Ppp1uIWrtWN28Ms8A3OZUZhwr8=
-sigs.k8s.io/kustomize/kyaml v0.13.0 h1:9c+ETyNfSrVhxvphs+K2dzT3dh5oVPPEqPOE/cUpScY=
+sigs.k8s.io/kustomize/api v0.10.2-0.20211130022056-a3e1c999154c h1:WCJz2U16gEI8d+kZNkra8QAPq8T8xxrho9g5pQc9NiI=
+sigs.k8s.io/kustomize/api v0.10.2-0.20211130022056-a3e1c999154c/go.mod h1:6JSgt1WR7U7Wr4LoZ/vAGP2nailrn2/ECpDZ23GJtFo=
 sigs.k8s.io/kustomize/kyaml v0.13.0/go.mod h1:FTJxEZ86ScK184NpGSAQcfEqee0nul8oLCK30D47m4E=
+sigs.k8s.io/kustomize/kyaml v0.13.1-0.20211130022056-a3e1c999154c h1:1hm94ZhtXaIwEhDj2CzBMp8qtARGo6/g07nhcfx1sO8=
+sigs.k8s.io/kustomize/kyaml v0.13.1-0.20211130022056-a3e1c999154c/go.mod h1:FTJxEZ86ScK184NpGSAQcfEqee0nul8oLCK30D47m4E=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=

--- a/functions/go/set-annotations/go.sum
+++ b/functions/go/set-annotations/go.sum
@@ -228,9 +228,13 @@ k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e h1:KLHHjkdQFomZy8+06csTWZ
 k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e/go.mod h1:vHXdDvt9+2spS2Rx9ql3I8tycm3H9FDfdUoIuKCefvw=
 sigs.k8s.io/kustomize/api v0.10.2-0.20211130022056-a3e1c999154c h1:WCJz2U16gEI8d+kZNkra8QAPq8T8xxrho9g5pQc9NiI=
 sigs.k8s.io/kustomize/api v0.10.2-0.20211130022056-a3e1c999154c/go.mod h1:6JSgt1WR7U7Wr4LoZ/vAGP2nailrn2/ECpDZ23GJtFo=
+sigs.k8s.io/kustomize/api v0.10.2-0.20211202184144-fe551be87b8d h1:R/dZYqyD+6VWspltlH6pC5/h5UL4GIjr3uZuScUL2bA=
+sigs.k8s.io/kustomize/api v0.10.2-0.20211202184144-fe551be87b8d/go.mod h1:6JSgt1WR7U7Wr4LoZ/vAGP2nailrn2/ECpDZ23GJtFo=
 sigs.k8s.io/kustomize/kyaml v0.13.0/go.mod h1:FTJxEZ86ScK184NpGSAQcfEqee0nul8oLCK30D47m4E=
 sigs.k8s.io/kustomize/kyaml v0.13.1-0.20211130022056-a3e1c999154c h1:1hm94ZhtXaIwEhDj2CzBMp8qtARGo6/g07nhcfx1sO8=
 sigs.k8s.io/kustomize/kyaml v0.13.1-0.20211130022056-a3e1c999154c/go.mod h1:FTJxEZ86ScK184NpGSAQcfEqee0nul8oLCK30D47m4E=
+sigs.k8s.io/kustomize/kyaml v0.13.1-0.20211202184144-fe551be87b8d h1:ZQl8im14EmKfcJ7IQ6GnUgfgJw0msaDcAn9PwlO3fig=
+sigs.k8s.io/kustomize/kyaml v0.13.1-0.20211202184144-fe551be87b8d/go.mod h1:FTJxEZ86ScK184NpGSAQcfEqee0nul8oLCK30D47m4E=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=

--- a/tests/set-annotations/additional-annotations/.expected/diff.patch
+++ b/tests/set-annotations/additional-annotations/.expected/diff.patch
@@ -1,0 +1,33 @@
+diff --git a/local-config.yaml b/local-config.yaml
+index b8d83d1..1619258 100644
+--- a/local-config.yaml
++++ b/local-config.yaml
+@@ -4,5 +4,11 @@ metadata:
+   name: local-config-map
+   annotations:
+     config.kubernetes.io/local-config: "true"
++    color: orange
++    fruit: apple
+ data:
+   some-key: some-value
++  selector:
++    annotations:
++      color: orange
++      fruit: apple
+diff --git a/resources.yaml b/resources.yaml
+index 3127bfa..1397bfd 100644
+--- a/resources.yaml
++++ b/resources.yaml
+@@ -2,5 +2,12 @@ apiVersion: v1
+ kind: ConfigMap
+ metadata:
+   name: the-map
++  annotations:
++    color: orange
++    fruit: apple
+ data:
+   some-key: some-value
++  selector:
++    annotations:
++      color: orange
++      fruit: apple

--- a/tests/set-annotations/additional-annotations/.expected/diff.patch
+++ b/tests/set-annotations/additional-annotations/.expected/diff.patch
@@ -15,10 +15,10 @@ index b8d83d1..1619258 100644
 +      color: orange
 +      fruit: apple
 diff --git a/resources.yaml b/resources.yaml
-index 3127bfa..1397bfd 100644
+index 799a41c..a251bbe 100644
 --- a/resources.yaml
 +++ b/resources.yaml
-@@ -2,5 +2,12 @@ apiVersion: v1
+@@ -2,12 +2,26 @@ apiVersion: v1
  kind: ConfigMap
  metadata:
    name: the-map
@@ -27,6 +27,20 @@ index 3127bfa..1397bfd 100644
 +    fruit: apple
  data:
    some-key: some-value
++  selector:
++    annotations:
++      color: orange
++      fruit: apple
+ ---
+ apiVersion: v1
+ kind: ConfigMap
+ metadata:
+   name: the-second-map
++  annotations:
++    color: orange
++    fruit: apple
+ data:
+   some-key: some-other-value
 +  selector:
 +    annotations:
 +      color: orange

--- a/tests/set-annotations/additional-annotations/.expected/results.yaml
+++ b/tests/set-annotations/additional-annotations/.expected/results.yaml
@@ -1,0 +1,49 @@
+apiVersion: kpt.dev/v1
+kind: FunctionResultList
+metadata:
+  name: fnresults
+exitCode: 0
+items:
+  - image: gcr.io/kpt-fn/set-annotations:unstable
+    exitCode: 0
+    results:
+      - message: set annotation value to "orange"
+        field:
+          path: data.selector.annotations.color
+        file:
+          path: local-config.yaml
+      - message: set annotation value to "orange"
+        field:
+          path: metadata.annotations.color
+        file:
+          path: local-config.yaml
+      - message: set annotation value to "apple"
+        field:
+          path: data.selector.annotations.fruit
+        file:
+          path: local-config.yaml
+      - message: set annotation value to "apple"
+        field:
+          path: metadata.annotations.fruit
+        file:
+          path: local-config.yaml
+      - message: set annotation value to "orange"
+        field:
+          path: data.selector.annotations.color
+        file:
+          path: resources.yaml
+      - message: set annotation value to "orange"
+        field:
+          path: metadata.annotations.color
+        file:
+          path: resources.yaml
+      - message: set annotation value to "apple"
+        field:
+          path: data.selector.annotations.fruit
+        file:
+          path: resources.yaml
+      - message: set annotation value to "apple"
+        field:
+          path: metadata.annotations.fruit
+        file:
+          path: resources.yaml

--- a/tests/set-annotations/additional-annotations/.expected/results.yaml
+++ b/tests/set-annotations/additional-annotations/.expected/results.yaml
@@ -7,43 +7,35 @@ items:
   - image: gcr.io/kpt-fn/set-annotations:unstable
     exitCode: 0
     results:
-      - message: set annotation value to "orange"
+      - message: 'set annotations: {"color":"orange","fruit":"apple"}'
         field:
-          path: data.selector.annotations.color
+          path: data.selector.annotations
         file:
           path: local-config.yaml
-      - message: set annotation value to "orange"
+      - message: 'set annotations: {"color":"orange","fruit":"apple"}'
         field:
-          path: metadata.annotations.color
+          path: metadata.annotations
         file:
           path: local-config.yaml
-      - message: set annotation value to "apple"
+      - message: 'set annotations: {"color":"orange","fruit":"apple"}'
         field:
-          path: data.selector.annotations.fruit
-        file:
-          path: local-config.yaml
-      - message: set annotation value to "apple"
-        field:
-          path: metadata.annotations.fruit
-        file:
-          path: local-config.yaml
-      - message: set annotation value to "orange"
-        field:
-          path: data.selector.annotations.color
+          path: data.selector.annotations
         file:
           path: resources.yaml
-      - message: set annotation value to "orange"
+      - message: 'set annotations: {"color":"orange","fruit":"apple"}'
         field:
-          path: metadata.annotations.color
+          path: metadata.annotations
         file:
           path: resources.yaml
-      - message: set annotation value to "apple"
+      - message: 'set annotations: {"color":"orange","fruit":"apple"}'
         field:
-          path: data.selector.annotations.fruit
+          path: data.selector.annotations
         file:
           path: resources.yaml
-      - message: set annotation value to "apple"
+          index: 1
+      - message: 'set annotations: {"color":"orange","fruit":"apple"}'
         field:
-          path: metadata.annotations.fruit
+          path: metadata.annotations
         file:
           path: resources.yaml
+          index: 1

--- a/tests/set-annotations/additional-annotations/.krmignore
+++ b/tests/set-annotations/additional-annotations/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/tests/set-annotations/additional-annotations/Kptfile
+++ b/tests/set-annotations/additional-annotations/Kptfile
@@ -1,0 +1,8 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: example
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/set-annotations:unstable
+      configPath: fn-config.yaml

--- a/tests/set-annotations/additional-annotations/fn-config.yaml
+++ b/tests/set-annotations/additional-annotations/fn-config.yaml
@@ -1,0 +1,13 @@
+apiVersion: fn.kpt.dev/v1alpha1
+kind: SetAnnotations
+metadata:
+  name: my-config
+  annotations:
+    config.kubernetes.io/local-config: "true"
+annotations:
+  color: orange
+  fruit: apple
+additionalAnnotationFields:
+- path: data/selector/annotations
+  kind: ConfigMap
+  create: true

--- a/tests/set-annotations/additional-annotations/local-config.yaml
+++ b/tests/set-annotations/additional-annotations/local-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-config-map
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  some-key: some-value

--- a/tests/set-annotations/additional-annotations/resources.yaml
+++ b/tests/set-annotations/additional-annotations/resources.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: the-map
+data:
+  some-key: some-value

--- a/tests/set-annotations/additional-annotations/resources.yaml
+++ b/tests/set-annotations/additional-annotations/resources.yaml
@@ -4,3 +4,10 @@ metadata:
   name: the-map
 data:
   some-key: some-value
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: the-second-map
+data:
+  some-key: some-other-value

--- a/tests/set-annotations/legacy-config/.expected/results.yaml
+++ b/tests/set-annotations/legacy-config/.expected/results.yaml
@@ -7,13 +7,8 @@ items:
   - image: gcr.io/kpt-fn/set-annotations:unstable
     exitCode: 0
     results:
-      - message: set annotation value to "orange"
+      - message: 'set annotations: {"color":"orange","fruit":"apple"}'
         field:
-          path: metadata.annotations.color
-        file:
-          path: resources.yaml
-      - message: set annotation value to "apple"
-        field:
-          path: metadata.annotations.fruit
+          path: metadata.annotations
         file:
           path: resources.yaml

--- a/tests/set-annotations/legacy-config/.expected/results.yaml
+++ b/tests/set-annotations/legacy-config/.expected/results.yaml
@@ -1,0 +1,19 @@
+apiVersion: kpt.dev/v1
+kind: FunctionResultList
+metadata:
+  name: fnresults
+exitCode: 0
+items:
+  - image: gcr.io/kpt-fn/set-annotations:unstable
+    exitCode: 0
+    results:
+      - message: set annotation value to "orange"
+        field:
+          path: metadata.annotations.color
+        file:
+          path: resources.yaml
+      - message: set annotation value to "apple"
+        field:
+          path: metadata.annotations.fruit
+        file:
+          path: resources.yaml

--- a/tests/set-annotations/local-config/.expected/results.yaml
+++ b/tests/set-annotations/local-config/.expected/results.yaml
@@ -1,0 +1,29 @@
+apiVersion: kpt.dev/v1
+kind: FunctionResultList
+metadata:
+  name: fnresults
+exitCode: 0
+items:
+  - image: gcr.io/kpt-fn/set-annotations:unstable
+    exitCode: 0
+    results:
+      - message: set annotation value to "orange"
+        field:
+          path: metadata.annotations.color
+        file:
+          path: local-config.yaml
+      - message: set annotation value to "apple"
+        field:
+          path: metadata.annotations.fruit
+        file:
+          path: local-config.yaml
+      - message: set annotation value to "orange"
+        field:
+          path: metadata.annotations.color
+        file:
+          path: resources.yaml
+      - message: set annotation value to "apple"
+        field:
+          path: metadata.annotations.fruit
+        file:
+          path: resources.yaml

--- a/tests/set-annotations/local-config/.expected/results.yaml
+++ b/tests/set-annotations/local-config/.expected/results.yaml
@@ -7,23 +7,13 @@ items:
   - image: gcr.io/kpt-fn/set-annotations:unstable
     exitCode: 0
     results:
-      - message: set annotation value to "orange"
+      - message: 'set annotations: {"color":"orange","fruit":"apple"}'
         field:
-          path: metadata.annotations.color
+          path: metadata.annotations
         file:
           path: local-config.yaml
-      - message: set annotation value to "apple"
+      - message: 'set annotations: {"color":"orange","fruit":"apple"}'
         field:
-          path: metadata.annotations.fruit
-        file:
-          path: local-config.yaml
-      - message: set annotation value to "orange"
-        field:
-          path: metadata.annotations.color
-        file:
-          path: resources.yaml
-      - message: set annotation value to "apple"
-        field:
-          path: metadata.annotations.fruit
+          path: metadata.annotations
         file:
           path: resources.yaml


### PR DESCRIPTION
This adds functionality to include the filepath, fieldpath, and
value for each set-annotation in the output. This behavior is
modeled after the behavior of apply-setters.

Issues: GoogleContainerTools/kpt#2448