### PR TITLE
upgrade golang 1.17

### DIFF
--- a/.github/workflows/verify-docs.yaml
+++ b/.github/workflows/verify-docs.yaml
@@ -19,10 +19,10 @@ jobs:
     - name: Install libs
       run: |
         pip install pyyaml
-    - name: Set up Go 1.16
+    - name: Set up Go 1.17
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16
+        go-version: 1.17
     - name: Install mdrip
       run: |
         go get github.com/russross/blackfriday/v2@v2.0.1

--- a/contrib/functions/go/annotate-apply-time-mutations/Dockerfile
+++ b/contrib/functions/go/annotate-apply-time-mutations/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.13
+FROM golang:1.17-alpine3.13
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 

--- a/contrib/functions/go/annotate-apply-time-mutations/go.mod
+++ b/contrib/functions/go/annotate-apply-time-mutations/go.mod
@@ -1,17 +1,31 @@
 module github.com/GoogleContainerTools/kpt-functions-catalog/contrib/functions/go/annotate-apply-time-mutations
 
-go 1.16
+go 1.17
+
+require sigs.k8s.io/kustomize/kyaml v0.11.1
 
 require (
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-errors/errors v1.4.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.6 // indirect
 	github.com/go-openapi/swag v0.19.15 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/cobra v1.2.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/xlab/treeprint v1.1.0 // indirect
 	golang.org/x/net v0.0.0-20210902165921-8d991716f632 // indirect
 	golang.org/x/text v0.3.7 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/kube-openapi v0.0.0-20210817084001-7fbd8d59e5b8 // indirect
-	sigs.k8s.io/kustomize/kyaml v0.11.1
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/contrib/functions/go/generate-kpt-pkg-docs/Dockerfile
+++ b/contrib/functions/go/generate-kpt-pkg-docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.13
+FROM golang:1.17-alpine3.13
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 

--- a/contrib/functions/go/generate-kpt-pkg-docs/go.mod
+++ b/contrib/functions/go/generate-kpt-pkg-docs/go.mod
@@ -1,12 +1,37 @@
 module github.com/GoogleContainerTools/kpt-functions-catalog/contrib/functions/go/blueprint-docs
 
-go 1.16
+go 1.17
 
 require (
 	github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/list-setters v0.1.0
 	github.com/GoogleContainerTools/kpt-functions-sdk/go v0.0.0-20211015223526-2e6d9522928b
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/sergi/go-diff v1.2.0 // indirect
-	github.com/stretchr/testify v1.7.0 // indirect
+	github.com/stretchr/testify v1.7.0
 	sigs.k8s.io/kustomize/kyaml v0.13.0
+)
+
+require (
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/sergi/go-diff v1.2.0 // indirect
+	github.com/spf13/cobra v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
+	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
+	golang.org/x/text v0.3.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/contrib/functions/go/generate-kpt-pkg-docs/go.sum
+++ b/contrib/functions/go/generate-kpt-pkg-docs/go.sum
@@ -167,6 +167,7 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -214,9 +215,11 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -329,6 +332,7 @@ github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/y
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -488,6 +492,7 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
@@ -552,8 +557,6 @@ modernc.org/strutil v1.0.0/go.mod h1:lstksw84oURvj9y3tn8lGvRxyRC1S2+g5uuIzNfIOBs
 modernc.org/xc v1.0.0/go.mod h1:mRNCo0bvLjGhHO9WsyuKVU4q0ceiDDDoEeWDJHrNx8I=
 sigs.k8s.io/controller-runtime v0.4.0/go.mod h1:ApC79lpY3PHW9xj/w9pj+lYkLgwAAUZwfXkME1Lajns=
 sigs.k8s.io/kustomize/kyaml v0.11.0/go.mod h1:GNMwjim4Ypgp/MueD3zXHLRJEjz7RvtPae0AwlvEMFM=
-sigs.k8s.io/kustomize/kyaml v0.12.0 h1:k08l8SLwnKa/eXXB5GW2/OnEc/4gJF90VDFebsOwqw4=
-sigs.k8s.io/kustomize/kyaml v0.12.0/go.mod h1:FTJxEZ86ScK184NpGSAQcfEqee0nul8oLCK30D47m4E=
 sigs.k8s.io/kustomize/kyaml v0.13.0 h1:9c+ETyNfSrVhxvphs+K2dzT3dh5oVPPEqPOE/cUpScY=
 sigs.k8s.io/kustomize/kyaml v0.13.0/go.mod h1:FTJxEZ86ScK184NpGSAQcfEqee0nul8oLCK30D47m4E=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/functions/go/apply-setters/Dockerfile
+++ b/functions/go/apply-setters/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.13
+FROM golang:1.17-alpine3.13
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 

--- a/functions/go/apply-setters/go.mod
+++ b/functions/go/apply-setters/go.mod
@@ -1,9 +1,30 @@
 module github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/apply-setters
 
-go 1.16
+go 1.17
 
 require (
 	github.com/stretchr/testify v1.6.1
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	sigs.k8s.io/kustomize/kyaml v0.10.21
+)
+
+require (
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/cobra v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
+	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
+	golang.org/x/text v0.3.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e // indirect
 )

--- a/functions/go/create-setters/Dockerfile
+++ b/functions/go/create-setters/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.13
+FROM golang:1.17-alpine3.13
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 

--- a/functions/go/create-setters/go.mod
+++ b/functions/go/create-setters/go.mod
@@ -1,9 +1,30 @@
 module github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/create-setters
 
-go 1.16
+go 1.17
 
 require (
 	github.com/stretchr/testify v1.6.1
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	sigs.k8s.io/kustomize/kyaml v0.10.21
+)
+
+require (
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/cobra v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
+	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
+	golang.org/x/text v0.3.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e // indirect
 )

--- a/functions/go/enable-gcp-services/Dockerfile
+++ b/functions/go/enable-gcp-services/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.13
+FROM golang:1.17-alpine3.13
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 

--- a/functions/go/enable-gcp-services/go.mod
+++ b/functions/go/enable-gcp-services/go.mod
@@ -1,8 +1,32 @@
 module github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/project-services
 
-go 1.16
+go 1.17
 
 require (
 	github.com/stretchr/testify v1.7.0
 	sigs.k8s.io/kustomize/kyaml v0.13.1-0.20211119203701-d11342489acd
+)
+
+require (
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/cobra v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
+	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
+	golang.org/x/text v0.3.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
+	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/functions/go/ensure-name-substring/Dockerfile
+++ b/functions/go/ensure-name-substring/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.13
+FROM golang:1.17-alpine3.13
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 

--- a/functions/go/ensure-name-substring/go.mod
+++ b/functions/go/ensure-name-substring/go.mod
@@ -1,12 +1,45 @@
 module github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/ensure-name-substring
 
-go 1.16
+go 1.17
 
 require (
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/api v0.21.0
 	k8s.io/apimachinery v0.21.0
 	sigs.k8s.io/kustomize/api v0.8.11-0.20210614195535-7e8ba62e9fd9
 	sigs.k8s.io/kustomize/kyaml v0.10.21
 	sigs.k8s.io/yaml v1.2.0
+)
+
+require (
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-logr/logr v0.4.0 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/google/go-cmp v0.5.2 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.10 // indirect
+	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/cobra v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/testify v1.6.1 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
+	golang.org/x/net v0.0.0-20210224082022-3d97a244fca7 // indirect
+	golang.org/x/text v0.3.4 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/klog/v2 v2.8.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.1.0 // indirect
 )

--- a/functions/go/fix/Dockerfile
+++ b/functions/go/fix/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.13
+FROM golang:1.17-alpine3.13
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 

--- a/functions/go/fix/go.mod
+++ b/functions/go/fix/go.mod
@@ -1,10 +1,33 @@
 module github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/fix
 
-go 1.16
+go 1.17
 
 require (
 	github.com/stretchr/testify v1.7.0
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e
 	sigs.k8s.io/kustomize/kyaml v0.10.21
+)
+
+require (
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/sergi/go-diff v1.1.0 // indirect
+	github.com/spf13/cobra v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
+	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
+	golang.org/x/text v0.3.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/functions/go/format/Dockerfile
+++ b/functions/go/format/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.13
+FROM golang:1.17-alpine3.13
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 

--- a/functions/go/format/go.mod
+++ b/functions/go/format/go.mod
@@ -1,8 +1,28 @@
 module github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/format
 
-go 1.16
+go 1.17
+
+require sigs.k8s.io/kustomize/kyaml v0.10.21
 
 require (
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/cobra v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/testify v1.5.1 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
+	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
+	golang.org/x/text v0.3.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-	sigs.k8s.io/kustomize/kyaml v0.10.21
+	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e // indirect
 )

--- a/functions/go/gatekeeper/Dockerfile
+++ b/functions/go/gatekeeper/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.13
+FROM golang:1.17-alpine3.13
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 

--- a/functions/go/list-setters/Dockerfile
+++ b/functions/go/list-setters/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.13
+FROM golang:1.17-alpine3.13
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 

--- a/functions/go/list-setters/go.mod
+++ b/functions/go/list-setters/go.mod
@@ -1,10 +1,32 @@
 module github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/list-setters
 
-go 1.16
+go 1.17
 
 require (
 	github.com/GoogleContainerTools/kpt-functions-sdk/go v0.0.0-20210810181223-632b30549de6
 	github.com/stretchr/testify v1.7.0
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	sigs.k8s.io/kustomize/kyaml v0.11.0
+)
+
+require (
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/cobra v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
+	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
+	golang.org/x/text v0.3.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e // indirect
 )

--- a/functions/go/list-setters/go.sum
+++ b/functions/go/list-setters/go.sum
@@ -11,8 +11,6 @@ github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6L
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/GoogleContainerTools/kpt-functions-sdk/go v0.0.0-20210810054117-e438c46aea31 h1:O8Q/q0+i3FdMHKeP6co2aNxfrc7lpyWkWcc1DZGACXs=
-github.com/GoogleContainerTools/kpt-functions-sdk/go v0.0.0-20210810054117-e438c46aea31/go.mod h1:4rnsRbykRP7d90BpSyYPTchap7ad35lTmM1yLDjUGfs=
 github.com/GoogleContainerTools/kpt-functions-sdk/go v0.0.0-20210810181223-632b30549de6 h1:oo4q344mHs4eg8puEsXdyikhwORcu2cLsKGsNFDqxqM=
 github.com/GoogleContainerTools/kpt-functions-sdk/go v0.0.0-20210810181223-632b30549de6/go.mod h1:k86q33ABlA9TnUqRmHH9dnKY2Edh8YbxjRyPfjlM8jE=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=

--- a/functions/go/remove-local-config-resources/Dockerfile
+++ b/functions/go/remove-local-config-resources/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.13
+FROM golang:1.17-alpine3.13
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 

--- a/functions/go/remove-local-config-resources/go.mod
+++ b/functions/go/remove-local-config-resources/go.mod
@@ -1,16 +1,36 @@
 module github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/format
 
-go 1.16
+go 1.17
 
 require (
-	github.com/google/go-cmp v0.5.4 // indirect
-	github.com/kr/text v0.2.0 // indirect
-	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
-	github.com/spf13/cobra v1.1.3 // indirect
 	github.com/stretchr/testify v1.7.0
+	sigs.k8s.io/kustomize/kyaml v0.11.1
+)
+
+require (
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/google/go-cmp v0.5.4 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/kr/text v0.2.0 // indirect
+	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/cobra v1.1.3 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
 	golang.org/x/text v0.3.5 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-	sigs.k8s.io/kustomize/kyaml v0.11.1
+	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/functions/go/render-helm-chart/Dockerfile
+++ b/functions/go/render-helm-chart/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.13
+FROM golang:1.17-alpine3.13
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 

--- a/functions/go/render-helm-chart/go.mod
+++ b/functions/go/render-helm-chart/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/render-helm-chart
 
-go 1.16
+go 1.17
 
 require (
 	github.com/imdario/mergo v0.3.12
@@ -8,4 +8,26 @@ require (
 	sigs.k8s.io/kustomize/api v0.8.11
 	sigs.k8s.io/kustomize/kyaml v0.11.0
 	sigs.k8s.io/yaml v1.2.0
+)
+
+require (
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/cobra v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/testify v1.5.1 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
+	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
+	golang.org/x/text v0.3.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e // indirect
 )

--- a/functions/go/search-replace/Dockerfile
+++ b/functions/go/search-replace/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.13
+FROM golang:1.17-alpine3.13
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 

--- a/functions/go/search-replace/go.mod
+++ b/functions/go/search-replace/go.mod
@@ -1,10 +1,31 @@
 module github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/search-replace
 
-go 1.16
+go 1.17
 
 require (
-	github.com/bmatcuk/doublestar/v4 v4.0.2 // indirect
+	github.com/bmatcuk/doublestar/v4 v4.0.2
 	github.com/stretchr/testify v1.6.1
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	sigs.k8s.io/kustomize/kyaml v0.10.21
+)
+
+require (
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/cobra v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
+	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
+	golang.org/x/text v0.3.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e // indirect
 )

--- a/functions/go/set-annotations/Dockerfile
+++ b/functions/go/set-annotations/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.13
+FROM golang:1.17-alpine3.13
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 

--- a/functions/go/set-annotations/go.mod
+++ b/functions/go/set-annotations/go.mod
@@ -1,9 +1,32 @@
 module github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/set-annotations
 
-go 1.16
+go 1.17
 
 require (
 	sigs.k8s.io/kustomize/api v0.10.2-0.20211202184144-fe551be87b8d
 	sigs.k8s.io/kustomize/kyaml v0.13.1-0.20211202184144-fe551be87b8d
 	sigs.k8s.io/yaml v1.2.0
+)
+
+require (
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/cobra v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/testify v1.5.1 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
+	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
+	golang.org/x/text v0.3.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e // indirect
 )

--- a/functions/go/set-annotations/go.sum
+++ b/functions/go/set-annotations/go.sum
@@ -226,13 +226,9 @@ k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e h1:KLHHjkdQFomZy8+06csTWZ0m1343QqxZhR2LJ1OxCYM=
 k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e/go.mod h1:vHXdDvt9+2spS2Rx9ql3I8tycm3H9FDfdUoIuKCefvw=
-sigs.k8s.io/kustomize/api v0.10.2-0.20211130022056-a3e1c999154c h1:WCJz2U16gEI8d+kZNkra8QAPq8T8xxrho9g5pQc9NiI=
-sigs.k8s.io/kustomize/api v0.10.2-0.20211130022056-a3e1c999154c/go.mod h1:6JSgt1WR7U7Wr4LoZ/vAGP2nailrn2/ECpDZ23GJtFo=
 sigs.k8s.io/kustomize/api v0.10.2-0.20211202184144-fe551be87b8d h1:R/dZYqyD+6VWspltlH6pC5/h5UL4GIjr3uZuScUL2bA=
 sigs.k8s.io/kustomize/api v0.10.2-0.20211202184144-fe551be87b8d/go.mod h1:6JSgt1WR7U7Wr4LoZ/vAGP2nailrn2/ECpDZ23GJtFo=
 sigs.k8s.io/kustomize/kyaml v0.13.0/go.mod h1:FTJxEZ86ScK184NpGSAQcfEqee0nul8oLCK30D47m4E=
-sigs.k8s.io/kustomize/kyaml v0.13.1-0.20211130022056-a3e1c999154c h1:1hm94ZhtXaIwEhDj2CzBMp8qtARGo6/g07nhcfx1sO8=
-sigs.k8s.io/kustomize/kyaml v0.13.1-0.20211130022056-a3e1c999154c/go.mod h1:FTJxEZ86ScK184NpGSAQcfEqee0nul8oLCK30D47m4E=
 sigs.k8s.io/kustomize/kyaml v0.13.1-0.20211202184144-fe551be87b8d h1:ZQl8im14EmKfcJ7IQ6GnUgfgJw0msaDcAn9PwlO3fig=
 sigs.k8s.io/kustomize/kyaml v0.13.1-0.20211202184144-fe551be87b8d/go.mod h1:FTJxEZ86ScK184NpGSAQcfEqee0nul8oLCK30D47m4E=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=

--- a/functions/go/set-enforcement-action/Dockerfile
+++ b/functions/go/set-enforcement-action/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.13
+FROM golang:1.17-alpine3.13
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 

--- a/functions/go/set-enforcement-action/go.mod
+++ b/functions/go/set-enforcement-action/go.mod
@@ -1,16 +1,36 @@
 module github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/format
 
-go 1.16
+go 1.17
 
 require (
-	github.com/google/go-cmp v0.5.4 // indirect
-	github.com/kr/text v0.2.0 // indirect
-	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
-	github.com/spf13/cobra v1.1.3 // indirect
 	github.com/stretchr/testify v1.7.0
+	sigs.k8s.io/kustomize/kyaml v0.12.0
+)
+
+require (
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/google/go-cmp v0.5.4 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/kr/text v0.2.0 // indirect
+	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/cobra v1.1.3 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
 	golang.org/x/text v0.3.5 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-	sigs.k8s.io/kustomize/kyaml v0.12.0
+	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/functions/go/set-labels/Dockerfile
+++ b/functions/go/set-labels/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.12
+FROM golang:1.17-alpine3.13
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 

--- a/functions/go/set-labels/go.mod
+++ b/functions/go/set-labels/go.mod
@@ -1,10 +1,33 @@
 module github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/set-labels
 
-go 1.16
+go 1.17
 
 require (
 	github.com/stretchr/testify v1.7.0
 	sigs.k8s.io/kustomize/api v0.10.2-0.20220110181313-a1a0a4982226
 	sigs.k8s.io/kustomize/kyaml v0.13.2-0.20220110181313-a1a0a4982226
 	sigs.k8s.io/yaml v1.2.0
+)
+
+require (
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/cobra v1.2.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
+	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
+	golang.org/x/text v0.3.5 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e // indirect
 )

--- a/functions/go/set-labels/main.go
+++ b/functions/go/set-labels/main.go
@@ -45,8 +45,8 @@ func (slp *SetLabelsProcessor) Process(resourceList *framework.ResourceList) err
 	if err != nil {
 		resourceList.Results = framework.Results{
 			{
-					Message:  err.Error(),
-					Severity: framework.Error,
+				Message:  err.Error(),
+				Severity: framework.Error,
 			},
 		}
 		return resourceList.Results

--- a/functions/go/set-namespace/Dockerfile
+++ b/functions/go/set-namespace/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.13
+FROM golang:1.17-alpine3.13
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 

--- a/functions/go/set-namespace/go.mod
+++ b/functions/go/set-namespace/go.mod
@@ -1,10 +1,33 @@
 module github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/set-namespace
 
-go 1.16
+go 1.17
 
 require (
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	sigs.k8s.io/kustomize/api v0.8.11-0.20210614195535-7e8ba62e9fd9
 	sigs.k8s.io/kustomize/kyaml v0.10.21
 	sigs.k8s.io/yaml v1.2.0
+)
+
+require (
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/cobra v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/testify v1.5.1 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
+	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
+	golang.org/x/text v0.3.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e // indirect
 )

--- a/functions/go/set-project-id/Dockerfile
+++ b/functions/go/set-project-id/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.13
+FROM golang:1.17-alpine3.13
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 

--- a/functions/go/set-project-id/go.mod
+++ b/functions/go/set-project-id/go.mod
@@ -1,10 +1,32 @@
 module github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/set-project-id
 
-go 1.16
+go 1.17
 
 require (
 	github.com/GoogleContainerTools/kpt-functions-sdk/go v0.0.0-20210810181223-632b30549de6
-	github.com/stretchr/testify v1.7.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	sigs.k8s.io/kustomize/kyaml v0.11.0
+)
+
+require (
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/cobra v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/testify v1.7.0 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
+	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
+	golang.org/x/text v0.3.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e // indirect
 )

--- a/functions/go/set-project-id/go.sum
+++ b/functions/go/set-project-id/go.sum
@@ -11,8 +11,6 @@ github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6L
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/GoogleContainerTools/kpt-functions-sdk/go v0.0.0-20210810054117-e438c46aea31 h1:O8Q/q0+i3FdMHKeP6co2aNxfrc7lpyWkWcc1DZGACXs=
-github.com/GoogleContainerTools/kpt-functions-sdk/go v0.0.0-20210810054117-e438c46aea31/go.mod h1:4rnsRbykRP7d90BpSyYPTchap7ad35lTmM1yLDjUGfs=
 github.com/GoogleContainerTools/kpt-functions-sdk/go v0.0.0-20210810181223-632b30549de6 h1:oo4q344mHs4eg8puEsXdyikhwORcu2cLsKGsNFDqxqM=
 github.com/GoogleContainerTools/kpt-functions-sdk/go v0.0.0-20210810181223-632b30549de6/go.mod h1:k86q33ABlA9TnUqRmHH9dnKY2Edh8YbxjRyPfjlM8jE=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=

--- a/functions/go/starlark/Dockerfile
+++ b/functions/go/starlark/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.13
+FROM golang:1.17-alpine3.13
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 

--- a/functions/go/starlark/go.mod
+++ b/functions/go/starlark/go.mod
@@ -1,13 +1,53 @@
 module github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/starlark
 
-go 1.16
+go 1.17
 
 require (
 	github.com/qri-io/starlib v0.5.0
 	go.starlark.net v0.0.0-20210901212718-87f333178d59
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/api v0.21.0
 	k8s.io/apimachinery v0.21.0
 	sigs.k8s.io/kustomize/kyaml v0.11.1
 	sigs.k8s.io/yaml v1.2.0
+)
+
+require (
+	github.com/360EntSecGroup-Skylar/excelize v1.4.1 // indirect
+	github.com/PuerkitoBio/goquery v1.5.1 // indirect
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/andybalholm/cascadia v1.1.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dustmop/soup v1.1.2-0.20190516214245-38228baa104e // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-logr/logr v0.4.0 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/google/go-cmp v0.5.2 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.10 // indirect
+	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/paulmach/orb v0.1.5 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/cobra v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/testify v1.6.1 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
+	golang.org/x/net v0.0.0-20210224082022-3d97a244fca7 // indirect
+	golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073 // indirect
+	golang.org/x/text v0.3.4 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/klog/v2 v2.8.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.1.0 // indirect
 )

--- a/functions/go/upsert-resource/Dockerfile
+++ b/functions/go/upsert-resource/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.13
+FROM golang:1.17-alpine3.13
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 

--- a/functions/go/upsert-resource/go.mod
+++ b/functions/go/upsert-resource/go.mod
@@ -1,9 +1,30 @@
 module github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/upsert-resource
 
-go 1.16
+go 1.17
 
 require (
 	github.com/stretchr/testify v1.6.1
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	sigs.k8s.io/kustomize/kyaml v0.10.21
+)
+
+require (
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/cobra v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
+	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
+	golang.org/x/text v0.3.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e // indirect
 )

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -25,7 +25,7 @@ RUN apk add --no-cache make
 RUN apk add --no-cache curl
 
 # Install golang
-COPY --from=golang:1.16-alpine /usr/local/go/ /usr/local/go/
+COPY --from=golang:1.17-alpine /usr/local/go/ /usr/local/go/
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 # Install node and npm

--- a/scripts/generate_catalog/go.mod
+++ b/scripts/generate_catalog/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleContainerTools/kpt-functions-catalog
 
-go 1.16
+go 1.17
 
 require (
 	golang.org/x/mod v0.4.1

--- a/scripts/update_function_docs/go.mod
+++ b/scripts/update_function_docs/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleContainerTools/kpt-functions-catalog
 
-go 1.16
+go 1.17
 
 require (
 	golang.org/x/mod v0.4.1

--- a/tests/e2etest/go.mod
+++ b/tests/e2etest/go.mod
@@ -1,5 +1,29 @@
 module github.com/GoogleContainerTools/kpt-functions-catalog/tests/e2etest
 
-go 1.16
+go 1.17
 
 require github.com/GoogleContainerTools/kpt v1.0.0-alpha.7.0.20210614205835-0e004952f169
+
+require (
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-errors/errors v1.4.0 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.7.0 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
+	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 // indirect
+	golang.org/x/text v0.3.6 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/apimachinery v0.21.1 // indirect
+	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e // indirect
+	k8s.io/kubectl v0.21.1 // indirect
+	sigs.k8s.io/kustomize/kyaml v0.10.21 // indirect
+)


### PR DESCRIPTION
Our release pipeline for `unstable` tag is not working, since one of the function requires go 1.17.
This PR does a bulk update.