### PR TITLE
pinning the version of gatekeeper

### DIFF
--- a/examples/gatekeeper-disallow-root-user/.expected/results.yaml
+++ b/examples/gatekeeper-disallow-root-user/.expected/results.yaml
@@ -4,7 +4,7 @@ metadata:
   name: fnresults
 exitCode: 1
 items:
-  - image: gcr.io/kpt-fn/gatekeeper:unstable
+  - image: gcr.io/kpt-fn/gatekeeper:v0.2.1
     stderr: |-
       [error] apps/v1/Deployment/nginx-deploy : Containers must not run as root
       violatedConstraint: disallowroot

--- a/examples/gatekeeper-disallow-root-user/Kptfile
+++ b/examples/gatekeeper-disallow-root-user/Kptfile
@@ -4,4 +4,4 @@ metadata:
   name: example
 pipeline:
   validators:
-    - image: gcr.io/kpt-fn/gatekeeper:unstable
+    - image: gcr.io/kpt-fn/gatekeeper:v0.2.1

--- a/examples/gatekeeper-disallow-root-user/README.md
+++ b/examples/gatekeeper-disallow-root-user/README.md
@@ -81,7 +81,7 @@ metadata:
   name: fnresults
 exitCode: 1
 items:
-  - image: gcr.io/kpt-fn/gatekeeper:unstable
+  - image: gcr.io/kpt-fn/gatekeeper:v0.2.1
     stderr: |-
       [error] apps/v1/Deployment/nginx-deploy : Containers must not run as root
       violatedConstraint: disallowroot

--- a/examples/gatekeeper-imperative/.expected/config.yaml
+++ b/examples/gatekeeper-imperative/.expected/config.yaml
@@ -1,3 +1,3 @@
 exitCode: 1
 testType: eval
-image: gcr.io/kpt-fn/gatekeeper:unstable
+image: gcr.io/kpt-fn/gatekeeper:v0.2.1

--- a/examples/gatekeeper-imperative/.expected/results.yaml
+++ b/examples/gatekeeper-imperative/.expected/results.yaml
@@ -4,7 +4,7 @@ metadata:
   name: fnresults
 exitCode: 1
 items:
-  - image: gcr.io/kpt-fn/gatekeeper:unstable
+  - image: gcr.io/kpt-fn/gatekeeper:v0.2.1
     stderr: |-
       [error] v1/ConfigMap/default/super-secret : The following banned keys are being used in the ConfigMap: {"private_key"}
       violatedConstraint: no-secrets-in-configmap

--- a/examples/gatekeeper-imperative/README.md
+++ b/examples/gatekeeper-imperative/README.md
@@ -26,7 +26,7 @@ We have a `ConfigMap` in `config-map.yaml` that violates the policy.
 Run the function with `--results-dir` flag:
 
 ```shell
-$ kpt fn eval gatekeeper-imperative --image gcr.io/kpt-fn/gatekeeper:unstable --results-dir /tmp
+$ kpt fn eval gatekeeper-imperative --image gcr.io/kpt-fn/gatekeeper:v0.2.1 --results-dir /tmp
 ```
 
 ### Expected result
@@ -40,7 +40,7 @@ metadata:
   name: fnresults
 exitCode: 1
 items:
-  - image: gcr.io/kpt-fn/gatekeeper:unstable
+  - image: gcr.io/kpt-fn/gatekeeper:v0.2.1
     stderr: |-
       The following banned keys are being used in the ConfigMap: {"private_key"}
       violatedConstraint: no-secrets-in-configmap

--- a/examples/gatekeeper-invalid-configmap/.expected/results.yaml
+++ b/examples/gatekeeper-invalid-configmap/.expected/results.yaml
@@ -4,7 +4,7 @@ metadata:
   name: fnresults
 exitCode: 1
 items:
-  - image: gcr.io/kpt-fn/gatekeeper:unstable
+  - image: gcr.io/kpt-fn/gatekeeper:v0.2.1
     stderr: |-
       [error] v1/ConfigMap/default/super-secret : The following banned keys are being used in the ConfigMap: {"private_key"}
       violatedConstraint: no-secrets-in-configmap

--- a/examples/gatekeeper-invalid-configmap/Kptfile
+++ b/examples/gatekeeper-invalid-configmap/Kptfile
@@ -4,4 +4,4 @@ metadata:
   name: example
 pipeline:
   validators:
-    - image: gcr.io/kpt-fn/gatekeeper:unstable
+    - image: gcr.io/kpt-fn/gatekeeper:v0.2.1

--- a/examples/gatekeeper-invalid-configmap/README.md
+++ b/examples/gatekeeper-invalid-configmap/README.md
@@ -25,7 +25,7 @@ metadata:
   name: example
 pipeline:
   validators:
