### PR TITLE
docs: Dynamically render latest image tag in docs

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -220,6 +220,23 @@
                   examplesDropdown +
                   "</div>";
 
+                const latestImage =
+                    `<div>` +
+                    `<p>Image URL: ` +
+                    `<code class="lang-shell language-shell">` +
+                    `gcr.io/kpt-fn${isContribFn ? "-contrib" : ""}/${functionName}:${patchSemver}` +
+                    `</code>` +
+                    `</p>` +
+                    `</div>`
+
+                const functionTitle = document.getElementById(functionName);
+                // Render image URL section on function doc page (not examples)
+                if (functionTitle) {
+                  const imageElement = document.createElement("div");
+                  functionTitle.insertAdjacentElement('afterend', imageElement);
+                  imageElement.outerHTML = latestImage
+                }
+
                 const dropdownContainer = document.createElement("div");
                 const content = document.getElementsByClassName("markdown-section").item(0);
                 content.prepend(dropdownContainer);


### PR DESCRIPTION
This change displays the latest image tag for the function in the
function doc page. This is intended as a convenience for users
to discover the full tag of the latest function image.