### PR TITLE
feat(docs-fn): support explicit pkg name, handle empty pkg

### DIFF
--- a/contrib/functions/go/generate-kpt-pkg-docs/README.md
+++ b/contrib/functions/go/generate-kpt-pkg-docs/README.md
@@ -27,7 +27,9 @@ This function supports `ConfigMap` `functionConfig`.
 
 - A `readme-path` can be provided to write to a specific file. If a `readme-path` is not provided, it defaults to `/tmp/README.md`. If the file specified via `readme-path` does not exist, readme generation is skipped with a warning.
 
-- A `repo-path` can be provided to include in usage section. This will generate a usage section with sample commands like `kpt pkg get ${repo-path}/{pkgname}@version`. If a `repo-path` is not provided, it defaults to `https://github.com/GoogleCloudPlatform/blueprints.git/catalog`.
+- A `repo-path` can be provided to include in usage section. This will generate a usage section with sample commands like `kpt pkg get ${repo-path}/{pkg-name}@version`. If a `repo-path` is not provided, it defaults to `https://github.com/GoogleCloudPlatform/blueprints.git/catalog`.
+
+- A `pkg-name` can be provided to include in usage section. This will generate a usage section with sample commands like `kpt pkg get ${repo-path}/{pkg-name}@version`. If a `pkg-name` is not provided, it defaults to the name specified in the Kptfile.
 
 The `generate-kpt-pkg-docs` function does the following:
 

