### PR TITLE
feat: ensure-name-substring supports depends-on

### DIFF
--- a/examples/ensure-name-substring-depends-on/.expected/diff.patch
+++ b/examples/ensure-name-substring-depends-on/.expected/diff.patch
@@ -1,0 +1,56 @@
+diff --git a/resources.yaml b/resources.yaml
+index 28bdcf3..63e0ad6 100644
+--- a/resources.yaml
++++ b/resources.yaml
+@@ -2,10 +2,10 @@ apiVersion: v1
+ kind: Deployment
+ metadata:
+   annotations:
+-    config.kubernetes.io/depends-on: /namespaces/default/StatefulSet/wordpress-mysql
++    config.kubernetes.io/depends-on: /namespaces/default/StatefulSet/prod-wordpress-mysql
+   labels:
+     app: wordpress
+-  name: wordpress
++  name: prod-wordpress
+   namespace: default
+ ---
+ apiVersion: v1
+@@ -13,7 +13,7 @@ kind: StatefulSet
+ metadata:
+   labels:
+     app: wordpress
+-  name: wordpress-mysql
++  name: prod-wordpress-mysql
+   namespace: default
+ ---
+ apiVersion: v1
+@@ -23,19 +23,19 @@ metadata:
+     config.kubernetes.io/depends-on: /namespaces/default/StatefulSet/outside-resource
+   labels:
+     app: bar
+-  name: bar
++  name: prod-bar
+   namespace: default
+ ---
+ apiVersion: rbac.authorization.k8s.io/v1
+ kind: ClusterRoleBinding
+ metadata:
+   annotations:
+-    config.kubernetes.io/depends-on: rbac.authorization.k8s.io/ClusterRole/secret-reader
+-  name: read-secrets-global
++    config.kubernetes.io/depends-on: rbac.authorization.k8s.io/ClusterRole/prod-secret-reader
++  name: prod-read-secrets-global
+ roleRef:
+   apiGroup: rbac.authorization.k8s.io
+   kind: ClusterRole
+-  name: secret-reader
++  name: prod-secret-reader
+ subjects:
+ - apiGroup: rbac.authorization.k8s.io
+   kind: Group
+@@ -44,4 +44,4 @@ subjects:
+ apiVersion: rbac.authorization.k8s.io/v1
+ kind: ClusterRole
+ metadata:
+-  name: secret-reader
++  name: prod-secret-reader

--- a/examples/ensure-name-substring-depends-on/.krmignore
+++ b/examples/ensure-name-substring-depends-on/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/examples/ensure-name-substring-depends-on/Kptfile
+++ b/examples/ensure-name-substring-depends-on/Kptfile
@@ -1,0 +1,9 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: example
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/ensure-name-substring:unstable
+      configMap:
+        prepend: prod-

--- a/examples/ensure-name-substring-depends-on/README.md
+++ b/examples/ensure-name-substring-depends-on/README.md
@@ -1,0 +1,63 @@
+# ensure-name-substring: Depends on example
+
+### Overview
+
+This example demonstrates how the [`ensure-name-substring`] function interacts
+with resources that use the [`depends-on`] annotation. The [`depends-on`]
+annotation is a special annotation which is used to specify one or more resource
+dependencies. If the resource being referenced in a depends-on annotation is
+included in the input to the [`ensure-name-substring`] function, then the
+function will also apply the ensure-name-substring logic to the name portion of
+the annotation.
+
+### Fetch the example package
+
+Get the example package by running the following commands:
+
+```shell
+$ kpt pkg get https://github.com/GoogleContainerTools/kpt-functions-catalog.git/examples/ensure-name-substring-depends-on
+```
+
+We use the following `Kptfile` to configure the function.
+
+```yaml
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: example
+pipeline:
+  mutators:
+  - image: gcr.io/kpt-fn/ensure-name-substring:unstable
+    configMap:
+      prepend: prod-
+```
+
+The function configuration is provided using a `ConfigMap`. We set only one
+key-value pair:
+- `prepend: prod-`: The desired name substring.
+
+### Function invocation
+
+Invoke the function by running the following commands:
+
+```shell
+$ kpt fn render ensure-name-substring-depends-on
+```
+
+### Expected result
+
+Check that:
+- all resources have `metadata.name` prepended with `prod-`.
+- the `Deployment` with name `wordpress` had its `depends-on`
+annotation updated, since the corresponding `StatefulSet` is also included in
+the package.
+- the `Deployment` with name `bar` did not have its `depends-on`
+annotation updated, since it references a resource which was not included in the
+package.
+- the `ClusterRoleBinding` with name `read-secrets-global` had its `depends-on`
+annotation updated, since the corresponding `ClusterRole` is also included in
+the package.
+
+[ensure-name-substring]: https://catalog.kpt.dev/ensure-name-substring/v0.1/
+
+[`depends-on`]: https://kpt.dev/reference/annotations/depends-on/