-    - image: gcr.io/kpt-fn/gatekeeper:unstable
+    - image: gcr.io/kpt-fn/gatekeeper:v0.2.1
 ```
 
 ### Function invocation
@@ -47,7 +47,7 @@ metadata:
   name: fnresults
 exitCode: 1
 items:
-  - image: gcr.io/kpt-fn/gatekeeper:unstable
+  - image: gcr.io/kpt-fn/gatekeeper:v0.2.1
     stderr: |-
       The following banned keys are being used in the ConfigMap: {"private_key"}
       violatedConstraint: no-secrets-in-configmap

--- a/examples/gatekeeper-warning-only/.expected/results.yaml
+++ b/examples/gatekeeper-warning-only/.expected/results.yaml
@@ -4,7 +4,7 @@ metadata:
   name: fnresults
 exitCode: 0
 items:
-  - image: gcr.io/kpt-fn/gatekeeper:unstable
+  - image: gcr.io/kpt-fn/gatekeeper:v0.2.1
     exitCode: 0
     results:
       - message: |-

--- a/examples/gatekeeper-warning-only/Kptfile
+++ b/examples/gatekeeper-warning-only/Kptfile
@@ -4,4 +4,4 @@ metadata:
   name: example
 pipeline:
   validators:
-    - image: gcr.io/kpt-fn/gatekeeper:unstable
+    - image: gcr.io/kpt-fn/gatekeeper:v0.2.1

--- a/examples/gatekeeper-warning-only/README.md
+++ b/examples/gatekeeper-warning-only/README.md
@@ -23,7 +23,7 @@ metadata:
   name: example
 pipeline:
   validators:
-    - image: gcr.io/kpt-fn/gatekeeper:unstable
+    - image: gcr.io/kpt-fn/gatekeeper:v0.2.1
 ```
 
 In the constraint, we use `enforcementAction: warn` instead of
@@ -58,7 +58,7 @@ metadata:
   name: fnresults
 exitCode: 0
 items:
-  - image: gcr.io/kpt-fn/gatekeeper:unstable
+  - image: gcr.io/kpt-fn/gatekeeper:v0.2.1
     exitCode: 0
     results:
       - message: |-

--- a/tests/gatekeeper/decode-json-as-yaml/.expected/exec.sh
+++ b/tests/gatekeeper/decode-json-as-yaml/.expected/exec.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker run --rm -v "$(pwd)"/resources:/resources gcr.io/kpt-fn/gatekeeper:unstable --input resources/resources.json --output resources/resources.json
+docker run --rm -v "$(pwd)"/resources:/resources gcr.io/kpt-fn/gatekeeper:v0.2.1 --input resources/resources.json --output resources/resources.json

--- a/tests/gatekeeper/dryrun/.expected/results.yaml
+++ b/tests/gatekeeper/dryrun/.expected/results.yaml
@@ -4,7 +4,7 @@ metadata:
   name: fnresults
 exitCode: 0
 items:
-  - image: gcr.io/kpt-fn/gatekeeper:unstable
+  - image: gcr.io/kpt-fn/gatekeeper:v0.2.1
     exitCode: 0
     results:
       - message: |-

--- a/tests/gatekeeper/dryrun/Kptfile
+++ b/tests/gatekeeper/dryrun/Kptfile
@@ -4,4 +4,4 @@ metadata:
   name: example
 pipeline:
   validators:
-    - image: gcr.io/kpt-fn/gatekeeper:unstable
+    - image: gcr.io/kpt-fn/gatekeeper:v0.2.1

--- a/tests/gatekeeper/inputoutputflags/.expected/exec.sh
+++ b/tests/gatekeeper/inputoutputflags/.expected/exec.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker run --rm -v "$(pwd)"/resources:/resources gcr.io/kpt-fn/gatekeeper:unstable --input resources/resources.yaml --output resources/resources.yaml
+docker run --rm -v "$(pwd)"/resources:/resources gcr.io/kpt-fn/gatekeeper:v0.2.1 --input resources/resources.yaml --output resources/resources.yaml

--- a/tests/gatekeeper/jsonflag/.expected/exec.sh
+++ b/tests/gatekeeper/jsonflag/.expected/exec.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker run --rm -v "$(pwd)"/resources:/resources gcr.io/kpt-fn/gatekeeper:unstable --input resources/resources.json --output resources/resources.json --json
+docker run --rm -v "$(pwd)"/resources:/resources gcr.io/kpt-fn/gatekeeper:v0.2.1 --input resources/resources.json --output resources/resources.json --json

--- a/tests/gatekeeper/v1beta1-template/.expected/results.yaml
+++ b/tests/gatekeeper/v1beta1-template/.expected/results.yaml
@@ -4,7 +4,7 @@ metadata:
   name: fnresults
 exitCode: 1
 items:
-  - image: gcr.io/kpt-fn/gatekeeper:unstable
+  - image: gcr.io/kpt-fn/gatekeeper:v0.2.1
     stderr: |-
       [error] apps/v1/Deployment/nginx-deploy : Containers must not run as root
       violatedConstraint: disallowroot

--- a/tests/gatekeeper/v1beta1-template/Kptfile
+++ b/tests/gatekeeper/v1beta1-template/Kptfile
@@ -4,4 +4,4 @@ metadata:
   name: example
 pipeline:
   validators:
-    - image: gcr.io/kpt-fn/gatekeeper:unstable
+    - image: gcr.io/kpt-fn/gatekeeper:v0.2.1

--- a/tests/gatekeeper/valid/Kptfile
+++ b/tests/gatekeeper/valid/Kptfile
@@ -4,4 +4,4 @@ metadata:
   name: example
 pipeline:
   validators:
-    - image: gcr.io/kpt-fn/gatekeeper:unstable
+    - image: gcr.io/kpt-fn/gatekeeper:v0.2.1


### PR DESCRIPTION
When looking through examples I noticed that we forgot to pin the gatekeeper content.  Why do I think we should do it:
1) it shows the best practice
2) it introduces stability for our own selves.

Hopefully this is a quick PR review 👀 .
