### PR TITLE
docs: Dynamically render latest image tag in docs

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -220,6 +220,19 @@
                   examplesDropdown +
                   "</div>";
 
+                const latestImage =
+                    `<div>` +
+                    `<p>Image URL: ` +
+                    `<code class="lang-shell language-shell">` +
+                    `gcr.io/kpt-fn${isContribFn ? "-contrib" : ""}/${functionName}:${patchSemver}` +
+                    `</code>` +
+                    `</p>` +
+                    `</div>`
+
+                const imageElement = document.createElement("div");
+                document.getElementById(functionName).insertAdjacentElement('afterend', imageElement)
+                imageElement.outerHTML = latestImage
+
                 const dropdownContainer = document.createElement("div");
                 const content = document.getElementsByClassName("markdown-section").item(0);
                 content.prepend(dropdownContainer);


### PR DESCRIPTION
This change displays the latest image tag for the function in the
function doc page. This is intended as a convenience for users
to discover the full tag of the latest function image.

Issues: GoogleContainerTools/kpt#2320