--- a/examples/ensure-name-substring-depends-on/resources.yaml
+++ b/examples/ensure-name-substring-depends-on/resources.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  annotations:
+    config.kubernetes.io/depends-on: /namespaces/default/StatefulSet/wordpress-mysql
+  labels:
+    app: wordpress
+  name: wordpress
+  namespace: default
+---
+apiVersion: v1
+kind: StatefulSet
+metadata:
+  labels:
+    app: wordpress
+  name: wordpress-mysql
+  namespace: default
+---
+apiVersion: v1
+kind: Deployment
+metadata:
+  annotations:
+    config.kubernetes.io/depends-on: /namespaces/default/StatefulSet/outside-resource
+  labels:
+    app: bar
+  name: bar
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    config.kubernetes.io/depends-on: rbac.authorization.k8s.io/ClusterRole/secret-reader
+  name: read-secrets-global
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: secret-reader
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: admin
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: secret-reader

--- a/functions/go/ensure-name-substring/README.md
+++ b/functions/go/ensure-name-substring/README.md
@@ -49,6 +49,10 @@ field. e.g. if the name of a `ConfigMap` got updated and this `ConfigMap` is
 being referenced in `Volumes` in a `Pod`, field `spec.volumes.configMap.name`
 will also be updated.
 
+If there is a [`depends-on`] annotation for a resource, the name section of the
+annotation will be updated if the referenced resource is also declared in the
+package.
+
 This function can be used both declaratively and imperatively.
 
 ### FunctionConfig
@@ -122,3 +126,5 @@ additionalNameFields:
 [namereference]: https://github.com/kubernetes-sigs/kustomize/blob/master/api/konfig/builtinpluginconsts/namereference.go#L7
 
 [defaultnamefields]: https://github.com/kubernetes-sigs/kustomize/blob/master/api/konfig/builtinpluginconsts/nameprefix.go#L7
+
+[depends-on]: https://kpt.dev/reference/annotations/depends-on/

