### PR TITLE
Set labels changed files output

### DIFF
--- a/functions/go/set-labels/go.mod
+++ b/functions/go/set-labels/go.mod
@@ -3,6 +3,7 @@ module github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/set-la
 go 1.16
 
 require (
+	github.com/stretchr/testify v1.7.0
 	sigs.k8s.io/kustomize/api v0.10.2-0.20220110181313-a1a0a4982226
 	sigs.k8s.io/kustomize/kyaml v0.13.2-0.20220110181313-a1a0a4982226
 	sigs.k8s.io/yaml v1.2.0

--- a/tests/set-labels/additional-labels/.expected/diff.patch
+++ b/tests/set-labels/additional-labels/.expected/diff.patch
@@ -1,0 +1,48 @@
+diff --git a/local-config.yaml b/local-config.yaml
+index b8d83d1..936d631 100644
+--- a/local-config.yaml
++++ b/local-config.yaml
+@@ -4,5 +4,12 @@ metadata:
+   name: local-config-map
+   annotations:
+     config.kubernetes.io/local-config: "true"
++  labels:
++    color: orange
++    fruit: apple
+ data:
+   some-key: some-value
++  selector:
++    annotations:
++      color: orange
++      fruit: apple
+diff --git a/resources.yaml b/resources.yaml
+index 799a41c..7d8063d 100644
+--- a/resources.yaml
++++ b/resources.yaml
+@@ -2,12 +2,26 @@ apiVersion: v1
+ kind: ConfigMap
+ metadata:
+   name: the-map
++  labels:
++    color: orange
++    fruit: apple
+ data:
+   some-key: some-value
++  selector:
++    annotations:
++      color: orange
++      fruit: apple
+ ---
+ apiVersion: v1
+ kind: ConfigMap
+ metadata:
+   name: the-second-map
++  labels:
++    color: orange
++    fruit: apple
+ data:
+   some-key: some-other-value
++  selector:
++    annotations:
++      color: orange
++      fruit: apple

--- a/tests/set-labels/additional-labels/.expected/results.yaml
+++ b/tests/set-labels/additional-labels/.expected/results.yaml
@@ -1,0 +1,41 @@
+apiVersion: kpt.dev/v1
+kind: FunctionResultList
+metadata:
+  name: fnresults
+exitCode: 0
+items:
+  - image: gcr.io/kpt-fn/set-labels:unstable
+    exitCode: 0
+    results:
+      - message: 'set labels: {"color":"orange","fruit":"apple"}'
+        field:
+          path: data.selector.annotations
+        file:
+          path: local-config.yaml
+      - message: 'set labels: {"color":"orange","fruit":"apple"}'
+        field:
+          path: metadata.labels
+        file:
+          path: local-config.yaml
+      - message: 'set labels: {"color":"orange","fruit":"apple"}'
+        field:
+          path: data.selector.annotations
+        file:
+          path: resources.yaml
+      - message: 'set labels: {"color":"orange","fruit":"apple"}'
+        field:
+          path: metadata.labels
+        file:
+          path: resources.yaml
+      - message: 'set labels: {"color":"orange","fruit":"apple"}'
+        field:
+          path: data.selector.annotations
+        file:
+          path: resources.yaml
+          index: 1
+      - message: 'set labels: {"color":"orange","fruit":"apple"}'
+        field:
+          path: metadata.labels
+        file:
+          path: resources.yaml
+          index: 1

--- a/tests/set-labels/additional-labels/.krmignore
+++ b/tests/set-labels/additional-labels/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/tests/set-labels/additional-labels/Kptfile
+++ b/tests/set-labels/additional-labels/Kptfile
@@ -1,0 +1,8 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: example
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/set-labels:unstable
+      configPath: fn-config.yaml

--- a/tests/set-labels/additional-labels/fn-config.yaml
+++ b/tests/set-labels/additional-labels/fn-config.yaml
@@ -1,0 +1,13 @@
+apiVersion: fn.kpt.dev/v1alpha1
+kind: SetLabelConfig
+metadata:
+  name: my-config
+  annotations:
+    config.kubernetes.io/local-config: "true"
+labels:
+  color: orange
+  fruit: apple
+additionalLabelFields:
+- path: data/selector/annotations
+  kind: ConfigMap
+  create: true

--- a/tests/set-labels/additional-labels/local-config.yaml
+++ b/tests/set-labels/additional-labels/local-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-config-map
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  some-key: some-value

--- a/tests/set-labels/additional-labels/resources.yaml
+++ b/tests/set-labels/additional-labels/resources.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: the-map
+data:
+  some-key: some-value
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: the-second-map
+data:
+  some-key: some-other-value

--- a/tests/set-labels/legacy-config/.expected/results.yaml
+++ b/tests/set-labels/legacy-config/.expected/results.yaml
@@ -1,0 +1,26 @@
+apiVersion: kpt.dev/v1
+kind: FunctionResultList
+metadata:
+  name: fnresults
+exitCode: 0
+items:
+  - image: gcr.io/kpt-fn/set-labels:unstable
+    exitCode: 0
+    results:
+      - message: 'set labels: {"color":"orange","fruit":"apple"}'
+        field:
+          path: metadata.labels
+        file:
+          path: resources.yaml
+      - message: 'set labels: {"color":"orange","fruit":"apple"}'
+        field:
+          path: metadata.labels
+        file:
+          path: resources.yaml
+          index: 1
+      - message: 'set labels: {"color":"orange","fruit":"apple"}'
+        field:
+          path: spec.selector.labels
+        file:
+          path: resources.yaml
+          index: 1

--- a/tests/set-labels/local-config/.expected/results.yaml
+++ b/tests/set-labels/local-config/.expected/results.yaml
@@ -1,0 +1,19 @@
+apiVersion: kpt.dev/v1
+kind: FunctionResultList
+metadata:
+  name: fnresults
+exitCode: 0
+items:
+  - image: gcr.io/kpt-fn/set-labels:unstable
+    exitCode: 0
+    results:
+      - message: 'set labels: {"color":"orange","fruit":"apple"}'
+        field:
+          path: metadata.labels
+        file:
+          path: local-config.yaml
+      - message: 'set labels: {"color":"orange","fruit":"apple"}'
+        field:
+          path: metadata.labels
+        file:
+          path: resources.yaml


### PR DESCRIPTION
This adds functionality to include the filepath, fieldpath, and
value for each set-label in the output. This behavior is
modeled after the behavior of set-annotations.

An example output:
```
$ kpt fn render set-labels-advanced
Package "set-labels-advanced": 
[RUNNING] "gcr.io/kpt-fn/set-labels:unstable"
[PASS] "gcr.io/kpt-fn/set-labels:unstable" in 3.2s
  Results:
    [info] metadata.labels: set labels: {"color":"orange","fruit":"apple"}
    [info] metadata.labels: set labels: {"color":"orange","fruit":"apple"}
    [info] spec.selector.labels: set labels: {"color":"orange","fruit":"apple"}

Successfully executed 1 function(s) in 1 package(s).
```

This change is based on a change to bump the version of kustomize consumed by set-labels. That change has been proposed as a separate pull request here: https://github.com/GoogleContainerTools/kpt-functions-catalog/pull/728

Issues: GoogleContainerTools/kpt#2448