### PR TITLE
ci: add github action for short release tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,35 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Create Short Tag for Function Release
+on:
+  push:
+    tags:
+    # e.g. functions/go/apply-setters/v1.1.1
+    - "functions/*/*/v[0-9]+.[0-9]+.[0-9]+"
+    - "contrib/functions/*/*/v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: function-release
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Create Short Tag for Function Release
+      # Create secondary short tag, e.g. functions/go/apply-setters/v1.1.1 -> apply-setters/v1.1.1
+      run: |
+        export NEW_TAG=${GITHUB_REF#refs/tags/**functions/*/}
+        git tag -f "${NEW_TAG}" "${GITHUB_REF}"
+        git push origin "${NEW_TAG}"


### PR DESCRIPTION
This github action is intended to be run when a new release tag is
published with the form `functions/<lang>/<func>/<version>`.

It publishes a shorter tag for the same commit with the form
`<func>/<version>`. This is intended as a convenience and is needed for
the examples in the docs to function properly.

Issues: GoogleContainerTools/kpt#2704