### PR TITLE
feat: Improve export-terraform function to handle additional resources

### DIFF
--- a/examples/export-terraform-advanced/.expected/config.yaml
+++ b/examples/export-terraform-advanced/.expected/config.yaml
@@ -1,0 +1,2 @@
+testType: eval
+image: gcr.io/kpt-fn/export-terraform:unstable

--- a/examples/export-terraform-advanced/.expected/diff.patch
+++ b/examples/export-terraform-advanced/.expected/diff.patch
@@ -1,0 +1,22 @@
+diff --git a/configmap_terraform.yaml b/configmap_terraform.yaml
+new file mode 100644
+index 0000000..92f809c
+--- /dev/null
++++ b/configmap_terraform.yaml
+@@ -0,0 +1,16 @@
++apiVersion: v1
++kind: ConfigMap
++metadata:
++  name: terraform
++  annotations:
++    blueprints.cloud.google.com/flavor: terraform
++    blueprints.cloud.google.com/syntax: hcl
++    config.kubernetes.io/local-config: "true"
++    internal.config.kubernetes.io/path: terraform.yaml
++data:
++  folders.tf: |
++    resource "google_folder" "test" {
++      display_name = "Test Display"
++      parent       = "organizations/11111111111"
++    }
++  iam.tf: "module \"organization-iam\" {\n  source  = \"terraform-google-modules/iam/google//modules/organizations_iam\"\n  version = \"~> 7.4\"\n\n  organizations = [\"11111111111\"]\n\n  bindings = {\n    \n    \"roles/editor\" = [\n      \"group:gcp-organization-admins@example.com\",\n      \"group:gcp-developers@example.com\",\n    ]\n    \n    \"roles/orgpolicy.policyAdmin\" = [\n      \"group:gcp-organization-admins@example.com\",\n    ]\n    \n  }\n}\n\n\nmodule \"folder-1-iam\" {\n  source  = \"terraform-google-modules/iam/google//modules/folders_iam\"\n  version = \"~> 7.4\"\n\n  folders = [\"folders/335620346181\"]\n\n  bindings = {\n    \n    \"roles/viewer\" = [\n      \"group:gcp-developers@example.com\",\n    ]\n    \n  }\n}\n\n\nmodule \"test-iam\" {\n  source  = \"terraform-google-modules/iam/google//modules/folders_iam\"\n  version = \"~> 7.4\"\n\n  folders = [google_folder.test.name]\n\n  bindings = {\n    \n    \"roles/viewer\" = [\n      \"group:gcp-developers@example.com\",\n    ]\n    \n  }\n}\n"

--- a/examples/export-terraform-advanced/.expected/diff.patch
+++ b/examples/export-terraform-advanced/.expected/diff.patch
@@ -1,9 +1,9 @@
 diff --git a/terraform.yaml b/terraform.yaml
 new file mode 100644
-index 0000000..84a00c7
+index 0000000..c79a7cd
 --- /dev/null
 +++ b/terraform.yaml
-@@ -0,0 +1,73 @@
+@@ -0,0 +1,74 @@
 +apiVersion: v1
 +kind: ConfigMap
 +metadata:
