### PR TITLE
fix: update-function-docs contrib sourceURL

### DIFF
--- a/scripts/update_function_docs/function_release.go
+++ b/scripts/update_function_docs/function_release.go
@@ -284,8 +284,12 @@ func (fr *functionRelease) replaceKptPackages(contents []byte) []byte {
 // https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-namespace/v0.2/examples/set-namespace-simple
 func (fr *functionRelease) replaceGithubURLs(contents []byte) []byte {
 	exampleSubPath := fr.exampleSubPath()
+	sourceUrlSuffix := fmt.Sprintf(`/functions/%s/%s`, fr.Language, fr.FunctionName)
+	if fr.IsContrib {
+		sourceUrlSuffix = fmt.Sprintf(`/contrib/functions/%s/%s`, fr.Language, fr.FunctionName)
+	}
 	suffixes := []string{
-		fmt.Sprintf(`/functions/%s/%s`, fr.Language, fr.FunctionName),
+		sourceUrlSuffix,
 	}
 	for _, ex := range fr.Examples.exampleNames() {
 		suffixes = append(suffixes, fmt.Sprintf(`/%s/%s`, exampleSubPath, ex))


### PR DESCRIPTION
This change fixes the update-function-docs script to properly update the
sourceUrl field in the metadata.yaml file. This is done by using the
appropriate suffix for sourceUrl depending on whether it is a contrib
function.