### PR TITLE
Verify docs kptfile patch version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ check-licenses:
 
 verify-docs:
 	GO111MODULE=on go get github.com/monopole/mdrip
+	(cd scripts/patch_reader/ && go build -o patch_reader .)
 	scripts/verify-docs.py
 
 build: ## Build all function images. Variable 'TAG' is used to specify tag. 'dev' will be used if not set.

--- a/scripts/patch_reader/go.mod
+++ b/scripts/patch_reader/go.mod
@@ -1,0 +1,5 @@
+module github.com/GoogleContainerTools/kpt-functions-catalog/scripts/patch_reader
+
+go 1.17
+
+require golang.org/x/mod v0.4.1

--- a/scripts/patch_reader/go.sum
+++ b/scripts/patch_reader/go.sum
@@ -1,0 +1,13 @@
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/mod v0.4.1 h1:Kvvh58BN8Y9/lBi7hTekvtMpm07eUZ0ck5pRHpsMWrY=
+golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/scripts/patch_reader/main.go
+++ b/scripts/patch_reader/main.go
@@ -1,0 +1,78 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/GoogleContainerTools/kpt-functions-catalog/scripts/patch_reader/pkg/latestpatch"
+)
+
+func exitWithErr(err error) {
+	fmt.Fprintf(os.Stderr, "%v\n", err)
+	os.Exit(1)
+}
+
+type arguments struct {
+	FunctionName string
+	MinorVersion string
+}
+
+// validate command line arguments
+func (a arguments) validate() error {
+	if a.FunctionName == "" {
+		return fmt.Errorf("function name not set")
+	}
+	if a.MinorVersion == "" {
+		return fmt.Errorf("minor version not set")
+	}
+	return nil
+}
+
+// parse command line arguments
+func parseArgs() (arguments, error) {
+	args := arguments{}
+	flag.StringVar(&args.FunctionName, "function", os.Getenv("FUNCTION_NAME"),
+		"function name (can also use FUNCTION_NAME environment variable)")
+	flag.StringVar(&args.MinorVersion, "minor", os.Getenv("MINOR_VERSION"),
+		"minor version (can also use MINOR_VERSION environment variable)")
+
+	flag.Parse()
+
+	err := args.validate()
+	if err != nil {
+		flag.Usage()
+	}
+	return args, err
+}
+
+func main() {
+	var err error
+	args, err := parseArgs()
+	if err != nil {
+		exitWithErr(err)
+	}
+	patch, err := latestpatch.GetLatestPatch(args.FunctionName, args.MinorVersion)
+	if err != nil {
+		exitWithErr(err)
+	}
+	output, err := json.Marshal(patch)
+	if err != nil {
+		exitWithErr(err)
+	}
+	fmt.Printf("%s", output)
+}

--- a/scripts/patch_reader/pkg/latestpatch/latestpatch.go
+++ b/scripts/patch_reader/pkg/latestpatch/latestpatch.go
@@ -1,0 +1,79 @@
+// Package latestpatch Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package latestpatch
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"golang.org/x/mod/semver"
+)
+
+var (
+	// pattern of release tags, e.g. functions/go/apply-setters/v1.0.1
+	releaseTagPattern = regexp.MustCompile(`.*(go|ts)/[-\w]*/(v\d*\.\d*\.\d*)`)
+)
+
+func runCmd(name string, arg ...string) (string, error) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd := exec.Command(name, arg...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return stdout.String(), fmt.Errorf("%s\n%s", stderr.String(), err)
+	}
+	return stdout.String(), err
+}
+
+type PatchVersion struct {
+	LatestPatch string `json:"latest_patch"`
+	Lang        string `json:"lang"`
+}
+
+func GetLatestPatch(functionName string, minorVersion string) (PatchVersion, error) {
+	tags, err := gitTag()
+	if err != nil {
+		return PatchVersion{}, err
+	}
+	funcPattern := fmt.Sprintf("%s/%s", functionName, minorVersion)
+	var lang, latestPatchVersion string
+	for _, tag := range strings.Split(tags, "\n") {
+		if !strings.Contains(tag, funcPattern) || !releaseTagPattern.MatchString(tag) {
+			continue
+		}
+		segments := strings.Split(tag, "/")
+		patchVersion := segments[len(segments)-1]
+		if latestPatchVersion == "" ||
+				semver.Compare(patchVersion, latestPatchVersion) == 1 {
+			latestPatchVersion = patchVersion
+			lang = segments[len(segments)-3]
+		}
+	}
+	if latestPatchVersion == "" || lang == "" {
+		return PatchVersion{}, fmt.Errorf("could not find matching tag for release branch")
+	}
+	return PatchVersion{
+		LatestPatch: latestPatchVersion,
+		Lang:        lang,
+	}, nil
+}
+
+func gitTag() (string, error) {
+	return runCmd("git", "tag")
+}

