### PR TITLE
Don't add path and index annotation in golden test util

### DIFF
--- a/thirdparty/kyaml/fnsdk/testutil/golden.go
+++ b/thirdparty/kyaml/fnsdk/testutil/golden.go
@@ -24,6 +24,8 @@ func ResourceListFromDirectory(dir string, fnConfigFile string) (*fnsdk.Resource
 	reader := &kio.LocalPackageReader{
 		PackagePath:        dir,
 		IncludeSubpackages: true,
+		// TODO(mengqiy): We should figure out how to let the user control this behavior.
+		OmitReaderAnnotations: true,
 	}
 	items, err := reader.Read()
 	if err != nil {


### PR DESCRIPTION
Ref: https://github.com/GoogleContainerTools/kpt-functions-catalog/pull/665#pullrequestreview-846955659

The test util need to better handling when to add these annotations or not. Alternatively, we can let the users control if add these annotations or not.
We will do that in the near future.