### PR TITLE
fix: Correct path in href for contrib fn dropdown

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -147,7 +147,7 @@
                 <ol class="dropdown-menu">`;
                 sortedSemvers.forEach(
                   (ver, ix) =>
-                    (versionDropdown += `<li><a href="/${functionName}/${ver}/">${versions[ver]['LatestPatchVersion'].replace(
+                    (versionDropdown += `<li><a href="${isContribFn ? "/contrib" : ""}/${functionName}/${ver}/">${versions[ver]['LatestPatchVersion'].replace(
                       "v",
                       ""
                     )}${ix ? "" : " (latest)"}</a></li>`)


### PR DESCRIPTION
Contrib functions are under the /contrib path, so this corrects
the path used in the href for contrib function version dropdowns.