--- a/contrib/functions/go/generate-kpt-pkg-docs/docs/readme.go
+++ b/contrib/functions/go/generate-kpt-pkg-docs/docs/readme.go
@@ -2,6 +2,7 @@ package docs
 
 import (
 	"fmt"
+	"path"
 	"strings"
 
 	kptfilev1 "github.com/GoogleContainerTools/kpt-functions-sdk/go/pkg/api/kptfile/v1"
@@ -45,10 +46,15 @@ func newBlueprintReadme(n []*yaml.RNode, repoPath, pkgName string) (blueprintRea
 	if !hasRootKf {
 		return blueprintReadme{}, fmt.Errorf("unable to find root Kptfile, please include --include-meta-resources flag if a Kptfile is present")
 	}
-	// specific files we want to omit from readme including Kptfile and any fn configs
+	// specific files we want to omit from readme including Kptfile, subpkgs and any fn configs
 	skipFiles := map[string]bool{kptfilev1.KptFileName: true}
 	for _, fnCfg := range getFnCfgPaths(rootKf) {
 		skipFiles[fnCfg] = true
+	}
+	for pkgPath := range pkgs {
+		if pkgPath != kptfilev1.KptFileName {
+			skipFiles[path.Dir(pkgPath)] = true
+		}
 	}
 	// if no explicit pkg name, use kf pkgname
 	if pkgName == "" {

--- a/contrib/functions/go/generate-kpt-pkg-docs/docs/readme.go
+++ b/contrib/functions/go/generate-kpt-pkg-docs/docs/readme.go
@@ -11,6 +11,7 @@ import (
 // blueprint represents a kpt pkg with a root kptfile, resources and any additional subpackages.
 type blueprint struct {
 	rootKf   *kptfilev1.KptFile
+	pkgName  string
 	kfs      map[string]*kptfilev1.KptFile
 	nodes    []*yaml.RNode
 	repoPath string
@@ -28,7 +29,7 @@ type blueprintReadme struct {
 type generateSection func(*blueprintReadme) error
 
 // newBlueprintReadme initializes a blueprint readme
-func newBlueprintReadme(n []*yaml.RNode, repoPath string) (blueprintReadme, error) {
+func newBlueprintReadme(n []*yaml.RNode, repoPath, pkgName string) (blueprintReadme, error) {
 	// deep copy resources to prevent any changes to resources
 	nodes := []*yaml.RNode{}
 	for _, r := range n {
@@ -49,7 +50,11 @@ func newBlueprintReadme(n []*yaml.RNode, repoPath string) (blueprintReadme, erro
 	for _, fnCfg := range getFnCfgPaths(rootKf) {
 		skipFiles[fnCfg] = true
 	}
-	b := blueprint{rootKf: rootKf, kfs: pkgs, nodes: nodes, repoPath: repoPath}
+	// if no explicit pkg name, use kf pkgname
+	if pkgName == "" {
+		pkgName = rootKf.Name
+	}
+	b := blueprint{rootKf: rootKf, kfs: pkgs, nodes: nodes, repoPath: repoPath, pkgName: pkgName}
 	return blueprintReadme{content: &strings.Builder{}, bp: b, filteredNodes: filterResources(nodes, skipFiles)}, nil
 }
 

--- a/contrib/functions/go/generate-kpt-pkg-docs/docs/resources.go
+++ b/contrib/functions/go/generate-kpt-pkg-docs/docs/resources.go
@@ -2,6 +2,7 @@ package docs
 
 import (
 	"fmt"
+	"path"
 	"strings"
 
 	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
@@ -71,15 +72,9 @@ func filterResources(nodes []*yaml.RNode, skipFiles map[string]bool) []*yaml.RNo
 
 // shouldSkipResource returns true if resource path is present in skipFiles
 func shouldSkipResource(r *yaml.RNode, skipFiles map[string]bool) bool {
-	path, err := findResourcePath(r)
+	rPath, err := findResourcePath(r)
 	if err != nil {
 		return true
 	}
-	// only include resources that are part of the root pkg
-	pathParts := strings.Split(path, "/")
-	if len(pathParts) > 1 {
-		return true
-	}
-	_, shouldSkip := skipFiles[path]
-	return shouldSkip
+	return skipFiles[rPath] || skipFiles[path.Dir(rPath)]
 }

--- a/contrib/functions/go/generate-kpt-pkg-docs/docs/resources_test.go
+++ b/contrib/functions/go/generate-kpt-pkg-docs/docs/resources_test.go
@@ -71,7 +71,20 @@ metadata:
   annotations:
     cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
     internal.config.kubernetes.io/path: foo/bar.yaml`,
-			want: true,
+			want:      true,
+			skipFiles: map[string]bool{"foo": true},
+		},
+		{
+			name: "should skip file",
+			r: `apiVersion: v1
+kind: Namespace
+metadata:
+  name: project-id # kpt-set: ${project-id}
+  annotations:
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+    internal.config.kubernetes.io/path: foo/bar.yaml`,
+			want:      true,
+			skipFiles: map[string]bool{"foo/bar.yaml": true},
 		},
 		{
 			name: "should skip setter cfg",

--- a/contrib/functions/go/generate-kpt-pkg-docs/generated/docs.go
+++ b/contrib/functions/go/generate-kpt-pkg-docs/generated/docs.go
@@ -20,7 +20,9 @@ This function supports ` + "`" + `ConfigMap` + "`" + ` ` + "`" + `functionConfig
 
 - A ` + "`" + `readme-path` + "`" + ` can be provided to write to a specific file. If a ` + "`" + `readme-path` + "`" + ` is not provided, it defaults to ` + "`" + `/tmp/README.md` + "`" + `. If the file specified via ` + "`" + `readme-path` + "`" + ` does not exist, readme generation is skipped with a warning.
 
-- A ` + "`" + `repo-path` + "`" + ` can be provided to include in usage section. This will generate a usage section with sample commands like ` + "`" + `kpt pkg get ${repo-path}/{pkgname}@version` + "`" + `. If a ` + "`" + `repo-path` + "`" + ` is not provided, it defaults to ` + "`" + `https://github.com/GoogleCloudPlatform/blueprints.git/catalog` + "`" + `.
+- A ` + "`" + `repo-path` + "`" + ` can be provided to include in usage section. This will generate a usage section with sample commands like ` + "`" + `kpt pkg get ${repo-path}/{pkg-name}@version` + "`" + `. If a ` + "`" + `repo-path` + "`" + ` is not provided, it defaults to ` + "`" + `https://github.com/GoogleCloudPlatform/blueprints.git/catalog` + "`" + `.
+
+- A ` + "`" + `pkg-name` + "`" + ` can be provided to include in usage section. This will generate a usage section with sample commands like ` + "`" + `kpt pkg get ${repo-path}/{pkg-name}@version` + "`" + `. If a ` + "`" + `pkg-name` + "`" + ` is not provided, it defaults to the name specified in the Kptfile.
 
 The ` + "`" + `generate-kpt-pkg-docs` + "`" + ` function does the following:
 

--- a/contrib/functions/go/generate-kpt-pkg-docs/main.go
+++ b/contrib/functions/go/generate-kpt-pkg-docs/main.go
@@ -32,7 +32,7 @@ func main() {
 type ReadmeProcessor struct{}
 
 func (rp *ReadmeProcessor) Process(resourceList *framework.ResourceList) error {
-	readmePath, repoPath := parseFnCfg(resourceList.FunctionConfig)
+	readmePath, repoPath, pkgName := parseFnCfg(resourceList.FunctionConfig)
 
 	currentDoc, err := ioutil.ReadFile(readmePath)
 	if err != nil {
@@ -43,7 +43,7 @@ func (rp *ReadmeProcessor) Process(resourceList *framework.ResourceList) error {
 			resourceList.Results = getResults(err.Error(), framework.Error)
 		}
 	}
-	err = generateReadme(repoPath, readmePath, string(currentDoc), resourceList)
+	err = generateReadme(repoPath, readmePath, pkgName, string(currentDoc), resourceList)
 	if err != nil {
 		resourceList.Results = getResults(err.Error(), framework.Error)
 		return err
@@ -51,8 +51,8 @@ func (rp *ReadmeProcessor) Process(resourceList *framework.ResourceList) error {
 	return nil
 }
 
-func generateReadme(repoPath, readmePath, currentDoc string, resourceList *framework.ResourceList) error {
-	title, generatedDoc, err := docs.GenerateBlueprintReadme(resourceList.Items, repoPath)
+func generateReadme(repoPath, readmePath, pkgName, currentDoc string, resourceList *framework.ResourceList) error {
+	title, generatedDoc, err := docs.GenerateBlueprintReadme(resourceList.Items, repoPath, pkgName)
 	if err != nil {
 		return err
 	}
@@ -67,7 +67,7 @@ func generateReadme(repoPath, readmePath, currentDoc string, resourceList *frame
 	return nil
 }
 
-func parseFnCfg(r *yaml.RNode) (string, string) {
+func parseFnCfg(r *yaml.RNode) (string, string, string) {
 	cm := r.GetDataMap()
 	readme, exists := cm["readme-path"]
 	if !exists {
@@ -77,7 +77,8 @@ func parseFnCfg(r *yaml.RNode) (string, string) {
 	if !exists {
 		repoPath = defaultRepoPath
 	}
-	return readme, repoPath
+	pkgName := cm["pkg-name"]
+	return readme, repoPath, pkgName
 
 }
 


### PR DESCRIPTION
This adds support for specifying an optional pkg name while generating documentation to support blueprint repo dir naming convention https://github.com/GoogleContainerTools/kpt/issues/2592. Also handles cases where a pkg may be empty.