### PR TITLE
ci: Allow patch version for pkg url in verify-docs

### DIFF
--- a/scripts/verify-docs.py
+++ b/scripts/verify-docs.py
@@ -255,7 +255,7 @@ def validate_example_md(fn_name, dir_name, example_name, branch):
                 desired_pkg_url = f'{git_url_prefix}/{example_path}'
                 if branch != 'master':
                     desired_pkg_url = desired_pkg_url + f'@{branch}'
-                if item != desired_pkg_url:
+                if not item.startswith(desired_pkg_url):
                     raise Exception(f'the desired package url in {md_file_path} is {desired_pkg_url}, but found {item}')
 
             if gcr_prefix in item:


### PR DESCRIPTION
The documentation is being updated to specify the patch version
rather than the minor version in the package URLs. This change
will allow both minor/patch version to be specified in the
meantime. Once all the documentation has been updated, this
can be made more strict to only allow the latest patch version.