### PR TITLE
fix: Skip clusterless resources in exported Terraform

### DIFF
--- a/functions/go/export-terraform/README.md
+++ b/functions/go/export-terraform/README.md
@@ -40,6 +40,21 @@ data:
     }
 ```
 
+### Skipping Resources
+Any resource annotated with `cnrm.cloud.google.com/ignore-clusterless: "true"` will be excluded from the export.
+
+### Attribution
+The exported Terraform configuration will include a `provider_meta` block for attributing it back to this function.
+If you want to prevent attributing the configuration to this function, you should delete this block.
+
+```
+terraform {
+  provider_meta "google" {
+    module_name = "blueprints/terraform/exported-krm/v0.1.0"
+  }
+}
+```
+
 <!--mdtogo:Long-->
 
 ## Usage

--- a/functions/go/export-terraform/terraformgenerator/terraform_generator.go
+++ b/functions/go/export-terraform/terraformgenerator/terraform_generator.go
@@ -27,6 +27,11 @@ import (
 //go:embed templates
 var templates embed.FS
 
+const (
+	kccAPI         = "cnrm.cloud.google.com"
+	skipAnnotation = "cnrm.cloud.google.com/ignore-clusterless"
+)
+
 func Processor(rl *sdk.ResourceList) error {
 	var resources terraformResources
 	supportedKinds := map[string]bool{
@@ -39,7 +44,12 @@ func Processor(rl *sdk.ResourceList) error {
 	}
 
 	for _, item := range rl.Items {
-		if !strings.Contains(item.APIVersion(), "cnrm.cloud.google.com") {
+		if !strings.Contains(item.APIVersion(), kccAPI) {
+			continue
+		}
+
+		shouldSkip := item.Annotation(skipAnnotation)
+		if shouldSkip == "true" {
 			continue
 		}
 

--- a/functions/go/export-terraform/testdata/iam/input/folder_ignored.yaml
+++ b/functions/go/export-terraform/testdata/iam/input/folder_ignored.yaml
@@ -14,12 +14,14 @@
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
-  name: external-viewer
+  name: ignored-resource
   namespace: config-control
+  annotations:
+    cnrm.cloud.google.com/ignore-clusterless: "true"
 spec:
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Folder
     external: "335620346181"
   role: roles/viewer
-  member: group:gcp-developers@example.com
+  member: group:missing-group@example.com


### PR DESCRIPTION
Since Terraform is a clusterless service, the exported config should exclude any resources which are specific to Config Controller.

Context: b/225041968