### PR TITLE
fix: Remove quotes from generated commit messages

### DIFF
--- a/scripts/update_function_docs/git.go
+++ b/scripts/update_function_docs/git.go
@@ -61,8 +61,7 @@ func gitAdd() error {
 }
 
 func gitCommit(msg string) error {
-	formattedMsg := fmt.Sprintf("\"%s\"", msg)
-	stdout, err := runCmd("git", "commit", "-m", formattedMsg)
+	stdout, err := runCmd("git", "commit", "-m", msg)
 	fmt.Printf("%v\n", stdout)
 	return err
 }


### PR DESCRIPTION
The prior implementation was resulting in redundant quotes in the
commit message.