### PR TITLE
fix: use default value for build args

### DIFF
--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -51,10 +51,11 @@ function docker_build {
   [[ -f "${override_dockerfile}" ]] && dockerfile="${override_dockerfile}"
   [[ -f "${dockerfile}" ]] || err "Dockerfile does not exist: ${dockerfile}"
 
+  # Use + conditional parameter expansion to protect from unbound array variable
   docker build \
     -t "${GCR_REGISTRY}/${name}:${UNSTABLE_TAG}" \
     -f "${dockerfile}" \
-    "${build_args[@]}" \
+    "${build_args[@]+"${build_args[@]}"}" \
     "${function_dir}"
 }
 


### PR DESCRIPTION
On some versions of bash an error was being thrown due to the build_args
being interpreted as an unbound variable. This change adds a default
empty string value to the variable expansion so that this error does not
occur.

Issues: GoogleContainerTools/kpt#2902