### PR TITLE
Revert "Don't add path and index annotation in golden test util"

### DIFF
--- a/thirdparty/kyaml/fnsdk/testutil/golden.go
+++ b/thirdparty/kyaml/fnsdk/testutil/golden.go
@@ -24,8 +24,6 @@ func ResourceListFromDirectory(dir string, fnConfigFile string) (*fnsdk.Resource
 	reader := &kio.LocalPackageReader{
 		PackagePath:        dir,
 		IncludeSubpackages: true,
-		// TODO(mengqiy): We should figure out how to let the user control this behavior.
-		OmitReaderAnnotations: true,
 	}
 	items, err := reader.Read()
 	if err != nil {


### PR DESCRIPTION
Reverts GoogleContainerTools/kpt-functions-catalog#725