@@ -62,6 +62,7 @@ index 0000000..84a00c7
 +    variable "org_id" {
 +      description = "The organization id for the associated resources"
 +      type        = string
++      default     = "11111111111"
 +    }
 +  versions.tf: |
 +    terraform {

--- a/examples/export-terraform-advanced/.expected/diff.patch
+++ b/examples/export-terraform-advanced/.expected/diff.patch
@@ -1,9 +1,9 @@
-diff --git a/configmap_terraform.yaml b/configmap_terraform.yaml
+diff --git a/terraform.yaml b/terraform.yaml
 new file mode 100644
-index 0000000..92f809c
+index 0000000..84885c5
 --- /dev/null
-+++ b/configmap_terraform.yaml
-@@ -0,0 +1,16 @@
++++ b/terraform.yaml
+@@ -0,0 +1,75 @@
 +apiVersion: v1
 +kind: ConfigMap
 +metadata:
@@ -12,11 +12,70 @@ index 0000000..92f809c
 +    blueprints.cloud.google.com/flavor: terraform
 +    blueprints.cloud.google.com/syntax: hcl
 +    config.kubernetes.io/local-config: "true"
-+    internal.config.kubernetes.io/path: terraform.yaml
 +data:
++  README.md: |
++    # Google Cloud Foundation Blueprint
++
++    This directory contains Terraform configuration for a foundational environment on Google Cloud.
++
++    It includes a subset of resources configured via the [setup checklist](https://cloud.google.com/docs/enterprise/setup-checklist)
++    and is based on the [security foundations blueprint](https://cloud.google.com/architecture/security-foundations).
++
++    ## Prerequisites
++
++    To run the commands described in this document, you need to have the following
++    installed:
++
++    - The [Google Cloud SDK](https://cloud.google.com/sdk/install) version 319.0.0 or later
++    - [Terraform](https://www.terraform.io/downloads.html) version 0.13.7 or later.
++
++    1. Set up a Google Cloud
++       [organization](https://cloud.google.com/resource-manager/docs/creating-managing-organization).
++    1. Set up a Google Cloud
++       [billing account](https://cloud.google.com/billing/docs/how-to/manage-billing-account).
++    1. Created Cloud Identity or Google Workspace (formerly G Suite) groups for
++       organization and billing admins.
++    1. For the user who will run the procedures in this document, granted the
++       following roles:
++       -  The `roles/resourcemanager.organizationAdmin` role on the Google
++          Cloud organization.
++       -  The `roles/billing.admin` role on the billing account.
++       -  The `roles/resourcemanager.folderCreator` role.
++       -  The `roles/resourcemanager.projectCreator` role.
++
++    ## Deploying
++
++    1. Run `terraform init`.
++    1. Run `terraform plan` and review the output.
++    1. Run `terraform apply`.
++
++    ## Next steps
++
++    Once you have the basic foundation deployed, you should explore:
++    1. Building an [advanced foundation](https://github.com/terraform-google-modules/terraform-example-foundation) using the security blueprint
++    2. Automatically deploying Terraform with [Cloud Build](https://cloud.google.com/architecture/managing-infrastructure-as-code)
 +  folders.tf: |
 +    resource "google_folder" "test" {
 +      display_name = "Test Display"
-+      parent       = "organizations/11111111111"
++      parent       = "organizations/${var.org_id}"
 +    }
 +  iam.tf: "module \"organization-iam\" {\n  source  = \"terraform-google-modules/iam/google//modules/organizations_iam\"\n  version = \"~> 7.4\"\n\n  organizations = [\"11111111111\"]\n\n  bindings = {\n    \n    \"roles/editor\" = [\n      \"group:gcp-organization-admins@example.com\",\n      \"group:gcp-developers@example.com\",\n    ]\n    \n    \"roles/orgpolicy.policyAdmin\" = [\n      \"group:gcp-organization-admins@example.com\",\n    ]\n    \n  }\n}\n\n\nmodule \"folder-1-iam\" {\n  source  = \"terraform-google-modules/iam/google//modules/folders_iam\"\n  version = \"~> 7.4\"\n\n  folders = [\"folders/335620346181\"]\n\n  bindings = {\n    \n    \"roles/viewer\" = [\n      \"group:gcp-developers@example.com\",\n    ]\n    \n  }\n}\n\n\nmodule \"test-iam\" {\n  source  = \"terraform-google-modules/iam/google//modules/folders_iam\"\n  version = \"~> 7.4\"\n\n  folders = [google_folder.test.name]\n\n  bindings = {\n    \n    \"roles/viewer\" = [\n      \"group:gcp-developers@example.com\",\n    ]\n    \n  }\n}\n"
++  variables.tf: |
++    variable "org_id" {
++      description = "The organization id for the associated resources"
++      type        = string
++    }
++  versions.tf: |
++    terraform {
++      required_version = ">=0.13"
++
++      required_providers {
++        google = {
++          source  = "hashicorp/google"
++          version = ">= 4.0.0"
++        }
++      }
++      provider_meta "google" {
++        module_name = "blueprints/terraform/exported-krm/v0.1.0"
++      }
++    }

--- a/examples/export-terraform-advanced/.expected/diff.patch
+++ b/examples/export-terraform-advanced/.expected/diff.patch
@@ -1,9 +1,9 @@
 diff --git a/terraform.yaml b/terraform.yaml
 new file mode 100644
-index 0000000..84885c5
+index 0000000..84a00c7
 --- /dev/null
 +++ b/terraform.yaml
-@@ -0,0 +1,75 @@
+@@ -0,0 +1,73 @@
 +apiVersion: v1
 +kind: ConfigMap
 +metadata:
@@ -23,25 +23,23 @@ index 0000000..84885c5
 +
 +    ## Prerequisites
 +
-+    To run the commands described in this document, you need to have the following
-+    installed:
++    To run the commands described in this document, you need the following:
 +
-+    - The [Google Cloud SDK](https://cloud.google.com/sdk/install) version 319.0.0 or later
-+    - [Terraform](https://www.terraform.io/downloads.html) version 0.13.7 or later.
-+
++    1. Install the [Google Cloud SDK](https://cloud.google.com/sdk/install) version 319.0.0 or later
++    1. Install [Terraform](https://www.terraform.io/downloads.html) version 0.13.7 or later.
 +    1. Set up a Google Cloud
 +       [organization](https://cloud.google.com/resource-manager/docs/creating-managing-organization).
 +    1. Set up a Google Cloud
 +       [billing account](https://cloud.google.com/billing/docs/how-to/manage-billing-account).
-+    1. Created Cloud Identity or Google Workspace (formerly G Suite) groups for
-+       organization and billing admins.
-+    1. For the user who will run the procedures in this document, granted the
++    1. For the user who will run the Terraform install, grant the
 +       following roles:
++       -  The `roles/billing.admin` role on the billing account.
 +       -  The `roles/resourcemanager.organizationAdmin` role on the Google
 +          Cloud organization.
-+       -  The `roles/billing.admin` role on the billing account.
-+       -  The `roles/resourcemanager.folderCreator` role.
-+       -  The `roles/resourcemanager.projectCreator` role.
++       -  The `roles/resourcemanager.folderCreator` role on the Google
++          Cloud organization.
++       -  The `roles/resourcemanager.projectCreator` role on the Google
++          Cloud organization.
 +
 +    ## Deploying
 +

--- a/examples/export-terraform-advanced/.expected/results.yaml
+++ b/examples/export-terraform-advanced/.expected/results.yaml
@@ -1,0 +1,8 @@
+apiVersion: kpt.dev/v1
+kind: FunctionResultList
+metadata:
+  name: fnresults
+exitCode: 0
+items:
+  - image: gcr.io/kpt-fn/export-terraform:unstable
+    exitCode: 0

--- a/examples/export-terraform-advanced/.krmignore
+++ b/examples/export-terraform-advanced/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/examples/export-terraform-advanced/README.md
+++ b/examples/export-terraform-advanced/README.md
@@ -1,0 +1,30 @@
+# export-terraform: Advanced Example
+
+### Overview
+
+In this example, we will see how to export Terraform configuration from a complex blueprint with many KCC resources.
+
+### Fetch the example package
+
+Get the example package by running the following commands:
+
+```shell
+$ kpt pkg get https://github.com/GoogleContainerTools/kpt-functions-catalog.git/examples/export-terraform-advanced
+```
+
+### Function invocation
+
+Invoke the function by running the following commands:
+
+```shell
+$ kpt fn eval export-terraform-advanced --image gcr.io/kpt-fn/export-terraform:unstable
+```
+
+### Expected result
+The function should export successfully
+```shell
+[RUNNING] "gcr.io/kpt-fn/export-terraform:unstable"
+[PASS] "gcr.io/kpt-fn/export-terraform:unstable" in 1.5s
+```
+
+A `ConfigMap` will be placed in `terraform.yaml` which contains the converted Terraform code.

--- a/examples/export-terraform-advanced/folder_external.yaml
+++ b/examples/export-terraform-advanced/folder_external.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,18 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
 metadata:
-  name: terraform
-  annotations:
-    config.kubernetes.io/local-config: "true"
-    blueprints.cloud.google.com/syntax: "hcl"
-    blueprints.cloud.google.com/flavor: "terraform"
-data:
-  folders.tf: |+
-    resource "google_folder" "test" {
-      display_name = "Test Display"
-      parent       = "organizations/123456789012"
-    }
+  name: external-viewer
+  namespace: config-control
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Folder
+    external: "335620346181"
+  role: roles/viewer
+  member: group:gcp-developers@example.com

--- a/examples/export-terraform-advanced/folder_ref.yaml
+++ b/examples/export-terraform-advanced/folder_ref.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,18 +11,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Folder
 metadata:
-  name: terraform
-  annotations:
-    config.kubernetes.io/local-config: "true"
-    blueprints.cloud.google.com/syntax: "hcl"
-    blueprints.cloud.google.com/flavor: "terraform"
-data:
-  folders.tf: |+
-    resource "google_folder" "test" {
-      display_name = "Test Display"
-      parent       = "organizations/123456789012"
-    }
+  name: test
+  namespace: hierarchy
+spec:
+  displayName: Test Display
+  organizationRef:
+    external: '11111111111'
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: folder-viewer
+  namespace: config-control
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Folder
+    name: test
+    namespace: hierarchy
+  role: roles/viewer
+  member: group:gcp-developers@example.com

--- a/examples/export-terraform-advanced/org_iam.yaml
+++ b/examples/export-terraform-advanced/org_iam.yaml
@@ -1,0 +1,38 @@
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: gcp-organization-adminsorgpolicy-policyAdmin
+  namespace: config-control
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Organization
+    external: "11111111111"
+  role: roles/orgpolicy.policyAdmin
+  member: group:gcp-organization-admins@example.com
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: gcp-organization-adminsorgpolicy-editor
+  namespace: config-control
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Organization
+    external: "11111111111"
+  role: roles/editor
+  member: group:gcp-organization-admins@example.com
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: gcp-devs-editor
+  namespace: config-control
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Organization
+    external: "11111111111"
+  role: roles/editor
+  member: group:gcp-developers@example.com

--- a/examples/export-terraform-imperative/.expected/diff.patch
+++ b/examples/export-terraform-imperative/.expected/diff.patch
@@ -1,9 +1,9 @@
 diff --git a/terraform.yaml b/terraform.yaml
 new file mode 100644
-index 0000000..71490e8
+index 0000000..ae4cbb5
 --- /dev/null
 +++ b/terraform.yaml
-@@ -0,0 +1,20 @@
+@@ -0,0 +1,79 @@
 +apiVersion: v1
 +kind: ConfigMap
 +metadata:
@@ -13,7 +13,48 @@ index 0000000..71490e8
 +    blueprints.cloud.google.com/syntax: hcl
 +    config.kubernetes.io/local-config: "true"
 +data:
-+  folders.tf: |+
++  README.md: |
++    # Google Cloud Foundation Blueprint
++
++    This directory contains Terraform configuration for a foundational environment on Google Cloud.
++
++    It includes a subset of resources configured via the [setup checklist](https://cloud.google.com/docs/enterprise/setup-checklist)
++    and is based on the [security foundations blueprint](https://cloud.google.com/architecture/security-foundations).
++
++    ## Prerequisites
++
++    To run the commands described in this document, you need to have the following
++    installed:
++
++    - The [Google Cloud SDK](https://cloud.google.com/sdk/install) version 319.0.0 or later
++    - [Terraform](https://www.terraform.io/downloads.html) version 0.13.7 or later.
++
++    1. Set up a Google Cloud
++       [organization](https://cloud.google.com/resource-manager/docs/creating-managing-organization).
++    1. Set up a Google Cloud
++       [billing account](https://cloud.google.com/billing/docs/how-to/manage-billing-account).
++    1. Created Cloud Identity or Google Workspace (formerly G Suite) groups for
++       organization and billing admins.
++    1. For the user who will run the procedures in this document, granted the
++       following roles:
++       -  The `roles/resourcemanager.organizationAdmin` role on the Google
++          Cloud organization.
++       -  The `roles/billing.admin` role on the billing account.
++       -  The `roles/resourcemanager.folderCreator` role.
++       -  The `roles/resourcemanager.projectCreator` role.
++
++    ## Deploying
++
++    1. Run `terraform init`.
++    1. Run `terraform plan` and review the output.
++    1. Run `terraform apply`.
++
++    ## Next steps
++
++    Once you have the basic foundation deployed, you should explore:
++    1. Building an [advanced foundation](https://github.com/terraform-google-modules/terraform-example-foundation) using the security blueprint
++    2. Automatically deploying Terraform with [Cloud Build](https://cloud.google.com/architecture/managing-infrastructure-as-code)
++  folders.tf: |
 +    resource "google_folder" "child-folder" {
 +      display_name = "child-folder"
 +      parent       = google_folder.parent-folder.name
@@ -21,6 +62,24 @@ index 0000000..71490e8
 +
 +    resource "google_folder" "parent-folder" {
 +      display_name = "parent folder"
-+      parent       = "organizations/123456789012"
++      parent       = "organizations/${var.org_id}"
 +    }
++  variables.tf: |
++    variable "org_id" {
++      description = "The organization id for the associated resources"
++      type        = string
++    }
++  versions.tf: |
++    terraform {
++      required_version = ">=0.13"
 +
++      required_providers {
++        google = {
++          source  = "hashicorp/google"
++          version = ">= 4.0.0"
++        }
++      }
++      provider_meta "google" {
++        module_name = "blueprints/terraform/exported-krm/v0.1.0"
++      }
++    }

--- a/examples/export-terraform-imperative/.expected/diff.patch
+++ b/examples/export-terraform-imperative/.expected/diff.patch
@@ -1,9 +1,9 @@
 diff --git a/terraform.yaml b/terraform.yaml
 new file mode 100644
-index 0000000..a421a26
+index 0000000..60fa1a3
 --- /dev/null
 +++ b/terraform.yaml
-@@ -0,0 +1,77 @@
+@@ -0,0 +1,78 @@
 +apiVersion: v1
 +kind: ConfigMap
 +metadata:
@@ -66,6 +66,7 @@ index 0000000..a421a26
 +    variable "org_id" {
 +      description = "The organization id for the associated resources"
 +      type        = string
++      default     = "123456789012"
 +    }
 +  versions.tf: |
 +    terraform {

--- a/examples/export-terraform-imperative/.expected/diff.patch
+++ b/examples/export-terraform-imperative/.expected/diff.patch
@@ -1,9 +1,9 @@
 diff --git a/terraform.yaml b/terraform.yaml
 new file mode 100644
-index 0000000..ae4cbb5
+index 0000000..a421a26
 --- /dev/null
 +++ b/terraform.yaml
-@@ -0,0 +1,79 @@
+@@ -0,0 +1,77 @@
 +apiVersion: v1
 +kind: ConfigMap
 +metadata:
@@ -23,25 +23,23 @@ index 0000000..ae4cbb5
 +
 +    ## Prerequisites
 +
-+    To run the commands described in this document, you need to have the following
-+    installed:
++    To run the commands described in this document, you need the following:
 +
-+    - The [Google Cloud SDK](https://cloud.google.com/sdk/install) version 319.0.0 or later
-+    - [Terraform](https://www.terraform.io/downloads.html) version 0.13.7 or later.
-+
++    1. Install the [Google Cloud SDK](https://cloud.google.com/sdk/install) version 319.0.0 or later
++    1. Install [Terraform](https://www.terraform.io/downloads.html) version 0.13.7 or later.
 +    1. Set up a Google Cloud
 +       [organization](https://cloud.google.com/resource-manager/docs/creating-managing-organization).
 +    1. Set up a Google Cloud
 +       [billing account](https://cloud.google.com/billing/docs/how-to/manage-billing-account).
-+    1. Created Cloud Identity or Google Workspace (formerly G Suite) groups for
-+       organization and billing admins.
-+    1. For the user who will run the procedures in this document, granted the
++    1. For the user who will run the Terraform install, grant the
 +       following roles:
++       -  The `roles/billing.admin` role on the billing account.
 +       -  The `roles/resourcemanager.organizationAdmin` role on the Google
 +          Cloud organization.
-+       -  The `roles/billing.admin` role on the billing account.
-+       -  The `roles/resourcemanager.folderCreator` role.
-+       -  The `roles/resourcemanager.projectCreator` role.
++       -  The `roles/resourcemanager.folderCreator` role on the Google
++          Cloud organization.
++       -  The `roles/resourcemanager.projectCreator` role on the Google
++          Cloud organization.
 +
 +    ## Deploying
 +

--- a/examples/export-terraform-imperative/.expected/results.yaml
+++ b/examples/export-terraform-imperative/.expected/results.yaml
@@ -5,7 +5,4 @@ metadata:
 exitCode: 0
 items:
   - image: gcr.io/kpt-fn/export-terraform:unstable
-    stderr: |-
-      found matching template for Folder/child-folder: true
-      found matching template for Folder/parent-folder: true
     exitCode: 0

--- a/functions/go/export-terraform/README.md
+++ b/functions/go/export-terraform/README.md
@@ -13,6 +13,11 @@ This function generates idiomatic Terraform configuration by parsing [Config Con
 Where appropriate, the generated Terraform references [Cloud Foundation Toolkit modules](https://g.co/dev/terraformfoundation).
 The goal is to make the generated output as close to possible as what a human would have written.
 
+The following KCC resources are supported:
+- Folder
+- Project
+- IAMPolicyMember
+
 The output Terraform will be saved to a `ConfigMap` in `terraform.yaml` at the root of the package.
 Each key in the `ConfigMap` corresponds to a different file which is part of the Terraform module.
 

--- a/functions/go/export-terraform/README.md
+++ b/functions/go/export-terraform/README.md
@@ -16,6 +16,8 @@ The goal is to make the generated output as close to possible as what a human wo
 The following KCC resources are supported:
 - Folder
 - Project
+- IAMPartialPolicy
+- IAMPolicy
 - IAMPolicyMember
 
 The output Terraform will be saved to a `ConfigMap` in `terraform.yaml` at the root of the package.

--- a/functions/go/export-terraform/metadata.yaml
+++ b/functions/go/export-terraform/metadata.yaml
@@ -21,6 +21,7 @@ tags:
 sourceURL: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/functions/go/export-terraform
 examplePackageURLs:
   - https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/examples/export-terraform-imperative
+  - https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/examples/export-terraform-advanced
 emails:
   - kpt-team@google.com
 license: Apache-2.0

--- a/functions/go/export-terraform/terraformgenerator/iam.go
+++ b/functions/go/export-terraform/terraformgenerator/iam.go
@@ -57,7 +57,7 @@ func (resource *terraformResource) GetIAMBindings() map[string]*iamBinding {
 			role := child.GetStringFromObject("spec", "role")
 			member := child.GetStringFromObject("spec", "member")
 			policy.addBinding(role, member)
-		case "IAMPartialPolicy":
+		case "IAMPartialPolicy", "IAMPolicy":
 			var bindings []iamBinding
 			found, err := child.Item.Get(&bindings, "spec", "bindings")
 			if !found || err != nil {

--- a/functions/go/export-terraform/terraformgenerator/iam.go
+++ b/functions/go/export-terraform/terraformgenerator/iam.go
@@ -1,0 +1,45 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package terraformgenerator
+
+type iamBinding struct {
+	Member   string
+	Role     string
+	resource *terraformResource
+}
+
+func (resource *terraformResource) HasIAMBindings() bool {
+	bindings := resource.GetIAMBindings()
+	return len(bindings) > 0
+}
+
+// Retrieve IAM bindings for a given resource
+func (resource *terraformResource) GetIAMBindings() map[string][]*iamBinding {
+	bindings := make(map[string][]*iamBinding)
+
+	for _, child := range resource.Children {
+		switch child.Kind {
+		case "IAMPolicyMember":
+			binding := &iamBinding{
+				Member:   child.GetStringFromObject("spec", "member"),
+				Role:     child.GetStringFromObject("spec", "role"),
+				resource: child,
+			}
+			bindings[binding.Role] = append(bindings[binding.Role], binding)
+		}
+	}
+
+	return bindings
+}

--- a/functions/go/export-terraform/terraformgenerator/resources.go
+++ b/functions/go/export-terraform/terraformgenerator/resources.go
@@ -262,7 +262,7 @@ func (ref *terraformResource) GetTerraformId(prefix ...bool) string {
 	usePrefix := !(len(prefix) > 0 && !prefix[0])
 	isOrg := ref.Kind == "Organization"
 
-	switch true {
+	switch {
 	case !usePrefix && hasVariable:
 		return fmt.Sprintf("var.%s", ref.variable.Name)
 	case !usePrefix && !hasVariable:
@@ -274,6 +274,6 @@ func (ref *terraformResource) GetTerraformId(prefix ...bool) string {
 	case hasVariable:
 		return fmt.Sprintf("\"folders/${var.%s}\"", ref.variable.Name)
 	default:
-		return fmt.Sprintf("\"folders/%s\"", ref.Name)
+		return fmt.Sprintf(`"folders/%s"`, ref.Name)
 	}
 }

--- a/functions/go/export-terraform/terraformgenerator/resources.go
+++ b/functions/go/export-terraform/terraformgenerator/resources.go
@@ -28,6 +28,10 @@ type terraformResources struct {
 	grouped   map[string][]*terraformResource
 }
 
+func (rs *terraformResources) GetVersion() string {
+	return "0.1.0"
+}
+
 func (rs *terraformResources) getResourceRef(kind string, name string, item *sdk.KubeObject) (*terraformResource, error) {
 	if rs.resources == nil {
 		rs.resources = map[string]*terraformResource{}

--- a/functions/go/export-terraform/terraformgenerator/resources.go
+++ b/functions/go/export-terraform/terraformgenerator/resources.go
@@ -212,7 +212,9 @@ func (resource *terraformResource) getParentRef(path ...string) (string, string,
 
 		kind := path.kind
 		if len(kind) <= 1 {
-			kind = resource.GetStringFromObject(append(path.path[0:len(path.path)-1], "kind")...)
+			// retrieve everything except the last element of the path, to find the Kind in a sibling node
+			refPath := path.path[0 : len(path.path)-1]
+			kind = resource.GetStringFromObject(append(refPath, "kind")...)
 		}
 
 		return kind, strings.TrimSpace(name), nil

--- a/functions/go/export-terraform/terraformgenerator/resources.go
+++ b/functions/go/export-terraform/terraformgenerator/resources.go
@@ -85,15 +85,15 @@ func (rs *terraformResources) getGrouped() map[string][]*terraformResource {
 }
 
 type terraformResource struct {
-	Name       string
-	Kind       string
-	Item       *sdk.KubeObject
-	Parent     *terraformResource
-	Children   []*terraformResource
-	isChild    bool
-	resources  *terraformResources
-	variable   *variable
-	References map[string]*terraformResource
+	Name       string                        // The name of the resource (from metadata.name)
+	Kind       string                        // The Kubernetes Kind of the resource
+	Item       *sdk.KubeObject               // The Kubernetes object for the resource, if it exists
+	Parent     *terraformResource            // The parent for the resource (ex. folder for project), if there is one
+	Children   []*terraformResource          // A list of any children underneath the resource
+	isChild    bool                          // Whether the resource has a valid hierarchical Parent or not
+	resources  *terraformResources           // A back-reference to the bundle of resources this resource is part of
+	variable   *variable                     // If this resource is defined by a variable, a reference to the associated variable
+	References map[string]*terraformResource // A map of resources this resource references, by the kind of reference
 }
 
 // Return if the resource itself should be created

--- a/functions/go/export-terraform/terraformgenerator/resources.go
+++ b/functions/go/export-terraform/terraformgenerator/resources.go
@@ -17,20 +17,130 @@ package terraformgenerator
 import (
 	"fmt"
 	"regexp"
+	"sort"
+	"strings"
 
 	sdk "github.com/GoogleContainerTools/kpt-functions-catalog/thirdparty/kyaml/fnsdk"
 )
 
-type terraformResource struct {
-	Name     string
-	Kind     string
-	Item     *sdk.KubeObject
-	Parent   *terraformResource
-	Children []*terraformResource
-	isChild  bool
+type terraformResources struct {
+	resources map[string]*terraformResource
+	grouped   map[string][]*terraformResource
 }
 
-func getDisplayName(ref *terraformResource) string {
+func (rs *terraformResources) getResourceRef(kind string, name string, item *sdk.KubeObject) (*terraformResource, error) {
+	if rs.resources == nil {
+		rs.resources = map[string]*terraformResource{}
+	}
+
+	key := fmt.Sprintf("%s/%s", kind, name)
+	resourceRef, found := rs.resources[key]
+	if !found {
+		resourceRef = &terraformResource{
+			Name:      name,
+			Kind:      kind,
+			resources: rs,
+		}
+		rs.resources[key] = resourceRef
+	}
+	if item != nil {
+		resourceRef.Item = item
+
+		// attach parents
+		parentKind, parentName, err := resourceRef.getParentRef()
+		if err != nil {
+			sdk.Logf("no parent reference found for %s, %v", item.Name(), err)
+			return nil, err
+		}
+
+		if parentKind != "" {
+			parentRef, err := rs.getResourceRef(parentKind, parentName, nil)
+			if err != nil {
+				return nil, err
+			}
+			parentRef.Children = append(parentRef.Children, resourceRef)
+			resourceRef.isChild = true
+			resourceRef.Parent = parentRef
+		}
+	}
+	return resourceRef, nil
+}
+
+func (rs *terraformResources) getGrouped() map[string][]*terraformResource {
+	if rs.grouped != nil {
+		return rs.grouped
+	}
+	// iterate over resources in a stable order
+	keys := make([]string, len(rs.resources))
+	i := 0
+	for k := range rs.resources {
+		keys[i] = k
+		i++
+	}
+	sort.Strings(keys)
+
+	rs.grouped = make(map[string][]*terraformResource)
+
+	for _, key := range keys {
+		resource := rs.resources[key]
+		rs.grouped[resource.Kind] = append(rs.grouped[resource.Kind], resource)
+	}
+
+	return rs.grouped
+}
+
+type terraformResource struct {
+	Name      string
+	Kind      string
+	Item      *sdk.KubeObject
+	Parent    *terraformResource
+	Children  []*terraformResource
+	isChild   bool
+	resources *terraformResources
+}
+
+// Return if the resource itself should be created
+func (resource *terraformResource) ShouldCreate() bool {
+	return resource.Item != nil
+}
+
+// Look up a referenced resource at a given path
+func (resource *terraformResource) GetStringFromObject(path ...string) string {
+	var ref string
+	found, err := resource.Item.Get(&ref, path...)
+	if err != nil || !found {
+		return ""
+	}
+	return ref
+}
+
+func (resource *terraformResource) getParentRef(path ...string) (string, string, error) {
+	paths := [][]string{
+		{"Folder", "spec", "folderRef", "name"},
+		{"Organization", "spec", "organizationRef", "external"},
+		{"Project", "metadata", "annotations", "cnrm.cloud.google.com/my-project"},
+		{"detect", "spec", "resourceRef", "external"},
+		{"detect", "spec", "resourceRef", "name"},
+	}
+
+	for _, path := range paths {
+		name := resource.GetStringFromObject(path[1:]...)
+		if name == "" {
+			continue
+		}
+
+		kind := path[0]
+		if kind == "detect" {
+			kind = resource.GetStringFromObject(append(path[1:len(path)-1], "kind")...)
+		}
+
+		return kind, strings.TrimSpace(name), nil
+	}
+
+	return "", "", nil
+}
+
+func (ref *terraformResource) GetDisplayName() string {
 	var displayName string
 	found, err := ref.Item.Get(&displayName, "spec", "displayName")
 	if err != nil || !found {
@@ -42,18 +152,34 @@ func getDisplayName(ref *terraformResource) string {
 
 var tfNameRegex = regexp.MustCompile(`[^a-zA-Z\d_-]`)
 
-func getResourceName(ref *terraformResource) string {
-	name := ref.Item.Name()
-	if name != "" {
-		name = tfNameRegex.ReplaceAllString(name, "-")
-		return name
+func (ref *terraformResource) GetResourceName() string {
+	// For real resources, use their name
+	if ref.ShouldCreate() {
+		name := ref.Name
+		if name != "" {
+			name = tfNameRegex.ReplaceAllString(name, "-")
+			return name
+		}
 	}
-	return "organization"
+
+	ofKind := ref.resources.getGrouped()[ref.Kind]
+	if len(ofKind) < 2 {
+		return strings.ToLower(ref.Kind)
+	}
+	for i, testResource := range ofKind {
+		if testResource.Name == ref.Name {
+			return fmt.Sprintf("%s-%d", strings.ToLower(ref.Kind), i+1)
+		}
+	}
+	return ""
 }
 
-func getTerraformId(ref *terraformResource) string {
+func (ref *terraformResource) GetTerraformId() string {
+	if ref.ShouldCreate() {
+		return fmt.Sprintf("google_folder.%s.name", ref.GetResourceName())
+	}
 	if ref.Kind == "Organization" {
 		return fmt.Sprintf("\"organizations/%s\"", ref.Name)
 	}
-	return fmt.Sprintf("google_folder.%s.name", getResourceName(ref))
+	return fmt.Sprintf("\"folders/%s\"", ref.Name)
 }

--- a/functions/go/export-terraform/terraformgenerator/resources.go
+++ b/functions/go/export-terraform/terraformgenerator/resources.go
@@ -135,6 +135,20 @@ func (resource *terraformResource) GetStringFromObject(path ...string) string {
 	return ref
 }
 
+// Return if the resource itself should be created
+func (resource *terraformResource) GetOrganization() *terraformResource {
+	if resource.Parent.Kind == "Organization" {
+		return resource.Parent
+	}
+	orgs := resource.resources.getGrouped()["Organization"]
+	if len(orgs) < 1 {
+		sdk.Logf("Failed to fetch organization for %s/%s", resource.Kind, resource.Name)
+		return nil
+	}
+
+	return orgs[0]
+}
+
 func (resource *terraformResource) getParentRef(path ...string) (string, string, error) {
 	paths := [][]string{
 		{"Folder", "spec", "folderRef", "name"},

--- a/functions/go/export-terraform/terraformgenerator/resources_test.go
+++ b/functions/go/export-terraform/terraformgenerator/resources_test.go
@@ -1,0 +1,29 @@
+package terraformgenerator
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	sdk "github.com/GoogleContainerTools/kpt-functions-catalog/thirdparty/kyaml/fnsdk"
+)
+
+func TestGetParentRef(t *testing.T) {
+	require := require.New(t)
+	contents, err := os.ReadFile(path.Join("../testdata/iam/input/folder_external.yaml"))
+	require.NoErrorf(err, "Loads test content")
+
+	item, err := sdk.ParseKubeObject(contents)
+	require.NoErrorf(err, "Parses test content")
+
+	resource := &terraformResource{
+		Item: item,
+	}
+
+	kind, name, err := resource.getParentRef()
+	require.NoErrorf(err, "Finds parent resource")
+	require.Equalf("Folder", kind, "kind to match")
+	require.Equalf("335620346181", name, "name to match")
+}

--- a/functions/go/export-terraform/terraformgenerator/templates/README.md
+++ b/functions/go/export-terraform/terraformgenerator/templates/README.md
@@ -1,0 +1,40 @@
+# Google Cloud Foundation Blueprint
+
+This directory contains Terraform configuration for a foundational environment on Google Cloud.
+
+It includes a subset of resources configured via the [setup checklist](https://cloud.google.com/docs/enterprise/setup-checklist)
+and is based on the [security foundations blueprint](https://cloud.google.com/architecture/security-foundations).
+
+## Prerequisites
+
+To run the commands described in this document, you need to have the following
+installed:
+
+- The [Google Cloud SDK](https://cloud.google.com/sdk/install) version 319.0.0 or later
+- [Terraform](https://www.terraform.io/downloads.html) version 0.13.7 or later.
+
+1. Set up a Google Cloud
+   [organization](https://cloud.google.com/resource-manager/docs/creating-managing-organization).
+1. Set up a Google Cloud
+   [billing account](https://cloud.google.com/billing/docs/how-to/manage-billing-account).
+1. Created Cloud Identity or Google Workspace (formerly G Suite) groups for
+   organization and billing admins.
+1. For the user who will run the procedures in this document, granted the
+   following roles:
+   -  The `roles/resourcemanager.organizationAdmin` role on the Google
+      Cloud organization.
+   -  The `roles/billing.admin` role on the billing account.
+   -  The `roles/resourcemanager.folderCreator` role.
+   -  The `roles/resourcemanager.projectCreator` role.
+
+## Deploying
+
+1. Run `terraform init`.
+1. Run `terraform plan` and review the output.
+1. Run `terraform apply`.
+
+## Next steps
+
+Once you have the basic foundation deployed, you should explore:
+1. Building an [advanced foundation](https://github.com/terraform-google-modules/terraform-example-foundation) using the security blueprint
+2. Automatically deploying Terraform with [Cloud Build](https://cloud.google.com/architecture/managing-infrastructure-as-code)

--- a/functions/go/export-terraform/terraformgenerator/templates/README.md
+++ b/functions/go/export-terraform/terraformgenerator/templates/README.md
@@ -7,25 +7,23 @@ and is based on the [security foundations blueprint](https://cloud.google.com/ar
 
 ## Prerequisites
 
-To run the commands described in this document, you need to have the following
-installed:
+To run the commands described in this document, you need the following:
 
-- The [Google Cloud SDK](https://cloud.google.com/sdk/install) version 319.0.0 or later
-- [Terraform](https://www.terraform.io/downloads.html) version 0.13.7 or later.
-
+1. Install the [Google Cloud SDK](https://cloud.google.com/sdk/install) version 319.0.0 or later
+1. Install [Terraform](https://www.terraform.io/downloads.html) version 0.13.7 or later.
 1. Set up a Google Cloud
    [organization](https://cloud.google.com/resource-manager/docs/creating-managing-organization).
 1. Set up a Google Cloud
    [billing account](https://cloud.google.com/billing/docs/how-to/manage-billing-account).
-1. Created Cloud Identity or Google Workspace (formerly G Suite) groups for
-   organization and billing admins.
-1. For the user who will run the procedures in this document, granted the
+1. For the user who will run the Terraform install, grant the
    following roles:
+   -  The `roles/billing.admin` role on the billing account.
    -  The `roles/resourcemanager.organizationAdmin` role on the Google
       Cloud organization.
-   -  The `roles/billing.admin` role on the billing account.
-   -  The `roles/resourcemanager.folderCreator` role.
-   -  The `roles/resourcemanager.projectCreator` role.
+   -  The `roles/resourcemanager.folderCreator` role on the Google
+      Cloud organization.
+   -  The `roles/resourcemanager.projectCreator` role on the Google
+      Cloud organization.
 
 ## Deploying
 

--- a/functions/go/export-terraform/terraformgenerator/templates/folder.tf
+++ b/functions/go/export-terraform/terraformgenerator/templates/folder.tf
@@ -1,5 +1,0 @@
-resource "google_folder" "{{ . | resourceName }}" {
-  display_name = "{{. | displayName}}"
-  parent       = {{.Parent | reference}}
-}
-

--- a/functions/go/export-terraform/terraformgenerator/templates/folders.tf
+++ b/functions/go/export-terraform/terraformgenerator/templates/folders.tf
@@ -1,0 +1,7 @@
+{{range $folder := .Folder}}{{ if $folder.ShouldCreate }}
+resource "google_folder" "{{ $folder.GetResourceName }}" {
+  display_name = "{{ $folder.GetDisplayName }}"
+  parent       = {{ $folder.Parent.GetTerraformId }}
+}
+{{end}}{{end}}
+

--- a/functions/go/export-terraform/terraformgenerator/templates/iam.tf
+++ b/functions/go/export-terraform/terraformgenerator/templates/iam.tf
@@ -1,14 +1,14 @@
-{{range $org := .Organization}}{{ if $org.HasIAMBindings }}
-module "{{ $org.GetResourceName }}-iam" {
+{{range $ref := .Organization}}{{ if $ref.HasIAMBindings }}
+module "{{ $ref.GetResourceName }}-iam" {
   source  = "terraform-google-modules/iam/google//modules/organizations_iam"
   version = "~> 7.4"
 
-  organizations = ["{{ $org.Name }}"]
+  organizations = ["{{ $ref.Name }}"]
 
   bindings = {
-    {{ range $role, $bindings := $org.GetIAMBindings }}
-    "{{ $role }}" = [{{ range $binding := $bindings }}
-      "{{ $binding.Member }}",{{ end }}
+    {{ range $role, $binding := $ref.GetIAMBindings }}
+    "{{ $role }}" = [{{ range $member := $binding.Members }}
+      "{{ $member.Member }}",{{ end }}
     ]
     {{ end }}
   }
@@ -22,9 +22,9 @@ module "{{ $ref.GetResourceName }}-iam" {
   folders = [{{ $ref.GetTerraformId }}]
 
   bindings = {
-    {{ range $role, $bindings := $ref.GetIAMBindings }}
-    "{{ $role }}" = [{{ range $binding := $bindings }}
-      "{{ $binding.Member }}",{{ end }}
+    {{ range $role, $binding := $ref.GetIAMBindings }}
+    "{{ $role }}" = [{{ range $member := $binding.Members }}
+      "{{ $member.Member }}",{{ end }}
     ]
     {{ end }}
   }

--- a/functions/go/export-terraform/terraformgenerator/templates/iam.tf
+++ b/functions/go/export-terraform/terraformgenerator/templates/iam.tf
@@ -1,0 +1,33 @@
+{{range $org := .Organization}}{{ if $org.HasIAMBindings }}
+module "{{ $org.GetResourceName }}-iam" {
+  source  = "terraform-google-modules/iam/google//modules/organizations_iam"
+  version = "~> 7.4"
+
+  organizations = ["{{ $org.Name }}"]
+
+  bindings = {
+    {{ range $role, $bindings := $org.GetIAMBindings }}
+    "{{ $role }}" = [{{ range $binding := $bindings }}
+      "{{ $binding.Member }}",{{ end }}
+    ]
+    {{ end }}
+  }
+}
+
+{{end}}{{end}}{{range $ref := .Folder}}{{ if $ref.HasIAMBindings }}
+module "{{ $ref.GetResourceName }}-iam" {
+  source  = "terraform-google-modules/iam/google//modules/folders_iam"
+  version = "~> 7.4"
+
+  folders = [{{ $ref.GetTerraformId }}]
+
+  bindings = {
+    {{ range $role, $bindings := $ref.GetIAMBindings }}
+    "{{ $role }}" = [{{ range $binding := $bindings }}
+      "{{ $binding.Member }}",{{ end }}
+    ]
+    {{ end }}
+  }
+}
+
+{{end}}{{end}}

--- a/functions/go/export-terraform/terraformgenerator/templates/projects.tf
+++ b/functions/go/export-terraform/terraformgenerator/templates/projects.tf
@@ -4,9 +4,9 @@ module "{{ $project.GetResourceName }}" {
   version = "~> 12.0"
 
   name       = "{{ $project.GetDisplayName }}"{{ if ne $project.GetDisplayName $project.GetResourceName }}
-  project_id = "{{ $project.GetResourceName }}"{{end}}{{if eq $project.Parent.Kind "Folder"}}
-  folder_id = {{ $project.Parent.GetTerraformId false }}{{end}}{{if eq $project.Parent.Kind "Organization"}}
-  org_id = {{ $project.Parent.GetTerraformId false }}{{end}}
+  project_id = "{{ $project.GetResourceName }}"{{end}}
+  org_id     = {{ $project.GetOrganization.GetTerraformId false }}{{if eq $project.Parent.Kind "Folder"}}
+  folder_id  = {{ $project.Parent.GetTerraformId false }}{{end}}
 
   billing_account = "{{ $project.GetStringFromObject "spec" "billingAccountRef" "external" }}"{{if $project.GetBool "metadata" "annotations" "cnrm.cloud.google.com/auto-create-network"}}
   auto_create_network = true{{end}}

--- a/functions/go/export-terraform/terraformgenerator/templates/projects.tf
+++ b/functions/go/export-terraform/terraformgenerator/templates/projects.tf
@@ -1,0 +1,15 @@
+{{range $project := .Project}}{{ if $project.ShouldCreate }}
+module "{{ $project.GetResourceName }}" {
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 12.0"
+
+  name       = "{{ $project.GetDisplayName }}"{{ if ne $project.GetDisplayName $project.GetResourceName }}
+  project_id = "{{ $project.GetResourceName }}"{{end}}{{if eq $project.Parent.Kind "Folder"}}
+  folder_id = {{ $project.Parent.GetTerraformId }}{{end}}{{if eq $project.Parent.Kind "Organization"}}
+  org_id = {{ $project.Parent.GetTerraformId }}{{end}}
+
+  billing_account = "{{ $project.GetStringFromObject "spec" "billingAccountRef" "external" }}"{{if $project.GetBool "metadata" "annotations" "cnrm.cloud.google.com/auto-create-network"}}
+  auto_create_network = true{{end}}
+}
+{{end}}{{end}}
+

--- a/functions/go/export-terraform/terraformgenerator/templates/projects.tf
+++ b/functions/go/export-terraform/terraformgenerator/templates/projects.tf
@@ -5,8 +5,8 @@ module "{{ $project.GetResourceName }}" {
 
   name       = "{{ $project.GetDisplayName }}"{{ if ne $project.GetDisplayName $project.GetResourceName }}
   project_id = "{{ $project.GetResourceName }}"{{end}}{{if eq $project.Parent.Kind "Folder"}}
-  folder_id = {{ $project.Parent.GetTerraformId }}{{end}}{{if eq $project.Parent.Kind "Organization"}}
-  org_id = {{ $project.Parent.GetTerraformId }}{{end}}
+  folder_id = {{ $project.Parent.GetTerraformId false }}{{end}}{{if eq $project.Parent.Kind "Organization"}}
+  org_id = {{ $project.Parent.GetTerraformId false }}{{end}}
 
   billing_account = "{{ $project.GetStringFromObject "spec" "billingAccountRef" "external" }}"{{if $project.GetBool "metadata" "annotations" "cnrm.cloud.google.com/auto-create-network"}}
   auto_create_network = true{{end}}

--- a/functions/go/export-terraform/terraformgenerator/templates/projects.tf
+++ b/functions/go/export-terraform/terraformgenerator/templates/projects.tf
@@ -8,7 +8,7 @@ module "{{ $project.GetResourceName }}" {
   org_id     = {{ $project.GetOrganization.GetTerraformId false }}{{if eq $project.Parent.Kind "Folder"}}
   folder_id  = {{ $project.Parent.GetTerraformId false }}{{end}}
 
-  billing_account = "{{ $project.GetStringFromObject "spec" "billingAccountRef" "external" }}"{{if $project.GetBool "metadata" "annotations" "cnrm.cloud.google.com/auto-create-network"}}
+  billing_account = {{ $project.References.BillingAccount.GetTerraformId false }}{{if $project.GetBool "metadata" "annotations" "cnrm.cloud.google.com/auto-create-network"}}
   auto_create_network = true{{end}}
 }
 {{end}}{{end}}

--- a/functions/go/export-terraform/terraformgenerator/templates/variables.tf
+++ b/functions/go/export-terraform/terraformgenerator/templates/variables.tf
@@ -2,5 +2,6 @@
 variable "org_id" {
   description = "{{ $variable.Description }}"
   type        = string
+  default     = "{{ $variable.Default }}"
 }
 {{end}}

--- a/functions/go/export-terraform/terraformgenerator/templates/variables.tf
+++ b/functions/go/export-terraform/terraformgenerator/templates/variables.tf
@@ -1,5 +1,5 @@
 {{range $variable := .Variables}}
-variable "org_id" {
+variable "{{ $variable.Name }}" {
   description = "{{ $variable.Description }}"
   type        = string
   default     = "{{ $variable.Default }}"

--- a/functions/go/export-terraform/terraformgenerator/templates/variables.tf
+++ b/functions/go/export-terraform/terraformgenerator/templates/variables.tf
@@ -1,0 +1,6 @@
+{{range $variable := .Variables}}
+variable "org_id" {
+  description = "{{ $variable.Description }}"
+  type        = string
+}
+{{end}}

--- a/functions/go/export-terraform/terraformgenerator/templates/versions.tf
+++ b/functions/go/export-terraform/terraformgenerator/templates/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">=0.13"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.0.0"
+    }
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/exported-krm/v{{ .GetVersion }}"
+  }
+}

--- a/functions/go/export-terraform/terraformgenerator/terraform.go
+++ b/functions/go/export-terraform/terraformgenerator/terraform.go
@@ -44,6 +44,10 @@ func (rs *terraformResources) getHCL() (map[string]string, error) {
 		if err != nil {
 			return nil, err
 		}
+		err = addFile(tmpl, "variables.tf", rs, data)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return data, nil

--- a/functions/go/export-terraform/terraformgenerator/terraform.go
+++ b/functions/go/export-terraform/terraformgenerator/terraform.go
@@ -27,8 +27,6 @@ func (rs *terraformResources) getHCL() (map[string]string, error) {
 
 	groupedResources := rs.getGrouped()
 
-	// fmt.Printf("resources: %v\n", groupedResources)
-
 	data := make(map[string]string)
 	resourceFiles := []string{"folders.tf", "iam.tf", "projects.tf"}
 	for _, file := range resourceFiles {
@@ -38,15 +36,14 @@ func (rs *terraformResources) getHCL() (map[string]string, error) {
 		}
 	}
 
-	// only add versions.tf if other files exist
+	// only add other files if resource files exist
+	metaFiles := []string{"README.md", "versions.tf", "variables.tf"}
 	if len(data) > 0 {
-		err = addFile(tmpl, "versions.tf", rs, data)
-		if err != nil {
-			return nil, err
-		}
-		err = addFile(tmpl, "variables.tf", rs, data)
-		if err != nil {
-			return nil, err
+		for _, file := range metaFiles {
+			err := addFile(tmpl, file, rs, data)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/functions/go/export-terraform/terraformgenerator/terraform.go
+++ b/functions/go/export-terraform/terraformgenerator/terraform.go
@@ -19,20 +19,7 @@ import (
 	"text/template"
 )
 
-type TerraformFile struct {
-	name string
-}
-
 func (rs *terraformResources) getHCL() (map[string]string, error) {
-	files := []*TerraformFile{
-		{
-			name: "folders.tf",
-		},
-		{
-			name: "iam.tf",
-		},
-	}
-
 	tmpl, err := template.New("").ParseFS(templates, "templates/*")
 	if err != nil {
 		return nil, err
@@ -43,8 +30,9 @@ func (rs *terraformResources) getHCL() (map[string]string, error) {
 	// fmt.Printf("resources: %v\n", groupedResources)
 
 	data := make(map[string]string)
-	for _, file := range files {
-		err := addFile(tmpl, file.name, groupedResources, data)
+	resourceFiles := []string{"folders.tf", "iam.tf", "projects.tf"}
+	for _, file := range resourceFiles {
+		err := addFile(tmpl, file, groupedResources, data)
 		if err != nil {
 			return nil, err
 		}

--- a/functions/go/export-terraform/terraformgenerator/terraform.go
+++ b/functions/go/export-terraform/terraformgenerator/terraform.go
@@ -15,73 +15,12 @@
 package terraformgenerator
 
 import (
-	"fmt"
-	"io"
-	"sort"
 	"strings"
 	"text/template"
-
-	sdk "github.com/GoogleContainerTools/kpt-functions-catalog/thirdparty/kyaml/fnsdk"
 )
-
-type terraformResources struct {
-	resources map[string]*terraformResource
-}
-
-func (rs *terraformResources) getResourceRef(kind string, name string, item *sdk.KubeObject) *terraformResource {
-	if rs.resources == nil {
-		rs.resources = map[string]*terraformResource{}
-	}
-
-	key := fmt.Sprintf("%s/%s", kind, name)
-	resourceRef, found := rs.resources[key]
-	if !found {
-		resourceRef = &terraformResource{
-			Name: name,
-			Kind: kind,
-		}
-		rs.resources[key] = resourceRef
-	}
-	if item != nil {
-		resourceRef.Item = item
-	}
-	return resourceRef
-}
-
-func getParentRef(item *sdk.KubeObject) (string, string, error) {
-	paths := [][]string{
-		{"Folder", "spec", "folderRef", "name"},
-		{"Organization", "spec", "organizationRef", "external"},
-		{"Project", "metadata", "annotations", "cnrm.cloud.google.com/my-project"},
-	}
-
-	var name string
-	for _, path := range paths {
-		found, err := item.Get(&name, path[1:]...)
-		if err != nil || !found {
-			continue
-		}
-
-		return path[0], strings.TrimSpace(name), nil
-	}
-
-	return "", "", fmt.Errorf("no parent reference found for %s", item.Name())
-}
-
-func appendTerraform(wr io.Writer, myRef *terraformResource, tmpl *template.Template) error {
-	if (myRef.Kind) == "Organization" {
-		return nil
-	}
-	err := tmpl.Execute(wr, myRef)
-	if err != nil {
-		return err
-	}
-	return nil
-}
 
 type TerraformFile struct {
 	name     string
-	kinds    map[string]bool
 	contents strings.Builder
 }
 
@@ -89,52 +28,42 @@ func (rs *terraformResources) getHCL() (map[string]string, error) {
 	files := []*TerraformFile{
 		{
 			name:     "folders.tf",
-			kinds:    map[string]bool{"Folder": true},
+			contents: strings.Builder{},
+		},
+		{
+			name:     "iam.tf",
 			contents: strings.Builder{},
 		},
 	}
 
-	tmpl, err := template.New("folder.tf").Funcs(template.FuncMap{
-		"displayName":  getDisplayName,
-		"resourceName": getResourceName,
-		"reference":    getTerraformId,
-	}).ParseFS(templates, "templates/folder.tf")
-
+	tmpl, err := template.New("").Funcs(template.FuncMap{
+		// "displayName":  getDisplayName,
+		// "resourceName": getResourceName,
+		// "reference":    getTerraformId,
+	}).ParseFS(templates, "templates/*")
 	if err != nil {
 		return nil, err
 	}
 
-	// iterate over resources in a stable oder
-	keys := make([]string, len(rs.resources))
-	i := 0
-	for k := range rs.resources {
-		keys[i] = k
-		i++
-	}
-	sort.Strings(keys)
+	groupedResources := rs.getGrouped()
 
-	for _, key := range keys {
-		resource := rs.resources[key]
-		if resource.Item == nil {
-			continue
-		}
-		for _, file := range files {
-			_, ok := file.kinds[resource.Kind]
-			sdk.Logf("found matching template for %s/%s: %t\n", resource.Kind, resource.Name, ok)
-			if ok {
-				err := appendTerraform(&(file.contents), resource, tmpl)
-				if err != nil {
-					return nil, err
-				}
-			}
-		}
-	}
+	// fmt.Printf("resources: %v\n", groupedResources)
 
 	data := make(map[string]string)
 	for _, file := range files {
-		if file.contents.Len() > 0 {
-			data[file.name] = file.contents.String()
+		wr := &(file.contents)
+		err := tmpl.ExecuteTemplate(wr, file.name, groupedResources)
+		if err != nil {
+			return nil, err
 		}
+
+		content := strings.TrimSpace(file.contents.String())
+
+		if len(content) < 1 {
+			continue
+		}
+
+		data[file.name] = content + "\n"
 	}
 
 	return data, nil

--- a/functions/go/export-terraform/terraformgenerator/terraform_generator.go
+++ b/functions/go/export-terraform/terraformgenerator/terraform_generator.go
@@ -51,6 +51,8 @@ func Processor(rl *sdk.ResourceList) error {
 		}
 	}
 
+	resources.makeVariables()
+
 	data, err := resources.getHCL()
 	if err != nil {
 		return err

--- a/functions/go/export-terraform/terraformgenerator/terraform_generator.go
+++ b/functions/go/export-terraform/terraformgenerator/terraform_generator.go
@@ -29,7 +29,12 @@ var templates embed.FS
 
 func Processor(rl *sdk.ResourceList) error {
 	var resources terraformResources
-	supportedKinds := map[string]bool{"Folder": true, "Organization": true, "IAMPolicyMember": true}
+	supportedKinds := map[string]bool{
+		"Folder":          true,
+		"Organization":    true,
+		"IAMPolicyMember": true,
+		"Project":         true,
+	}
 
 	for _, item := range rl.Items {
 		if !strings.Contains(item.APIVersion(), "cnrm.cloud.google.com") {

--- a/functions/go/export-terraform/terraformgenerator/terraform_generator.go
+++ b/functions/go/export-terraform/terraformgenerator/terraform_generator.go
@@ -34,6 +34,7 @@ func Processor(rl *sdk.ResourceList) error {
 		"Organization":     true,
 		"IAMPolicyMember":  true,
 		"IAMPartialPolicy": true,
+		"IAMPolicy":        true,
 		"Project":          true,
 	}
 

--- a/functions/go/export-terraform/terraformgenerator/terraform_generator.go
+++ b/functions/go/export-terraform/terraformgenerator/terraform_generator.go
@@ -30,10 +30,11 @@ var templates embed.FS
 func Processor(rl *sdk.ResourceList) error {
 	var resources terraformResources
 	supportedKinds := map[string]bool{
-		"Folder":          true,
-		"Organization":    true,
-		"IAMPolicyMember": true,
-		"Project":         true,
+		"Folder":           true,
+		"Organization":     true,
+		"IAMPolicyMember":  true,
+		"IAMPartialPolicy": true,
+		"Project":          true,
 	}
 
 	for _, item := range rl.Items {

--- a/functions/go/export-terraform/terraformgenerator/terraform_generator_test.go
+++ b/functions/go/export-terraform/terraformgenerator/terraform_generator_test.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	sdk "github.com/GoogleContainerTools/kpt-functions-catalog/thirdparty/kyaml/fnsdk"
@@ -136,18 +137,19 @@ func TestTerraformGeneration(t *testing.T) {
 }
 
 func getTerraformFromDir(sourceDir string) (map[string]string, error) {
-	files, err := ioutil.ReadDir(sourceDir)
+	files, err := filepath.Glob(path.Join(sourceDir, "*.tf"))
 	if err != nil {
 		return nil, err
 	}
 
 	data := make(map[string]string)
 	for _, file := range files {
-		contents, err := os.ReadFile(path.Join(sourceDir, file.Name()))
+		name := filepath.Base(file)
+		contents, err := os.ReadFile(path.Join(sourceDir, name))
 		if err != nil {
 			return nil, err
 		}
-		data[file.Name()] = string(contents)
+		data[name] = string(contents)
 	}
 
 	return data, nil

--- a/functions/go/export-terraform/terraformgenerator/terraform_generator_test.go
+++ b/functions/go/export-terraform/terraformgenerator/terraform_generator_test.go
@@ -17,6 +17,7 @@ package terraformgenerator
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path"
 	"testing"
 
@@ -29,17 +30,25 @@ const testDir = "testdata"
 
 type TerraformTest struct {
 	Name string
+	Mode string
 }
 
 var testCases = []TerraformTest{
 	{
 		Name: "team",
+		Mode: "yaml",
 	},
 	{
 		Name: "empty",
+		Mode: "yaml",
 	},
 	{
 		Name: "other_resources",
+		Mode: "yaml",
+	},
+	{
+		Name: "iam",
+		Mode: "terraform",
 	},
 }
 
@@ -48,25 +57,52 @@ func TestTerraformGeneration(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			require := require.New(t)
 			inDir := path.Join("..", testDir, tt.Name, "input")
-			outDir := path.Join("..", testDir, tt.Name, "output")
 
 			actualRL, err := testutil.ResourceListFromDirectory(inDir, "")
 			require.NoError(err)
+			var expectedRL *sdk.ResourceList
 
-			expectedRL, err := testutil.ResourceListFromDirectory(outDir, "")
-			require.NoError(err)
+			if tt.Mode == "terraform" {
+				outDir := path.Join("..", testDir, tt.Name, "tf")
+				expectedTerraformMap, err := getTerraformFromDir(outDir)
+				require.NoError(err)
 
-			// append input items to output
-			expectedRL.Items = append(expectedRL.Items, actualRL.Items...)
+				// build our output list from input
+				tempRL, err := testutil.ResourceListFromDirectory(inDir, "")
+				require.NoError(err)
+				tempRL.UpsertObjectToItems(makeConfigMap(expectedTerraformMap), nil, false)
+
+				// round-trip to disk to make sure all annotations are consistent
+				tmpDir, err := ioutil.TempDir("", "export-terraform-test-*")
+				defer os.RemoveAll(tmpDir)
+				require.NoError(err)
+				err = testutil.ResourceListToDirectory(tempRL, tmpDir)
+				require.NoError(err)
+
+				// gather final resource list from disk
+				expectedRL, err = testutil.ResourceListFromDirectory(tmpDir, "")
+				require.NoError(err)
+			} else {
+				outDir := path.Join("..", testDir, tt.Name, "output")
+				expectedRL, err = testutil.ResourceListFromDirectory(outDir, "")
+				require.NoError(err)
+
+				// append input items to output
+				expectedRL.Items = append(expectedRL.Items, actualRL.Items...)
+			}
 
 			err = Processor(actualRL)
 			require.NoError(err)
 
-			actualTerraform, err := findTerraform(actualRL)
-			require.NoError(err)
 			expectedTerraform, err := findTerraform(expectedRL)
 			require.NoError(err)
-			require.EqualValues(fmt.Sprint(expectedTerraform), fmt.Sprint(actualTerraform))
+			actualTerraform, err := findTerraform(actualRL)
+			require.NoError(err)
+			require.Lenf(actualTerraform, len(expectedTerraform), "Generated Terraform doesn't have required keys")
+			for key, expectedString := range expectedTerraform {
+				actualString := actualTerraform[key]
+				require.Equalf(expectedString, actualString, "Terraform config for %s must match", key)
+			}
 
 			// We convert the output ResourceList to individual resource files in the
 			// file system first.
@@ -97,6 +133,24 @@ func TestTerraformGeneration(t *testing.T) {
 			require.YAMLEqf(string(expectedYAML), string(tmpDirYAML), "output yaml doesn't match")
 		})
 	}
+}
+
+func getTerraformFromDir(sourceDir string) (map[string]string, error) {
+	files, err := ioutil.ReadDir(sourceDir)
+	if err != nil {
+		return nil, err
+	}
+
+	data := make(map[string]string)
+	for _, file := range files {
+		contents, err := os.ReadFile(path.Join(sourceDir, file.Name()))
+		if err != nil {
+			return nil, err
+		}
+		data[file.Name()] = string(contents)
+	}
+
+	return data, nil
 }
 
 func findTerraform(rl *sdk.ResourceList) (map[string]string, error) {

--- a/functions/go/export-terraform/terraformgenerator/terraform_generator_test.go
+++ b/functions/go/export-terraform/terraformgenerator/terraform_generator_test.go
@@ -71,7 +71,8 @@ func TestTerraformGeneration(t *testing.T) {
 				// build our output list from input
 				tempRL, err := testutil.ResourceListFromDirectory(inDir, "")
 				require.NoError(err)
-				tempRL.UpsertObjectToItems(makeConfigMap(expectedTerraformMap), nil, false)
+				err = tempRL.UpsertObjectToItems(makeConfigMap(expectedTerraformMap), nil, false)
+				require.NoError(err)
 
 				// round-trip to disk to make sure all annotations are consistent
 				tmpDir, err := ioutil.TempDir("", "export-terraform-test-*")

--- a/functions/go/export-terraform/terraformgenerator/terraform_generator_test.go
+++ b/functions/go/export-terraform/terraformgenerator/terraform_generator_test.go
@@ -142,6 +142,7 @@ func TestTerraformGeneration(t *testing.T) {
 
 func getTerraformFromDir(sourceDir string) (map[string]string, error) {
 	files, err := filepath.Glob(path.Join(sourceDir, "*.tf"))
+	files = append(files, "README.md")
 	if err != nil {
 		return nil, err
 	}

--- a/functions/go/export-terraform/terraformgenerator/terraform_generator_test.go
+++ b/functions/go/export-terraform/terraformgenerator/terraform_generator_test.go
@@ -51,6 +51,10 @@ var testCases = []TerraformTest{
 		Name: "iam",
 		Mode: "terraform",
 	},
+	{
+		Name: "projects",
+		Mode: "terraform",
+	},
 }
 
 func TestTerraformGeneration(t *testing.T) {
@@ -115,8 +119,7 @@ func TestTerraformGeneration(t *testing.T) {
 			// The workaround is that we read the resource files as a ResourceList and
 			// then compare this ResourceList with the expected ResourceList.
 			tmpDir, err := ioutil.TempDir("", "export-terraform-test-*")
-			fmt.Println(tmpDir)
-			//defer os.RemoveAll(tmpDir)
+			defer os.RemoveAll(tmpDir)
 			require.NoError(err)
 			err = testutil.ResourceListToDirectory(actualRL, tmpDir)
 			require.NoError(err)

--- a/functions/go/export-terraform/terraformgenerator/variables.go
+++ b/functions/go/export-terraform/terraformgenerator/variables.go
@@ -1,0 +1,40 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package terraformgenerator
+
+type variable struct {
+	Name        string
+	Description string
+	Default     string
+}
+
+// Find common values and make them into variables
+func (rs *terraformResources) makeVariables() {
+	rs.Variables = make(map[string]*variable)
+
+	resources := rs.getGrouped()
+
+	// If we have a single org, make it a variable
+	if len(resources["Organization"]) == 1 {
+		org := resources["Organization"][0]
+		orgVar := &variable{
+			Name:        "org_id",
+			Description: "The organization id for the associated resources",
+			Default:     org.Name,
+		}
+		rs.Variables["org_id"] = orgVar
+		org.variable = orgVar
+	}
+}

--- a/functions/go/export-terraform/testdata/iam/input/folder_authoritative.yaml
+++ b/functions/go/export-terraform/testdata/iam/input/folder_authoritative.yaml
@@ -1,0 +1,38 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Folder
+metadata:
+  name: authoritative
+  namespace: hierarchy
+spec:
+  organizationRef:
+    external: '11111111111'
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicy
+metadata:
+  name: authoritative-folder-policy
+  namespace: config-control
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Folder
+    name: authoritative
+    namespace: hierarchy
+  bindings:
+  - role: roles/viewer
+    members:
+    - member: group:gcp-another@example.com
+    - member: group:gcp-test@example.com

--- a/functions/go/export-terraform/testdata/iam/input/folder_external.yaml
+++ b/functions/go/export-terraform/testdata/iam/input/folder_external.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,18 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
 metadata:
-  name: terraform
-  annotations:
-    config.kubernetes.io/local-config: "true"
-    blueprints.cloud.google.com/syntax: "hcl"
-    blueprints.cloud.google.com/flavor: "terraform"
-data:
-  folders.tf: |+
-    resource "google_folder" "test" {
-      display_name = "Test Display"
-      parent       = "organizations/123456789012"
-    }
+  name: external-viewer
+  namespace: config-control
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Folder
+    external: "335620346181"
+  role: roles/viewer
+  member: group:gcp-developers@example.com

--- a/functions/go/export-terraform/testdata/iam/input/folder_ref.yaml
+++ b/functions/go/export-terraform/testdata/iam/input/folder_ref.yaml
@@ -34,3 +34,23 @@ spec:
     namespace: hierarchy
   role: roles/viewer
   member: group:gcp-developers@example.com
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPartialPolicy
+metadata:
+  name: folder-partial-policy
+  namespace: config-control
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Folder
+    name: test
+    namespace: hierarchy
+  bindings:
+  - role: roles/editor
+    members:
+    - member: group:gcp-developers@example.com
+  - role: roles/viewer
+    members:
+    - member: group:gcp-viewers@example.com
+    - member: group:gcp-devops@example.com

--- a/functions/go/export-terraform/testdata/iam/input/folder_ref.yaml
+++ b/functions/go/export-terraform/testdata/iam/input/folder_ref.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,18 +11,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Folder
 metadata:
-  name: terraform
-  annotations:
-    config.kubernetes.io/local-config: "true"
-    blueprints.cloud.google.com/syntax: "hcl"
-    blueprints.cloud.google.com/flavor: "terraform"
-data:
-  folders.tf: |+
-    resource "google_folder" "test" {
-      display_name = "Test Display"
-      parent       = "organizations/123456789012"
-    }
+  name: test
+  namespace: hierarchy
+spec:
+  displayName: Test Display
+  organizationRef:
+    external: '11111111111'
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: folder-viewer
+  namespace: config-control
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Folder
+    name: test
+    namespace: hierarchy
+  role: roles/viewer
+  member: group:gcp-developers@example.com

--- a/functions/go/export-terraform/testdata/iam/input/org.yaml
+++ b/functions/go/export-terraform/testdata/iam/input/org.yaml
@@ -1,0 +1,38 @@
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: gcp-organization-adminsorgpolicy-policyAdmin
+  namespace: config-control
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Organization
+    external: "11111111111"
+  role: roles/orgpolicy.policyAdmin
+  member: group:gcp-organization-admins@example.com
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: gcp-organization-adminsorgpolicy-editor
+  namespace: config-control
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Organization
+    external: "11111111111"
+  role: roles/editor
+  member: group:gcp-organization-admins@example.com
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: gcp-devs-editor
+  namespace: config-control
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Organization
+    external: "11111111111"
+  role: roles/editor
+  member: group:gcp-developers@example.com

--- a/functions/go/export-terraform/testdata/iam/tf/README.md
+++ b/functions/go/export-terraform/testdata/iam/tf/README.md
@@ -1,0 +1,40 @@
+# Google Cloud Foundation Blueprint
+
+This directory contains Terraform configuration for a foundational environment on Google Cloud.
+
+It includes a subset of resources configured via the [setup checklist](https://cloud.google.com/docs/enterprise/setup-checklist)
+and is based on the [security foundations blueprint](https://cloud.google.com/architecture/security-foundations).
+
+## Prerequisites
+
+To run the commands described in this document, you need to have the following
+installed:
+
+- The [Google Cloud SDK](https://cloud.google.com/sdk/install) version 319.0.0 or later
+- [Terraform](https://www.terraform.io/downloads.html) version 0.13.7 or later.
+
+1. Set up a Google Cloud
+   [organization](https://cloud.google.com/resource-manager/docs/creating-managing-organization).
+1. Set up a Google Cloud
+   [billing account](https://cloud.google.com/billing/docs/how-to/manage-billing-account).
+1. Created Cloud Identity or Google Workspace (formerly G Suite) groups for
+   organization and billing admins.
+1. For the user who will run the procedures in this document, granted the
+   following roles:
+   -  The `roles/resourcemanager.organizationAdmin` role on the Google
+      Cloud organization.
+   -  The `roles/billing.admin` role on the billing account.
+   -  The `roles/resourcemanager.folderCreator` role.
+   -  The `roles/resourcemanager.projectCreator` role.
+
+## Deploying
+
+1. Run `terraform init`.
+1. Run `terraform plan` and review the output.
+1. Run `terraform apply`.
+
+## Next steps
+
+Once you have the basic foundation deployed, you should explore:
+1. Building an [advanced foundation](https://github.com/terraform-google-modules/terraform-example-foundation) using the security blueprint
+2. Automatically deploying Terraform with [Cloud Build](https://cloud.google.com/architecture/managing-infrastructure-as-code)

--- a/functions/go/export-terraform/testdata/iam/tf/README.md
+++ b/functions/go/export-terraform/testdata/iam/tf/README.md
@@ -7,25 +7,23 @@ and is based on the [security foundations blueprint](https://cloud.google.com/ar
 
 ## Prerequisites
 
-To run the commands described in this document, you need to have the following
-installed:
+To run the commands described in this document, you need the following:
 
-- The [Google Cloud SDK](https://cloud.google.com/sdk/install) version 319.0.0 or later
-- [Terraform](https://www.terraform.io/downloads.html) version 0.13.7 or later.
-
+1. Install the [Google Cloud SDK](https://cloud.google.com/sdk/install) version 319.0.0 or later
+1. Install [Terraform](https://www.terraform.io/downloads.html) version 0.13.7 or later.
 1. Set up a Google Cloud
    [organization](https://cloud.google.com/resource-manager/docs/creating-managing-organization).
 1. Set up a Google Cloud
    [billing account](https://cloud.google.com/billing/docs/how-to/manage-billing-account).
-1. Created Cloud Identity or Google Workspace (formerly G Suite) groups for
-   organization and billing admins.
-1. For the user who will run the procedures in this document, granted the
+1. For the user who will run the Terraform install, grant the
    following roles:
+   -  The `roles/billing.admin` role on the billing account.
    -  The `roles/resourcemanager.organizationAdmin` role on the Google
       Cloud organization.
-   -  The `roles/billing.admin` role on the billing account.
-   -  The `roles/resourcemanager.folderCreator` role.
-   -  The `roles/resourcemanager.projectCreator` role.
+   -  The `roles/resourcemanager.folderCreator` role on the Google
+      Cloud organization.
+   -  The `roles/resourcemanager.projectCreator` role on the Google
+      Cloud organization.
 
 ## Deploying
 

--- a/functions/go/export-terraform/testdata/iam/tf/folders.tf
+++ b/functions/go/export-terraform/testdata/iam/tf/folders.tf
@@ -1,0 +1,4 @@
+resource "google_folder" "test" {
+  display_name = "Test Display"
+  parent       = "organizations/11111111111"
+}

--- a/functions/go/export-terraform/testdata/iam/tf/folders.tf
+++ b/functions/go/export-terraform/testdata/iam/tf/folders.tf
@@ -1,4 +1,4 @@
 resource "google_folder" "test" {
   display_name = "Test Display"
-  parent       = "organizations/11111111111"
+  parent       = "organizations/${var.org_id}"
 }

--- a/functions/go/export-terraform/testdata/iam/tf/folders.tf
+++ b/functions/go/export-terraform/testdata/iam/tf/folders.tf
@@ -1,3 +1,8 @@
+resource "google_folder" "authoritative" {
+  display_name = "authoritative"
+  parent       = "organizations/${var.org_id}"
+}
+
 resource "google_folder" "test" {
   display_name = "Test Display"
   parent       = "organizations/${var.org_id}"

--- a/functions/go/export-terraform/testdata/iam/tf/iam.tf
+++ b/functions/go/export-terraform/testdata/iam/tf/iam.tf
@@ -35,6 +35,23 @@ module "folder-1-iam" {
 }
 
 
+module "authoritative-iam" {
+  source  = "terraform-google-modules/iam/google//modules/folders_iam"
+  version = "~> 7.4"
+
+  folders = [google_folder.authoritative.name]
+
+  bindings = {
+    
+    "roles/viewer" = [
+      "group:gcp-another@example.com",
+      "group:gcp-test@example.com",
+    ]
+    
+  }
+}
+
+
 module "test-iam" {
   source  = "terraform-google-modules/iam/google//modules/folders_iam"
   version = "~> 7.4"

--- a/functions/go/export-terraform/testdata/iam/tf/iam.tf
+++ b/functions/go/export-terraform/testdata/iam/tf/iam.tf
@@ -43,8 +43,14 @@ module "test-iam" {
 
   bindings = {
     
+    "roles/editor" = [
+      "group:gcp-developers@example.com",
+    ]
+    
     "roles/viewer" = [
       "group:gcp-developers@example.com",
+      "group:gcp-viewers@example.com",
+      "group:gcp-devops@example.com",
     ]
     
   }

--- a/functions/go/export-terraform/testdata/iam/tf/iam.tf
+++ b/functions/go/export-terraform/testdata/iam/tf/iam.tf
@@ -1,0 +1,51 @@
+module "organization-iam" {
+  source  = "terraform-google-modules/iam/google//modules/organizations_iam"
+  version = "~> 7.4"
+
+  organizations = ["11111111111"]
+
+  bindings = {
+    
+    "roles/editor" = [
+      "group:gcp-organization-admins@example.com",
+      "group:gcp-developers@example.com",
+    ]
+    
+    "roles/orgpolicy.policyAdmin" = [
+      "group:gcp-organization-admins@example.com",
+    ]
+    
+  }
+}
+
+
+module "folder-1-iam" {
+  source  = "terraform-google-modules/iam/google//modules/folders_iam"
+  version = "~> 7.4"
+
+  folders = ["folders/335620346181"]
+
+  bindings = {
+    
+    "roles/viewer" = [
+      "group:gcp-developers@example.com",
+    ]
+    
+  }
+}
+
+
+module "test-iam" {
+  source  = "terraform-google-modules/iam/google//modules/folders_iam"
+  version = "~> 7.4"
+
+  folders = [google_folder.test.name]
+
+  bindings = {
+    
+    "roles/viewer" = [
+      "group:gcp-developers@example.com",
+    ]
+    
+  }
+}

--- a/functions/go/export-terraform/testdata/iam/tf/variables.tf
+++ b/functions/go/export-terraform/testdata/iam/tf/variables.tf
@@ -1,4 +1,5 @@
 variable "org_id" {
   description = "The organization id for the associated resources"
   type        = string
+  default     = "11111111111"
 }

--- a/functions/go/export-terraform/testdata/iam/tf/variables.tf
+++ b/functions/go/export-terraform/testdata/iam/tf/variables.tf
@@ -1,0 +1,4 @@
+variable "org_id" {
+  description = "The organization id for the associated resources"
+  type        = string
+}

--- a/functions/go/export-terraform/testdata/iam/tf/versions.tf
+++ b/functions/go/export-terraform/testdata/iam/tf/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">=0.13"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.0.0"
+    }
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/exported-krm/v0.1.0"
+  }
+}

--- a/functions/go/export-terraform/testdata/other_resources/input/bucket.yaml
+++ b/functions/go/export-terraform/testdata/other_resources/input/bucket.yaml
@@ -16,7 +16,7 @@ kind: StorageBucket
 metadata:
   name: ignored-bucket
   annotations:
-    cnrm.cloud.google.com/my-project: test-project
+    cnrm.cloud.google.com/project-id: test-project
 spec:
   location: us-central1
   storageClass: standard

--- a/functions/go/export-terraform/testdata/other_resources/output/terraform.yaml
+++ b/functions/go/export-terraform/testdata/other_resources/output/terraform.yaml
@@ -21,6 +21,47 @@ metadata:
     blueprints.cloud.google.com/syntax: "hcl"
     blueprints.cloud.google.com/flavor: "terraform"
 data:
+  README.md: |+
+    # Google Cloud Foundation Blueprint
+
+    This directory contains Terraform configuration for a foundational environment on Google Cloud.
+
+    It includes a subset of resources configured via the [setup checklist](https://cloud.google.com/docs/enterprise/setup-checklist)
+    and is based on the [security foundations blueprint](https://cloud.google.com/architecture/security-foundations).
+
+    ## Prerequisites
+
+    To run the commands described in this document, you need to have the following
+    installed:
+
+    - The [Google Cloud SDK](https://cloud.google.com/sdk/install) version 319.0.0 or later
+    - [Terraform](https://www.terraform.io/downloads.html) version 0.13.7 or later.
+
+    1. Set up a Google Cloud
+       [organization](https://cloud.google.com/resource-manager/docs/creating-managing-organization).
+    1. Set up a Google Cloud
+       [billing account](https://cloud.google.com/billing/docs/how-to/manage-billing-account).
+    1. Created Cloud Identity or Google Workspace (formerly G Suite) groups for
+       organization and billing admins.
+    1. For the user who will run the procedures in this document, granted the
+       following roles:
+       -  The `roles/resourcemanager.organizationAdmin` role on the Google
+          Cloud organization.
+       -  The `roles/billing.admin` role on the billing account.
+       -  The `roles/resourcemanager.folderCreator` role.
+       -  The `roles/resourcemanager.projectCreator` role.
+
+    ## Deploying
+
+    1. Run `terraform init`.
+    1. Run `terraform plan` and review the output.
+    1. Run `terraform apply`.
+
+    ## Next steps
+
+    Once you have the basic foundation deployed, you should explore:
+    1. Building an [advanced foundation](https://github.com/terraform-google-modules/terraform-example-foundation) using the security blueprint
+    2. Automatically deploying Terraform with [Cloud Build](https://cloud.google.com/architecture/managing-infrastructure-as-code)
   folders.tf: |+
     resource "google_folder" "test" {
       display_name = "Test Display"

--- a/functions/go/export-terraform/testdata/other_resources/output/terraform.yaml
+++ b/functions/go/export-terraform/testdata/other_resources/output/terraform.yaml
@@ -31,25 +31,23 @@ data:
 
     ## Prerequisites
 
-    To run the commands described in this document, you need to have the following
-    installed:
+    To run the commands described in this document, you need the following:
 
-    - The [Google Cloud SDK](https://cloud.google.com/sdk/install) version 319.0.0 or later
-    - [Terraform](https://www.terraform.io/downloads.html) version 0.13.7 or later.
-
+    1. Install the [Google Cloud SDK](https://cloud.google.com/sdk/install) version 319.0.0 or later
+    1. Install [Terraform](https://www.terraform.io/downloads.html) version 0.13.7 or later.
     1. Set up a Google Cloud
        [organization](https://cloud.google.com/resource-manager/docs/creating-managing-organization).
     1. Set up a Google Cloud
        [billing account](https://cloud.google.com/billing/docs/how-to/manage-billing-account).
-    1. Created Cloud Identity or Google Workspace (formerly G Suite) groups for
-       organization and billing admins.
-    1. For the user who will run the procedures in this document, granted the
+    1. For the user who will run the Terraform install, grant the
        following roles:
+       -  The `roles/billing.admin` role on the billing account.
        -  The `roles/resourcemanager.organizationAdmin` role on the Google
           Cloud organization.
-       -  The `roles/billing.admin` role on the billing account.
-       -  The `roles/resourcemanager.folderCreator` role.
-       -  The `roles/resourcemanager.projectCreator` role.
+       -  The `roles/resourcemanager.folderCreator` role on the Google
+          Cloud organization.
+       -  The `roles/resourcemanager.projectCreator` role on the Google
+          Cloud organization.
 
     ## Deploying
 

--- a/functions/go/export-terraform/testdata/other_resources/output/terraform.yaml
+++ b/functions/go/export-terraform/testdata/other_resources/output/terraform.yaml
@@ -26,3 +26,17 @@ data:
       display_name = "Test Display"
       parent       = "organizations/123456789012"
     }
+  versions.tf: |+
+    terraform {
+      required_version = ">=0.13"
+
+      required_providers {
+        google = {
+          source  = "hashicorp/google"
+          version = ">= 4.0.0"
+        }
+      }
+      provider_meta "google" {
+        module_name = "blueprints/terraform/exported-krm/v0.1.0"
+      }
+    }

--- a/functions/go/export-terraform/testdata/other_resources/output/terraform.yaml
+++ b/functions/go/export-terraform/testdata/other_resources/output/terraform.yaml
@@ -69,6 +69,7 @@ data:
     variable "org_id" {
       description = "The organization id for the associated resources"
       type        = string
+      default     = "123456789012"
     }
   versions.tf: |+
     terraform {

--- a/functions/go/export-terraform/testdata/other_resources/output/terraform.yaml
+++ b/functions/go/export-terraform/testdata/other_resources/output/terraform.yaml
@@ -24,7 +24,12 @@ data:
   folders.tf: |+
     resource "google_folder" "test" {
       display_name = "Test Display"
-      parent       = "organizations/123456789012"
+      parent       = "organizations/${var.org_id}"
+    }
+  variables.tf: |+
+    variable "org_id" {
+      description = "The organization id for the associated resources"
+      type        = string
     }
   versions.tf: |+
     terraform {

--- a/functions/go/export-terraform/testdata/projects/input/folder_ref.yaml
+++ b/functions/go/export-terraform/testdata/projects/input/folder_ref.yaml
@@ -19,4 +19,4 @@ metadata:
 spec:
   displayName: Test Display
   organizationRef:
-    external: '11111111111'
+    external: '123456789012'

--- a/functions/go/export-terraform/testdata/projects/input/folder_ref.yaml
+++ b/functions/go/export-terraform/testdata/projects/input/folder_ref.yaml
@@ -1,0 +1,22 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Folder
+metadata:
+  name: test
+  namespace: hierarchy
+spec:
+  displayName: Test Display
+  organizationRef:
+    external: '11111111111'

--- a/functions/go/export-terraform/testdata/projects/input/project_in_external.yaml
+++ b/functions/go/export-terraform/testdata/projects/input/project_in_external.yaml
@@ -1,0 +1,26 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Project
+metadata:
+  name: project-in-external
+  namespace: projects
+spec:
+  name: project-in-external
+  billingAccountRef:
+    external: AAAAAA-AAAAAA-AAAAAA
+  folderRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Folder
+    external: "335620346181"

--- a/functions/go/export-terraform/testdata/projects/input/project_in_folder.yaml
+++ b/functions/go/export-terraform/testdata/projects/input/project_in_folder.yaml
@@ -1,0 +1,27 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Project
+metadata:
+  name: project-in-folder
+  namespace: projects
+  annotations:
+    cnrm.cloud.google.com/auto-create-network: "false"
+spec:
+  name: project-name
+  billingAccountRef:
+    external: AAAAAA-AAAAAA-AAAAAA
+  folderRef:
+    name: test
+    namespace: hierarchy

--- a/functions/go/export-terraform/testdata/projects/input/project_in_org.yaml
+++ b/functions/go/export-terraform/testdata/projects/input/project_in_org.yaml
@@ -1,0 +1,26 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Project
+metadata:
+  name: project-in-org
+  namespace: projects
+  annotations:
+    cnrm.cloud.google.com/auto-create-network: "true"
+spec:
+  name: project-in-org
+  billingAccountRef:
+    external: AAAAAA-AAAAAA-AAAAAA
+  organizationRef:
+    external: '123456789012'

--- a/functions/go/export-terraform/testdata/projects/tf/README.md
+++ b/functions/go/export-terraform/testdata/projects/tf/README.md
@@ -1,0 +1,40 @@
+# Google Cloud Foundation Blueprint
+
+This directory contains Terraform configuration for a foundational environment on Google Cloud.
+
+It includes a subset of resources configured via the [setup checklist](https://cloud.google.com/docs/enterprise/setup-checklist)
+and is based on the [security foundations blueprint](https://cloud.google.com/architecture/security-foundations).
+
+## Prerequisites
+
+To run the commands described in this document, you need to have the following
+installed:
+
+- The [Google Cloud SDK](https://cloud.google.com/sdk/install) version 319.0.0 or later
+- [Terraform](https://www.terraform.io/downloads.html) version 0.13.7 or later.
+
+1. Set up a Google Cloud
+   [organization](https://cloud.google.com/resource-manager/docs/creating-managing-organization).
+1. Set up a Google Cloud
+   [billing account](https://cloud.google.com/billing/docs/how-to/manage-billing-account).
+1. Created Cloud Identity or Google Workspace (formerly G Suite) groups for
+   organization and billing admins.
+1. For the user who will run the procedures in this document, granted the
+   following roles:
+   -  The `roles/resourcemanager.organizationAdmin` role on the Google
+      Cloud organization.
+   -  The `roles/billing.admin` role on the billing account.
+   -  The `roles/resourcemanager.folderCreator` role.
+   -  The `roles/resourcemanager.projectCreator` role.
+
+## Deploying
+
+1. Run `terraform init`.
+1. Run `terraform plan` and review the output.
+1. Run `terraform apply`.
+
+## Next steps
+
+Once you have the basic foundation deployed, you should explore:
+1. Building an [advanced foundation](https://github.com/terraform-google-modules/terraform-example-foundation) using the security blueprint
+2. Automatically deploying Terraform with [Cloud Build](https://cloud.google.com/architecture/managing-infrastructure-as-code)

--- a/functions/go/export-terraform/testdata/projects/tf/README.md
+++ b/functions/go/export-terraform/testdata/projects/tf/README.md
@@ -7,25 +7,23 @@ and is based on the [security foundations blueprint](https://cloud.google.com/ar
 
 ## Prerequisites
 
-To run the commands described in this document, you need to have the following
-installed:
+To run the commands described in this document, you need the following:
 
-- The [Google Cloud SDK](https://cloud.google.com/sdk/install) version 319.0.0 or later
-- [Terraform](https://www.terraform.io/downloads.html) version 0.13.7 or later.
-
+1. Install the [Google Cloud SDK](https://cloud.google.com/sdk/install) version 319.0.0 or later
+1. Install [Terraform](https://www.terraform.io/downloads.html) version 0.13.7 or later.
 1. Set up a Google Cloud
    [organization](https://cloud.google.com/resource-manager/docs/creating-managing-organization).
 1. Set up a Google Cloud
    [billing account](https://cloud.google.com/billing/docs/how-to/manage-billing-account).
-1. Created Cloud Identity or Google Workspace (formerly G Suite) groups for
-   organization and billing admins.
-1. For the user who will run the procedures in this document, granted the
+1. For the user who will run the Terraform install, grant the
    following roles:
+   -  The `roles/billing.admin` role on the billing account.
    -  The `roles/resourcemanager.organizationAdmin` role on the Google
       Cloud organization.
-   -  The `roles/billing.admin` role on the billing account.
-   -  The `roles/resourcemanager.folderCreator` role.
-   -  The `roles/resourcemanager.projectCreator` role.
+   -  The `roles/resourcemanager.folderCreator` role on the Google
+      Cloud organization.
+   -  The `roles/resourcemanager.projectCreator` role on the Google
+      Cloud organization.
 
 ## Deploying
 

--- a/functions/go/export-terraform/testdata/projects/tf/folders.tf
+++ b/functions/go/export-terraform/testdata/projects/tf/folders.tf
@@ -1,0 +1,4 @@
+resource "google_folder" "test" {
+  display_name = "Test Display"
+  parent       = "organizations/11111111111"
+}

--- a/functions/go/export-terraform/testdata/projects/tf/folders.tf
+++ b/functions/go/export-terraform/testdata/projects/tf/folders.tf
@@ -1,4 +1,4 @@
 resource "google_folder" "test" {
   display_name = "Test Display"
-  parent       = "organizations/11111111111"
+  parent       = "organizations/${var.org_id}"
 }

--- a/functions/go/export-terraform/testdata/projects/tf/projects.tf
+++ b/functions/go/export-terraform/testdata/projects/tf/projects.tf
@@ -3,7 +3,7 @@ module "project-in-external" {
   version = "~> 12.0"
 
   name       = "project-in-external"
-  folder_id = "folders/335620346181"
+  folder_id = "335620346181"
 
   billing_account = "AAAAAA-AAAAAA-AAAAAA"
 }
@@ -24,7 +24,7 @@ module "project-in-org" {
   version = "~> 12.0"
 
   name       = "project-in-org"
-  org_id = "organizations/123456789012"
+  org_id = var.org_id
 
   billing_account = "AAAAAA-AAAAAA-AAAAAA"
   auto_create_network = true

--- a/functions/go/export-terraform/testdata/projects/tf/projects.tf
+++ b/functions/go/export-terraform/testdata/projects/tf/projects.tf
@@ -3,7 +3,8 @@ module "project-in-external" {
   version = "~> 12.0"
 
   name       = "project-in-external"
-  folder_id = "335620346181"
+  org_id     = var.org_id
+  folder_id  = "335620346181"
 
   billing_account = "AAAAAA-AAAAAA-AAAAAA"
 }
@@ -14,7 +15,8 @@ module "project-in-folder" {
 
   name       = "project-name"
   project_id = "project-in-folder"
-  folder_id = google_folder.test.name
+  org_id     = var.org_id
+  folder_id  = google_folder.test.name
 
   billing_account = "AAAAAA-AAAAAA-AAAAAA"
 }
@@ -24,7 +26,7 @@ module "project-in-org" {
   version = "~> 12.0"
 
   name       = "project-in-org"
-  org_id = var.org_id
+  org_id     = var.org_id
 
   billing_account = "AAAAAA-AAAAAA-AAAAAA"
   auto_create_network = true

--- a/functions/go/export-terraform/testdata/projects/tf/projects.tf
+++ b/functions/go/export-terraform/testdata/projects/tf/projects.tf
@@ -1,0 +1,31 @@
+module "project-in-external" {
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 12.0"
+
+  name       = "project-in-external"
+  folder_id = "folders/335620346181"
+
+  billing_account = "AAAAAA-AAAAAA-AAAAAA"
+}
+
+module "project-in-folder" {
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 12.0"
+
+  name       = "project-name"
+  project_id = "project-in-folder"
+  folder_id = google_folder.test.name
+
+  billing_account = "AAAAAA-AAAAAA-AAAAAA"
+}
+
+module "project-in-org" {
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 12.0"
+
+  name       = "project-in-org"
+  org_id = "organizations/123456789012"
+
+  billing_account = "AAAAAA-AAAAAA-AAAAAA"
+  auto_create_network = true
+}

--- a/functions/go/export-terraform/testdata/projects/tf/projects.tf
+++ b/functions/go/export-terraform/testdata/projects/tf/projects.tf
@@ -6,7 +6,7 @@ module "project-in-external" {
   org_id     = var.org_id
   folder_id  = "335620346181"
 
-  billing_account = "AAAAAA-AAAAAA-AAAAAA"
+  billing_account = var.billing_account
 }
 
 module "project-in-folder" {
@@ -18,7 +18,7 @@ module "project-in-folder" {
   org_id     = var.org_id
   folder_id  = google_folder.test.name
 
-  billing_account = "AAAAAA-AAAAAA-AAAAAA"
+  billing_account = var.billing_account
 }
 
 module "project-in-org" {
@@ -28,6 +28,6 @@ module "project-in-org" {
   name       = "project-in-org"
   org_id     = var.org_id
 
-  billing_account = "AAAAAA-AAAAAA-AAAAAA"
+  billing_account = var.billing_account
   auto_create_network = true
 }

--- a/functions/go/export-terraform/testdata/projects/tf/variables.tf
+++ b/functions/go/export-terraform/testdata/projects/tf/variables.tf
@@ -1,4 +1,5 @@
 variable "org_id" {
   description = "The organization id for the associated resources"
   type        = string
+  default     = "123456789012"
 }

--- a/functions/go/export-terraform/testdata/projects/tf/variables.tf
+++ b/functions/go/export-terraform/testdata/projects/tf/variables.tf
@@ -1,0 +1,4 @@
+variable "org_id" {
+  description = "The organization id for the associated resources"
+  type        = string
+}

--- a/functions/go/export-terraform/testdata/projects/tf/variables.tf
+++ b/functions/go/export-terraform/testdata/projects/tf/variables.tf
@@ -1,3 +1,9 @@
+variable "billing_account" {
+  description = "The ID of the billing account to associate projects with"
+  type        = string
+  default     = "AAAAAA-AAAAAA-AAAAAA"
+}
+
 variable "org_id" {
   description = "The organization id for the associated resources"
   type        = string

--- a/functions/go/export-terraform/testdata/projects/tf/versions.tf
+++ b/functions/go/export-terraform/testdata/projects/tf/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">=0.13"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.0.0"
+    }
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/exported-krm/v0.1.0"
+  }
+}

--- a/functions/go/export-terraform/testdata/team/output/terraform.yaml
+++ b/functions/go/export-terraform/testdata/team/output/terraform.yaml
@@ -21,6 +21,47 @@ metadata:
     blueprints.cloud.google.com/syntax: "hcl"
     blueprints.cloud.google.com/flavor: "terraform"
 data:
+  README.md: |+
+    # Google Cloud Foundation Blueprint
+
+    This directory contains Terraform configuration for a foundational environment on Google Cloud.
+
+    It includes a subset of resources configured via the [setup checklist](https://cloud.google.com/docs/enterprise/setup-checklist)
+    and is based on the [security foundations blueprint](https://cloud.google.com/architecture/security-foundations).
+
+    ## Prerequisites
+
+    To run the commands described in this document, you need to have the following
+    installed:
+
+    - The [Google Cloud SDK](https://cloud.google.com/sdk/install) version 319.0.0 or later
+    - [Terraform](https://www.terraform.io/downloads.html) version 0.13.7 or later.
+
+    1. Set up a Google Cloud
+       [organization](https://cloud.google.com/resource-manager/docs/creating-managing-organization).
+    1. Set up a Google Cloud
+       [billing account](https://cloud.google.com/billing/docs/how-to/manage-billing-account).
+    1. Created Cloud Identity or Google Workspace (formerly G Suite) groups for
+       organization and billing admins.
+    1. For the user who will run the procedures in this document, granted the
+       following roles:
+       -  The `roles/resourcemanager.organizationAdmin` role on the Google
+          Cloud organization.
+       -  The `roles/billing.admin` role on the billing account.
+       -  The `roles/resourcemanager.folderCreator` role.
+       -  The `roles/resourcemanager.projectCreator` role.
+
+    ## Deploying
+
+    1. Run `terraform init`.
+    1. Run `terraform plan` and review the output.
+    1. Run `terraform apply`.
+
+    ## Next steps
+
+    Once you have the basic foundation deployed, you should explore:
+    1. Building an [advanced foundation](https://github.com/terraform-google-modules/terraform-example-foundation) using the security blueprint
+    2. Automatically deploying Terraform with [Cloud Build](https://cloud.google.com/architecture/managing-infrastructure-as-code)
   folders.tf: |+
     resource "google_folder" "finance" {
       display_name = "finance"

--- a/functions/go/export-terraform/testdata/team/output/terraform.yaml
+++ b/functions/go/export-terraform/testdata/team/output/terraform.yaml
@@ -61,3 +61,17 @@ data:
       display_name = "retail.qa"
       parent       = google_folder.retail.name
     }
+  versions.tf: |+
+    terraform {
+      required_version = ">=0.13"
+
+      required_providers {
+        google = {
+          source  = "hashicorp/google"
+          version = ">= 4.0.0"
+        }
+      }
+      provider_meta "google" {
+        module_name = "blueprints/terraform/exported-krm/v0.1.0"
+      }
+    }

--- a/functions/go/export-terraform/testdata/team/output/terraform.yaml
+++ b/functions/go/export-terraform/testdata/team/output/terraform.yaml
@@ -31,25 +31,23 @@ data:
 
     ## Prerequisites
 
-    To run the commands described in this document, you need to have the following
-    installed:
+    To run the commands described in this document, you need the following:
 
-    - The [Google Cloud SDK](https://cloud.google.com/sdk/install) version 319.0.0 or later
-    - [Terraform](https://www.terraform.io/downloads.html) version 0.13.7 or later.
-
+    1. Install the [Google Cloud SDK](https://cloud.google.com/sdk/install) version 319.0.0 or later
+    1. Install [Terraform](https://www.terraform.io/downloads.html) version 0.13.7 or later.
     1. Set up a Google Cloud
        [organization](https://cloud.google.com/resource-manager/docs/creating-managing-organization).
     1. Set up a Google Cloud
        [billing account](https://cloud.google.com/billing/docs/how-to/manage-billing-account).
-    1. Created Cloud Identity or Google Workspace (formerly G Suite) groups for
-       organization and billing admins.
-    1. For the user who will run the procedures in this document, granted the
+    1. For the user who will run the Terraform install, grant the
        following roles:
+       -  The `roles/billing.admin` role on the billing account.
        -  The `roles/resourcemanager.organizationAdmin` role on the Google
           Cloud organization.
-       -  The `roles/billing.admin` role on the billing account.
-       -  The `roles/resourcemanager.folderCreator` role.
-       -  The `roles/resourcemanager.projectCreator` role.
+       -  The `roles/resourcemanager.folderCreator` role on the Google
+          Cloud organization.
+       -  The `roles/resourcemanager.projectCreator` role on the Google
+          Cloud organization.
 
     ## Deploying
 

--- a/functions/go/export-terraform/testdata/team/output/terraform.yaml
+++ b/functions/go/export-terraform/testdata/team/output/terraform.yaml
@@ -24,7 +24,7 @@ data:
   folders.tf: |+
     resource "google_folder" "finance" {
       display_name = "finance"
-      parent       = "organizations/123456789012"
+      parent       = "organizations/${var.org_id}"
     }
 
     resource "google_folder" "finance-dev" {
@@ -44,7 +44,7 @@ data:
 
     resource "google_folder" "retail" {
       display_name = "retail"
-      parent       = "organizations/123456789012"
+      parent       = "organizations/${var.org_id}"
     }
 
     resource "google_folder" "retail-dev" {
@@ -60,6 +60,11 @@ data:
     resource "google_folder" "retail-qa" {
       display_name = "retail.qa"
       parent       = google_folder.retail.name
+    }
+  variables.tf: |+
+    variable "org_id" {
+      description = "The organization id for the associated resources"
+      type        = string
     }
   versions.tf: |+
     terraform {

--- a/functions/go/export-terraform/testdata/team/output/terraform.yaml
+++ b/functions/go/export-terraform/testdata/team/output/terraform.yaml
@@ -61,4 +61,3 @@ data:
       display_name = "retail.qa"
       parent       = google_folder.retail.name
     }
-

--- a/functions/go/export-terraform/testdata/team/output/terraform.yaml
+++ b/functions/go/export-terraform/testdata/team/output/terraform.yaml
@@ -104,6 +104,7 @@ data:
     variable "org_id" {
       description = "The organization id for the associated resources"
       type        = string
+      default     = "123456789012"
     }
   versions.tf: |+
     terraform {


### PR DESCRIPTION
This makes a number of improvements to the export-terraform function for KCC resources:

1. Adds support for exporting projects and IAM bindings.
2. Adds attribution via a provider_meta block.
3. Generates variables for the org_id.
4. Includes a README in the generated output.