--- a/scripts/update_function_docs/function_release.go
+++ b/scripts/update_function_docs/function_release.go
@@ -21,15 +21,13 @@ import (
 	"regexp"
 	"strings"
 
-	"golang.org/x/mod/semver"
+	"github.com/GoogleContainerTools/kpt-functions-catalog/scripts/patch_reader/pkg/latestpatch"
 	"gopkg.in/yaml.v2"
 )
 
 var (
 	// pattern of release branches, e.g. apply-setters/v1.0
 	releaseBranchPattern = regexp.MustCompile(`[-\w]*/(v\d*\.\d*)`)
-	// pattern of release tags, e.g. functions/go/apply-setters/v1.0.1
-	releaseTagPattern = regexp.MustCompile(`.*(go|ts)/[-\w]*/(v\d*\.\d*\.\d*)`)
 	// pattern for version tags, e.g. unstable, v0.1.1, v0.1
 	versionGroup = `unstable|v\d*\.\d*\.\d*|v\d*\.\d*`
 )
@@ -98,29 +96,12 @@ func (fr *functionRelease) readLatestPatchVersion() error {
 	if fr.FunctionName == "" || fr.MinorVersion == "" {
 		return fmt.Errorf("missing function name and/or minor version")
 	}
-	tags, err := gitTag()
+	patch, err := latestpatch.GetLatestPatch(fr.FunctionName, fr.MinorVersion)
 	if err != nil {
 		return err
 	}
-	funcPattern := fmt.Sprintf("%s/%s", fr.FunctionName, fr.MinorVersion)
-	var lang, latestPatchVersion string
-	for _, tag := range strings.Split(tags, "\n") {
-		if !strings.Contains(tag, funcPattern) || !releaseTagPattern.MatchString(tag) {
-			continue
-		}
-		segments := strings.Split(tag, "/")
-		patchVersion := segments[len(segments)-1]
-		if latestPatchVersion == "" ||
-			semver.Compare(patchVersion, latestPatchVersion) == 1 {
-			latestPatchVersion = patchVersion
-			lang = segments[len(segments)-3]
-		}
-	}
-	if latestPatchVersion == "" || lang == "" {
-		return fmt.Errorf("could not find matching tag for release branch")
-	}
-	fr.Language = lang
-	fr.LatestPatchVersion = latestPatchVersion
+	fr.Language = patch.Lang
+	fr.LatestPatchVersion = patch.LatestPatch
 	return nil
 }
 

--- a/scripts/update_function_docs/go.mod
+++ b/scripts/update_function_docs/go.mod
@@ -3,6 +3,10 @@ module github.com/GoogleContainerTools/kpt-functions-catalog
 go 1.17
 
 require (
-	golang.org/x/mod v0.4.1
+	github.com/GoogleContainerTools/kpt-functions-catalog/scripts/patch_reader v0.0.0
 	gopkg.in/yaml.v2 v2.4.0
 )
+
+require golang.org/x/mod v0.4.1 // indirect
+
+replace github.com/GoogleContainerTools/kpt-functions-catalog/scripts/patch_reader v0.0.0 => ../patch_reader


### PR DESCRIPTION
Updates the verify-docs script to use the patch version for the Kptfile example checks.

The update_function_docs script currently sets the function tag in the Kptfile to the latest patch version, which is the expected behavior. This Kptfile check in verify-docs needs to be updated to allow the expected behavior to pass in CI.

The logic for parsing the latest patch version is moved to an independent module so that it can be reused by other scripts. A small CLI is added so that it can also be invoked by the verify-docs python script.