### PR TITLE
docs: include v in version dropdown for site

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -135,22 +135,20 @@
                   versionName = pathElements[2];
                 }
 
-                const patchSemver = versions[versionName]['LatestPatchVersion']
-                const currentVersion = patchSemver.replaceAll("v", "");
+                const patchSemver = versions[versionName]['LatestPatchVersion'];
                 const sortedSemvers = Object.keys(versions)
                   .sort((a, b) => compareVersions(a, b))
                   .reverse();
                 versionDropdown += `
               <div class="dropdown">
-                <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown">Version: ${currentVersion}
+                <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown">Version: ${patchSemver}
                 <span class="caret"></span></button>
                 <ol class="dropdown-menu">`;
                 sortedSemvers.forEach(
                   (ver, ix) =>
-                    (versionDropdown += `<li><a href="${isContribFn ? "/contrib" : ""}/${functionName}/${ver}/">${versions[ver]['LatestPatchVersion'].replace(
-                      "v",
-                      ""
-                    )}${ix ? "" : " (latest)"}</a></li>`)
+                    (versionDropdown += `<li><a href="${isContribFn ? "/contrib" : ""}/${functionName}/${ver}/">` +
+                        `${versions[ver]['LatestPatchVersion']}${ix ? "" : " (latest)"}` +
+                        `</a></li>`)
                 );
                 versionDropdown += `
                 </ol>


### PR DESCRIPTION
This updates the version dropdown to display the full version string,
e.g. v0.1.1 rather than 0.1.1

This is intended to make the versions displayed in the dropdown
consistent with the version used in tags.

Issues: https://github.com/GoogleContainerTools/kpt/issues/2320