### PR TITLE
Set namespace rolebinding behavior

### DIFF
--- a/functions/go/set-namespace/README.md
+++ b/functions/go/set-namespace/README.md
@@ -37,19 +37,35 @@ target the namespace. There are a few cases that worth pointing out:
 
 - If there is a `Namespace` resource, its `metadata.name` field will be updated.
 - If there's a `RoleBinding` or `ClusterRoleBinding` resource, the function will
-  update the namespace in the `ServiceAccount` if and only if the subject
-  element `name` is `default`. In the following example, the `set-namespace`
-  function will update `subjects.namespace` since the
-  corresponding `subjects.name` is `default`.
+  update the namespace in the `ServiceAccount` if one of the following are true:
+  1) the subject element `name` is `default`.
+  2) the subject element `name` matches the name of a `ServiceAccount` resource declared in the package.
+  
+In the following example, the `set-namespace` function will update:
+- `subjects[0].namespace` since `subjects[0].name` is `default`.
+- `subjects[1].namespace` since `subjects[1].name` matches a `ServiceAccount`
+  name declared in the package.
 
 ```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: service-account
+  namespace: original-namespace
+---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   ...
 subjects:
   - kind: ServiceAccount
-    name: default # <======== using name default here
+    name: default # <================== name default is used
+    namespace: original-namespace # <== this will be updated
+  - kind: ServiceAccount
+    name: service-account # <========== name matches above ServiceAccount
+    namespace: original-namespace # <== this will be updated
+  - kind: ServiceAccount
+    name: other-service-account # <==== this will NOT be updated
     namespace: original-namespace
 roleRef:
   kind: Role

--- a/functions/go/set-namespace/namespace_transformer_test.go
+++ b/functions/go/set-namespace/namespace_transformer_test.go
@@ -162,7 +162,7 @@ subjects:
   namespace: test
 - kind: ServiceAccount
   name: service-account
-  namespace: system
+  namespace: test
 - kind: ServiceAccount
   name: another
   namespace: random

--- a/tests/set-namespace/ensure-name-substring/.expected/diff.patch
+++ b/tests/set-namespace/ensure-name-substring/.expected/diff.patch
@@ -1,0 +1,52 @@
+diff --git a/resources.yaml b/resources.yaml
+index 0315d44..3a16469 100644
+--- a/resources.yaml
++++ b/resources.yaml
+@@ -1,21 +1,21 @@
+ apiVersion: v1
+ kind: ServiceAccount
+ metadata:
+-  name: service-account
+-  namespace: system
++  name: dev-service-account
++  namespace: example-ns
+ ---
+ apiVersion: rbac.authorization.k8s.io/v1
+ kind: RoleBinding
+ metadata:
+-  name: manager-rolebinding
+-  namespace: system
++  name: dev-manager-rolebinding
++  namespace: example-ns
+ subjects:
+ - kind: ServiceAccount
+   name: default
+-  namespace: system
++  namespace: example-ns
+ - kind: ServiceAccount
+-  name: service-account
+-  namespace: system
++  name: dev-service-account
++  namespace: example-ns
+ - kind: ServiceAccount
+   name: another
+   namespace: random
+@@ -23,14 +23,14 @@ subjects:
+ apiVersion: rbac.authorization.k8s.io/v1
+ kind: ClusterRoleBinding
+ metadata:
+-  name: manager-cluster-rolebinding
++  name: dev-manager-cluster-rolebinding
+ subjects:
+ - kind: ServiceAccount
+   name: default
+-  namespace: system
++  namespace: example-ns
+ - kind: ServiceAccount
+-  name: service-account
+-  namespace: system
++  name: dev-service-account
++  namespace: example-ns
+ - kind: ServiceAccount
+   name: another
+   namespace: random

--- a/tests/set-namespace/ensure-name-substring/.krmignore
+++ b/tests/set-namespace/ensure-name-substring/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/tests/set-namespace/ensure-name-substring/Kptfile
+++ b/tests/set-namespace/ensure-name-substring/Kptfile
@@ -1,0 +1,12 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: example
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/ensure-name-substring:unstable
+      configMap:
+        prepend: dev-
+    - image: gcr.io/kpt-fn/set-namespace:unstable
+      configMap:
+        namespace: example-ns

--- a/tests/set-namespace/ensure-name-substring/resources.yaml
+++ b/tests/set-namespace/ensure-name-substring/resources.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: service-account
+  namespace: system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: manager-rolebinding
+  namespace: system
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system
+- kind: ServiceAccount
+  name: service-account
+  namespace: system
+- kind: ServiceAccount
+  name: another
+  namespace: random
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-cluster-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system
+- kind: ServiceAccount
+  name: service-account
+  namespace: system
+- kind: ServiceAccount
+  name: another
+  namespace: random

--- a/tests/set-namespace/rolebindings/.expected/diff.patch
+++ b/tests/set-namespace/rolebindings/.expected/diff.patch
@@ -1,0 +1,42 @@
+diff --git a/resources.yaml b/resources.yaml
+index 0315d44..78167d3 100644
+--- a/resources.yaml
++++ b/resources.yaml
+@@ -2,20 +2,20 @@ apiVersion: v1
+ kind: ServiceAccount
+ metadata:
+   name: service-account
+-  namespace: system
++  namespace: example-ns
+ ---
+ apiVersion: rbac.authorization.k8s.io/v1
+ kind: RoleBinding
+ metadata:
+   name: manager-rolebinding
+-  namespace: system
++  namespace: example-ns
+ subjects:
+ - kind: ServiceAccount
+   name: default
+-  namespace: system
++  namespace: example-ns
+ - kind: ServiceAccount
+   name: service-account
+-  namespace: system
++  namespace: example-ns
+ - kind: ServiceAccount
+   name: another
+   namespace: random
+@@ -27,10 +27,10 @@ metadata:
+ subjects:
+ - kind: ServiceAccount
+   name: default
+-  namespace: system
++  namespace: example-ns
+ - kind: ServiceAccount
+   name: service-account
+-  namespace: system
++  namespace: example-ns
+ - kind: ServiceAccount
+   name: another
+   namespace: random

--- a/tests/set-namespace/rolebindings/.krmignore
+++ b/tests/set-namespace/rolebindings/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/tests/set-namespace/rolebindings/Kptfile
+++ b/tests/set-namespace/rolebindings/Kptfile
@@ -1,0 +1,9 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: example
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/set-namespace:unstable
+      configMap:
+        namespace: example-ns

--- a/tests/set-namespace/rolebindings/resources.yaml
+++ b/tests/set-namespace/rolebindings/resources.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: service-account
+  namespace: system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: manager-rolebinding
+  namespace: system
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system
+- kind: ServiceAccount
+  name: service-account
+  namespace: system
+- kind: ServiceAccount
+  name: another
+  namespace: random
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-cluster-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system
+- kind: ServiceAccount
+  name: service-account
+  namespace: system
+- kind: ServiceAccount
+  name: another
+  namespace: random


### PR DESCRIPTION
Issues: GoogleContainerTools/kpt#2397


This pull request adds support to update the namespace for
ServiceAccount resources which are referenced in the subjects
field of RoleBinding and ClusterRoleBinding resources.

Given a ServiceAccount with name sa-name is included in the
ResourceList, any RoleBinding or ClusterRoleBinding subject with
kind ServiceAccount and name sa-name will also have its namespace
set.

For the time being this functionality is being implemented in kpt
rather than the upstream kustomize library. If this behavior is
well received, it may be a future consideration to push this
functionality into kustomize.