### PR TITLE
Site examples patch version

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -117,9 +117,9 @@
 
               let catalogPath;
               if (isContribFn) {
-                catalogPath = "/contrib/catalog.json";
+                catalogPath = "/contrib/catalog-v2.json";
               } else {
-                catalogPath = "/catalog.json";
+                catalogPath = "/catalog-v2.json";
               }
               window.Docsify.get(catalogPath).then(function (
                 catalogResponse
@@ -135,8 +135,10 @@
                   versionName = pathElements[2];
                 }
 
-                const currentVersion = versionName.replaceAll("v", "");
+                const patchSemver = versions[versionName]['LatestPatchVersion']
+                const currentVersion = patchSemver.replaceAll("v", "");
                 const sortedSemvers = Object.keys(versions)
+                  .map((minor) => versions[minor]['LatestPatchVersion'])
                   .sort((a, b) => compareVersions(a, b))
                   .reverse();
                 versionDropdown += `
@@ -155,7 +157,7 @@
                 </ol>
               </div>`;
 
-                const examples = catalog[functionName][versionName];
+                const examples = catalog[functionName][versionName]['Examples'];
                 const ghElement = document
                   .getElementsByClassName("github-corner")
                   .item(0);


### PR DESCRIPTION
Issue: GoogleContainerTools/kpt#2609

This adds a new catalog-v2.json endpoint which expands upon the previous catalog.json schema to also include the latest patch version for each major/minor function release. This is presented as a new endpoint in order to avoid breaking compatibility with existing consumers of the original endpoint, such as versions of kpt already in the wild.

Updates the catalog pages of the website to include the latest patch version in:
- The version dropdown for the function
- A new dynamically rendered latest image section