### PR TITLE
[apply-replacements] return all function errors

### DIFF
--- a/functions/go/apply-replacements/go.mod
+++ b/functions/go/apply-replacements/go.mod
@@ -3,7 +3,7 @@ module github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/apply-
 go 1.17
 
 require (
-	github.com/GoogleContainerTools/kpt-functions-sdk/go/fn v0.0.0-20220316202203-f9115a993ebd
+	github.com/GoogleContainerTools/kpt-functions-sdk/go/fn v0.0.0-20220329070820-f687d1b931e6
 	sigs.k8s.io/kustomize/api v0.10.1
 	sigs.k8s.io/kustomize/kyaml v0.13.3
 )
@@ -13,6 +13,7 @@ require (
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
+	github.com/go-logr/logr v1.2.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.6 // indirect
 	github.com/go-openapi/swag v0.21.1 // indirect
@@ -28,6 +29,7 @@ require (
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/klog/v2 v2.30.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/functions/go/apply-replacements/go.sum
+++ b/functions/go/apply-replacements/go.sum
@@ -39,8 +39,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/GoogleContainerTools/kpt-functions-sdk/go/fn v0.0.0-20220316202203-f9115a993ebd h1:PzlNXoJTvlzct3n2hw3gmM6C9S/W4wmeaA3qqkM4TTQ=
-github.com/GoogleContainerTools/kpt-functions-sdk/go/fn v0.0.0-20220316202203-f9115a993ebd/go.mod h1:hENpuHQH/bIfHUCuG4hvzb5i4doJ1KTId5EdWBg6AvU=
+github.com/GoogleContainerTools/kpt-functions-sdk/go/fn v0.0.0-20220329070820-f687d1b931e6 h1:GfRyfQP2t0GuVozqJAHYX0rbf/ytUDvIuveMNEDMCPE=
+github.com/GoogleContainerTools/kpt-functions-sdk/go/fn v0.0.0-20220329070820-f687d1b931e6/go.mod h1:hENpuHQH/bIfHUCuG4hvzb5i4doJ1KTId5EdWBg6AvU=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=

--- a/functions/go/apply-replacements/replacements/replacements.go
+++ b/functions/go/apply-replacements/replacements/replacements.go
@@ -2,7 +2,6 @@ package replacements
 
 import (
 	"fmt"
-
 	"github.com/GoogleContainerTools/kpt-functions-sdk/go/fn"
 	"sigs.k8s.io/kustomize/api/filters/replacement"
 	"sigs.k8s.io/kustomize/api/types"
@@ -24,7 +23,7 @@ type Replacements struct {
 // Config initializes Replacements from a functionConfig fn.KubeObject
 func (r *Replacements) Config(functionConfig *fn.KubeObject) error {
 	if functionConfig.GetKind() != fnConfigKind || functionConfig.GetAPIVersion() != fnConfigApiVersion {
-		return fmt.Errorf("received functionConfig of kind %s and apiVersion %s, " +
+		return fmt.Errorf("received functionConfig of kind %s and apiVersion %s, "+
 			"only functionConfig of kind %s and apiVersion %s is supported",
 			functionConfig.GetKind(), functionConfig.GetAPIVersion(), fnConfigKind, fnConfigApiVersion)
 	}
@@ -43,11 +42,7 @@ func (r *Replacements) Process(rl *fn.ResourceList) error {
 	}
 	transformedItems, err := r.Transform(rl.Items)
 	if err != nil {
-		rl.Results = append(rl.Results, &fn.Result{
-			Message: err.Error(),
-			Severity: fn.Error,
-		})
-		return nil
+		return err
 	}
 	rl.Items = transformedItems
 	return nil
@@ -67,7 +62,7 @@ func (r *Replacements) Transform(items []*fn.KubeObject) ([]*fn.KubeObject, erro
 		nodes = append(nodes, objRN)
 	}
 	transformedNodes, err := replacement.Filter{
-		Replacements:  r.Replacements,
+		Replacements: r.Replacements,
 	}.Filter(nodes)
 	if err != nil {
 		return nil, err

--- a/functions/go/apply-replacements/replacements/replacements.go
+++ b/functions/go/apply-replacements/replacements/replacements.go
@@ -2,6 +2,7 @@ package replacements
 
 import (
 	"fmt"
+
 	"github.com/GoogleContainerTools/kpt-functions-sdk/go/fn"
 	"sigs.k8s.io/kustomize/api/filters/replacement"
 	"sigs.k8s.io/kustomize/api/types"
@@ -11,7 +12,7 @@ import (
 const fnConfigKind = "ApplyReplacements"
 const fnConfigApiVersion = "fn.kpt.dev/v1alpha1"
 
-func ApplyReplacements(rl *fn.ResourceList) error {
+func ApplyReplacements(rl *fn.ResourceList) (bool, error) {
 	r := Replacements{}
 	return r.Process(rl)
 }
@@ -36,16 +37,18 @@ func (r *Replacements) Config(functionConfig *fn.KubeObject) error {
 }
 
 // Process configures the replacements and transformers them.
-func (r *Replacements) Process(rl *fn.ResourceList) error {
+func (r *Replacements) Process(rl *fn.ResourceList) (bool, error) {
 	if err := r.Config(rl.FunctionConfig); err != nil {
-		return err
+		rl.LogResult(err)
+		return false, nil
 	}
 	transformedItems, err := r.Transform(rl.Items)
 	if err != nil {
-		return err
+		rl.LogResult(err)
+		return false, nil
 	}
 	rl.Items = transformedItems
-	return nil
+	return true, nil
 }
 
 // Transform runs the replacement filter in order to apply the replacements - this


### PR DESCRIPTION
The function needs to return errors, otherwise kpt will assume the function executed successfully. 

Combined with https://github.com/GoogleContainerTools/kpt-functions-sdk/pull/534, this fixes https://github.com/GoogleContainerTools/kpt/issues/2901.

Before: 

```
Package "apply-replacements-error": 
[RUNNING] "gcr.io/kpt-fn/apply-replacements:unstable"
[PASS] "gcr.io/kpt-fn/apply-replacements:unstable" in 1.1s
  Results:
    [error]: nothing selected by Pod.[noVer].[noGrp]/my-po.[noNs]:spec
```

After:

```
Package "apply-replacements-error": 
[RUNNING] "gcr.io/kpt-fn/apply-replacements:unstable"
[FAIL] "gcr.io/kpt-fn/apply-replacements:unstable" in 1.1s
  Results:
    [error]: nothing selected by Pod.[noVer].[noGrp]/my-po.[noNs]:spec
  Exit code: 1
```