--- a/functions/go/ensure-name-substring/ensure_name_substring.go
+++ b/functions/go/ensure-name-substring/ensure_name_substring.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -17,10 +18,19 @@ import (
 )
 
 const (
-	fnConfigGroup      = "fn.kpt.dev"
-	fnConfigVersion    = "v1alpha1"
-	fnConfigAPIVersion = fnConfigGroup + "/" + fnConfigVersion
-	fnConfigKind       = "EnsureNameSubstring"
+	fnConfigGroup       = "fn.kpt.dev"
+	fnConfigVersion     = "v1alpha1"
+	fnConfigAPIVersion  = fnConfigGroup + "/" + fnConfigVersion
+	fnConfigKind        = "EnsureNameSubstring"
+	dependsOnAnnotation = "config.kubernetes.io/depends-on"
+)
+
+var (
+	// Assumes alphanumeric characters, '-', or '.'
+	// <group>/namespaces/<namespace>/<kind>/<name>
+	namespacedResourcePattern = regexp.MustCompile(`\A([-.\w]*)/namespaces/([-.\w]*)/([-.\w]*)/([-.\w]*)\z`)
+	// <group>/<kind>/<name>
+	clusterScopedResourcePattern = regexp.MustCompile(`\A([-.\w]*)/([-.\w]*)/([-.\w]*)\z`)
 )
 
 type EnsureNameSubstring struct {
@@ -34,6 +44,8 @@ type EnsureNameSubstring struct {
 	FieldSpecs []types.FieldSpec `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
 	// AdditionalNameFields is used to specify additional fields to modify name.
 	AdditionalNameFields []types.FieldSpec `json:"additionalNameFields,omitempty" yaml:"additionalNameFields,omitempty"`
+	// inputResourceLookup is used internally to track input resources
+	inputResourceLookup resourceLookup
 }
 
 type EditMode string
@@ -70,6 +82,7 @@ func (ens *EnsureNameSubstring) Validate() error {
 }
 
 func (ens *EnsureNameSubstring) Transform(m resmap.ResMap) error {
+	ens.inputResourceLookup.FromResMap(m)
 	for _, r := range m.Resources() {
 		if shouldSkip(r.OrgId()) {
 			continue
@@ -115,6 +128,9 @@ func (ens *EnsureNameSubstring) Transform(m resmap.ResMap) error {
 			if err != nil {
 				return err
 			}
+			if err = ens.updateDependsOnAnnotation(r); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -151,6 +167,65 @@ func (ens *EnsureNameSubstring) UnmarshalYAML(value *yaml.Node) error {
 			schema.FromAPIVersionAndKind("v1", "ConfigMap").String(),
 			schema.FromAPIVersionAndKind(fnConfigAPIVersion, fnConfigKind).String(),
 			schema.FromAPIVersionAndKind(meta.APIVersion, meta.Kind).String())
+	}
+	return nil
+}
+
+// set name substring if input matches one of the following:
+// - namespaced resource:     <group>/namespaces/<namespace>/<kind>/<name>
+// - cluster-scoped resource: <group>/<kind>/<name>
+// returns (string, bool) where the bool indicates if namespace was set
+func (ens *EnsureNameSubstring) setDependsOnNameSubstring(dependsOn string) (string, bool) {
+	var groupIdx, kindIdx, nameIdx int
+	if namespacedResourcePattern.MatchString(dependsOn) {
+		groupIdx = 0
+		kindIdx = 3
+		nameIdx = 4
+	} else if clusterScopedResourcePattern.MatchString(dependsOn) {
+		groupIdx = 0
+		kindIdx = 1
+		nameIdx = 2
+	} else {
+		return dependsOn, false
+	}
+	segments := strings.Split(dependsOn, "/")
+	rk := resourceKey{
+		Group: segments[groupIdx],
+		Kind:  segments[kindIdx],
+		Name:  segments[nameIdx],
+	}
+	if !ens.inputResourceLookup.HasResource(rk) {
+		return dependsOn, false
+	}
+	switch ens.EditMode {
+	case Prepend:
+		segments[nameIdx] = ens.Substring + segments[nameIdx]
+	case Append:
+		segments[nameIdx] = segments[nameIdx] + ens.Substring
+	default:
+		return dependsOn, false
+	}
+	dependsOn = strings.Join(segments, "/")
+	return dependsOn, true
+}
+
+// updateDependsOnAnnotation updates the name for the depends-on annotation.
+// The expected syntax is one of the following:
+// - namespaced resource:     <group>/namespaces/<namespace>/<kind>/<name>
+// - cluster-scoped resource: <group>/<kind>/<name>
+func (ens *EnsureNameSubstring) updateDependsOnAnnotation(r *resource.Resource) error {
+	annotations := r.GetAnnotations()
+	dependsOn, ok := annotations[dependsOnAnnotation]
+	if !ok {
+		return nil
+	}
+	dependsOn, ok = ens.setDependsOnNameSubstring(dependsOn)
+	if !ok {
+		return nil
+	}
+	annotations[dependsOnAnnotation] = dependsOn
+	if err := r.SetAnnotations(annotations); err != nil {
+		return err
 	}
 	return nil
 }
@@ -219,4 +294,34 @@ func resourceContainsSubstring(r *resource.Resource, substring string, fs types.
 		return false, fmt.Errorf("unable to check if the substring exsits in %v: %w", r.OrgId().String(), err)
 	}
 	return strings.Contains(valStr, substring), nil
+}
+
+// resourceKey provides a key for looking up resources in resourceLookup
+type resourceKey struct {
+	Group string
+	Kind  string
+	Name  string
+}
+
+// resourceLookup provides an API for tracking resources
+type resourceLookup struct {
+	resourceMap map[resourceKey]bool
+}
+
+// FromResMap reads through a ResMap to populate ResourceLookup
+func (rl *resourceLookup) FromResMap(m resmap.ResMap) {
+	rl.resourceMap = make(map[resourceKey]bool)
+	for _, r := range m.Resources() {
+		gvk := r.GetGvk()
+		rl.resourceMap[resourceKey{
+			Group: gvk.Group,
+			Kind:  gvk.Kind,
+			Name:  r.GetName(),
+		}] = true
+	}
+}
+
+// HasResource returns whether a Resource with the provided resourceKey is present
+func (rl *resourceLookup) HasResource(rk resourceKey) bool {
+	return rl.resourceMap[rk]
 }

--- a/functions/go/ensure-name-substring/ensure_name_substring_test.go
+++ b/functions/go/ensure-name-substring/ensure_name_substring_test.go
@@ -1,0 +1,357 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/kustomize/kyaml/fn/framework"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+func runEnsureNameSubstringTransformerE(config, input string) (string, error) {
+	resmapFactory := newResMapFactory()
+	resMap, err := resmapFactory.NewResMapFromBytes([]byte(input))
+	if err != nil {
+		return "", err
+	}
+	configRN, err := yaml.Parse(config)
+	if err != nil {
+		return "", err
+	}
+	ens := &EnsureNameSubstring{}
+	if err = framework.LoadFunctionConfig(configRN, ens); err != nil {
+		return "", err
+	}
+	if defaultConfig, err := getDefaultConfig(); err != nil {
+		return "", err
+	} else {
+		ens.AdditionalNameFields = append(ens.AdditionalNameFields, defaultConfig.FieldSpecs...)
+	}
+	if err = ens.Transform(resMap); err != nil {
+		return "", err
+	}
+	resMap.RemoveBuildAnnotations()
+	y, err := resMap.AsYaml()
+	if err != nil {
+		return "", err
+	}
+	return string(y), nil
+}
+
+func runEnsureNameSubstringTransformer(t *testing.T, config, input string) string {
+	s, err := runEnsureNameSubstringTransformerE(config, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func TestEnsureNameSubstringDependsOn(t *testing.T) {
+	testCases := []struct {
+		TestName string
+		Config   string
+		Input    string
+		Expected string
+	}{
+		{
+			TestName: "support prepend for the depends-on annotation",
+			Config: `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fn-config
+data:
+  prepend: dev-
+`,
+			Input: `apiVersion: v1
+kind: Deployment
+metadata:
+  annotations:
+    config.kubernetes.io/depends-on: /namespaces/default/StatefulSet/wordpress-mysql
+  labels:
+    app: wordpress
+  name: wordpress
+  namespace: default
+---
+apiVersion: v1
+kind: StatefulSet
+metadata:
+  labels:
+    app: wordpress
+  name: wordpress-mysql
+  namespace: default
+`,
+			Expected: `apiVersion: v1
+kind: Deployment
+metadata:
+  annotations:
+    config.kubernetes.io/depends-on: /namespaces/default/StatefulSet/dev-wordpress-mysql
+  labels:
+    app: wordpress
+  name: dev-wordpress
+  namespace: default
+---
+apiVersion: v1
+kind: StatefulSet
+metadata:
+  labels:
+    app: wordpress
+  name: dev-wordpress-mysql
+  namespace: default
+`,
+		},
+		{
+			TestName: "support append for the depends-on annotation",
+			Config: `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fn-config
+data:
+  append: -dev
+`,
+			Input: `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    config.kubernetes.io/depends-on: rbac.authorization.k8s.io/ClusterRole/secret-reader
+  name: read-secrets-global
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: secret-reader
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: admin
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: secret-reader
+`,
+			Expected: `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    config.kubernetes.io/depends-on: rbac.authorization.k8s.io/ClusterRole/secret-reader-dev
+  name: read-secrets-global-dev
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: secret-reader
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: admin
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: secret-reader-dev
+`,
+		},
+		{
+			TestName: "not update the depends-on annotation if the referenced resource is not included",
+			Config: `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fn-config
+data:
+  append: -dev
+`,
+			Input: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    config.kubernetes.io/depends-on: apps/namespaces/default/StatefulSet/wordpress-mysql
+  labels:
+    app: wordpress
+  name: wordpress
+  namespace: default
+`,
+			Expected: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    config.kubernetes.io/depends-on: apps/namespaces/default/StatefulSet/wordpress-mysql
+  labels:
+    app: wordpress
+  name: wordpress-dev
+  namespace: default
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("ensure-name-substring should %s", tc.TestName), func(t *testing.T) {
+			actual := runEnsureNameSubstringTransformer(t, tc.Config, tc.Input)
+			assert.Equal(t, tc.Expected, actual)
+		})
+	}
+}
+
+func TestSetDependsOnNameSubstring(t *testing.T) {
+	testCases := []struct {
+		TestName            string
+		EditMode            EditMode
+		InputResourceLookup resourceLookup
+		Input               string
+		Expected            string
+		IsSet               bool
+	}{
+		{
+			TestName: "prepend the name substring for a namespaced resource",
+			EditMode: Prepend,
+			Input:    "group/namespaces/ns/kind/name",
+			InputResourceLookup: resourceLookup{
+				resourceMap: map[resourceKey]bool{
+					{
+						Group: "group",
+						Kind:  "kind",
+						Name:  "name",
+					}: true,
+				},
+			},
+			Expected: "group/namespaces/ns/kind/substrname",
+			IsSet:    true,
+		},
+		{
+			TestName: "append the name substring for a namespaced resource",
+			EditMode: Append,
+			Input:    "group/namespaces/ns/kind/name",
+			InputResourceLookup: resourceLookup{
+				resourceMap: map[resourceKey]bool{
+					{
+						Group: "group",
+						Kind:  "kind",
+						Name:  "name",
+					}: true,
+				},
+			},
+			Expected: "group/namespaces/ns/kind/namesubstr",
+			IsSet:    true,
+		},
+		{
+			TestName: "append the name substring for a core namespaced resource",
+			EditMode: Append,
+			Input:    "/namespaces/ns/kind/name",
+			InputResourceLookup: resourceLookup{
+				resourceMap: map[resourceKey]bool{
+					{
+						Group: "",
+						Kind:  "kind",
+						Name:  "name",
+					}: true,
+				},
+			},
+			Expected: "/namespaces/ns/kind/namesubstr",
+			IsSet:    true,
+		},
+		{
+			TestName: "prepend the name substring for a cluster scoped resource",
+			EditMode: Prepend,
+			Input:    "group/kind/name",
+			InputResourceLookup: resourceLookup{
+				resourceMap: map[resourceKey]bool{
+					{
+						Group: "group",
+						Kind:  "kind",
+						Name:  "name",
+					}: true,
+				},
+			},
+			Expected: "group/kind/substrname",
+			IsSet:    true,
+		},
+		{
+			TestName: "append the name substring for a cluster scoped resource",
+			EditMode: Append,
+			Input:    "group/kind/name",
+			InputResourceLookup: resourceLookup{
+				resourceMap: map[resourceKey]bool{
+					{
+						Group: "group",
+						Kind:  "kind",
+						Name:  "name",
+					}: true,
+				},
+			},
+			Expected: "group/kind/namesubstr",
+			IsSet:    true,
+		},
+		{
+			TestName: "append the name substring for a core cluster scoped resource",
+			EditMode: Append,
+			Input:    "/kind/name",
+			InputResourceLookup: resourceLookup{
+				resourceMap: map[resourceKey]bool{
+					{
+						Group: "",
+						Kind:  "kind",
+						Name:  "name",
+					}: true,
+				},
+			},
+			Expected: "/kind/namesubstr",
+			IsSet:    true,
+		},
+		{
+			TestName: "not change name for namespaced resource with unexpected prefix",
+			EditMode: Append,
+			Input:    "some-prefix/group/namespaces/ns/kind/name",
+			Expected: "some-prefix/group/namespaces/ns/kind/name",
+			IsSet:    false,
+		},
+		{
+			TestName: "not change name for namespaced resource with unexpected suffix",
+			EditMode: Append,
+			Input:    "group/namespaces/ns/kind/name/some-suffix",
+			Expected: "group/namespaces/ns/kind/name/some-suffix",
+			IsSet:    false,
+		},
+		{
+			TestName: "not change name for malformed namespaced resource",
+			EditMode: Append,
+			Input:    "group/oops/ns/kind/name/some-suffix",
+			Expected: "group/oops/ns/kind/name/some-suffix",
+			IsSet:    false,
+		},
+		{
+			TestName: "not change name for cluster scoped resource with unexpected prefix",
+			EditMode: Append,
+			Input:    "some-prefix/group/kind/name",
+			Expected: "some-prefix/group/kind/name",
+			IsSet:    false,
+		},
+		{
+			TestName: "not change name for cluster scoped resource with unexpected suffix",
+			EditMode: Append,
+			Input:    "group/kind/name/some-suffix",
+			Expected: "group/kind/name/some-suffix",
+			IsSet:    false,
+		},
+		{
+			TestName: "not change name if EditMode is unset",
+			Input:    "group/kind/name",
+			Expected: "group/kind/name",
+			IsSet:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("setDependsOnNameSubstring should %s", tc.TestName), func(t *testing.T) {
+			ens := EnsureNameSubstring{
+				Substring:           "substr",
+				EditMode:            tc.EditMode,
+				inputResourceLookup: tc.InputResourceLookup,
+			}
+			actual, set := ens.setDependsOnNameSubstring(tc.Input)
+			assert.Equal(t, tc.IsSet, set)
+			assert.Equal(t, tc.Expected, actual)
+		})
+	}
+}

