### PR TITLE
ci: fetch tags before getting latest patch version

### DIFF
--- a/scripts/patch_reader/pkg/latestpatch/latestpatch.go
+++ b/scripts/patch_reader/pkg/latestpatch/latestpatch.go
@@ -47,6 +47,9 @@ type PatchVersion struct {
 }
 
 func GetLatestPatch(functionName string, minorVersion string) (PatchVersion, error) {
+	if err := gitFetch(); err != nil {
+		return PatchVersion{}, err
+	}
 	tags, err := gitTag()
 	if err != nil {
 		return PatchVersion{}, err
@@ -72,6 +75,11 @@ func GetLatestPatch(functionName string, minorVersion string) (PatchVersion, err
 		LatestPatch: latestPatchVersion,
 		Lang:        lang,
 	}, nil
+}
+
+func gitFetch() error {
+	_, err := runCmd("git", "fetch", "--tags")
+	return err
 }
 
 func gitTag() (string, error) {

--- a/scripts/update_function_docs/git.go
+++ b/scripts/update_function_docs/git.go
@@ -51,10 +51,6 @@ func gitCheckout(branch string) error {
 	return err
 }
 
-func gitTag() (string, error) {
-	return runCmd("git", "tag")
-}
-
 func gitAdd() error {
 	_, err := runCmd("git", "add", "-u")
 	return err


### PR DESCRIPTION
This change ensures the tags are fetched before parsing the list of
tags. This is needed because the tags are not currently fetched by the
verify-docs github action.