--- a/functions/go/ensure-name-substring/go.mod
+++ b/functions/go/ensure-name-substring/go.mod
@@ -3,6 +3,7 @@ module github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/ensure
 go 1.17
 
 require (
+	github.com/stretchr/testify v1.7.0
 	k8s.io/api v0.21.0
 	k8s.io/apimachinery v0.21.0
 	sigs.k8s.io/kustomize/api v0.8.11-0.20210614195535-7e8ba62e9fd9
@@ -32,7 +33,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/cobra v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.6.1 // indirect
 	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
 	golang.org/x/net v0.0.0-20210224082022-3d97a244fca7 // indirect
 	golang.org/x/text v0.3.4 // indirect

--- a/functions/go/ensure-name-substring/go.sum
+++ b/functions/go/ensure-name-substring/go.sum
@@ -196,8 +196,9 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/functions/go/ensure-name-substring/main.go
+++ b/functions/go/ensure-name-substring/main.go
@@ -54,9 +54,7 @@ func (ensp *EnsureNameSubstringProcessor) Process(resourceList *framework.Resour
 
 	ens.AdditionalNameFields = append(ensp.tc.FieldSpecs, ens.AdditionalNameFields...)
 
-	resourceFactory := resource.NewFactory(&hasher.Hasher{})
-	resourceFactory.IncludeLocalConfigs = true
-	resmapFactory := resmap.NewFactory(resourceFactory)
+	resmapFactory := newResMapFactory()
 
 	resMap, err := resmapFactory.NewResMapFromRNodeSlice(resourceList.Items)
 	if err != nil {
@@ -79,6 +77,12 @@ func (ensp *EnsureNameSubstringProcessor) Process(resourceList *framework.Resour
 		return fmt.Errorf("failed to convert resource map to items: %w", err)
 	}
 	return nil
+}
+
+func newResMapFactory() *resmap.Factory {
+	resourceFactory := resource.NewFactory(&hasher.Hasher{})
+	resourceFactory.IncludeLocalConfigs = true
+	return resmap.NewFactory(resourceFactory)
 }
 
 type transformerConfig struct {

--- a/functions/go/ensure-name-substring/metadata.yaml
+++ b/functions/go/ensure-name-substring/metadata.yaml
@@ -10,6 +10,7 @@ examplePackageURLs:
   - https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/examples/ensure-name-substring-suffix
   - https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/examples/ensure-name-substring-advanced
   - https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/examples/ensure-name-substring-imperative
+  - https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/examples/ensure-name-substring-depends-on
 emails:
   - kpt-team@google.com
 license: Apache-2.0


### PR DESCRIPTION
The depends-on annotation can reference the name of other resources,
and this change makes sure that the name portion of such annotations
is properly handled by the ensure-name-substring function.

Issues: GoogleContainerTools/kpt#2579