### PR TITLE
update the starlark configmap example to work with latest kpt

### DIFF
--- a/examples/starlark-configmap-as-functionconfig/set-replicas.star
+++ b/examples/starlark-configmap-as-functionconfig/set-replicas.star
@@ -3,5 +3,7 @@ def setReplicas(resources, replicas):
         if r["apiVersion"] == "apps/v1" and r["kind"] == "Deployment":
             r["spec"]["replicas"] = replicas
 
-replicas = ctx.resource_list["functionConfig"]["data"]["replicas"]
+# The functionConfig is a ConfigMap, so the replicas we got from field
+# functionConfig.data.replicas is a string. We need to convert it to an int.
+replicas = int(ctx.resource_list["functionConfig"]["data"]["replicas"])
 setReplicas(ctx.resource_list["items"], replicas)


### PR DESCRIPTION
This PR was split out from https://github.com/GoogleContainerTools/kpt-functions-catalog/pull/778, since https://github.com/GoogleContainerTools/kpt-functions-catalog/pull/769 needs this PR while #778 is still blocked by another PR in the SDK repo.

Ref: changes in kpt: https://github.com/GoogleContainerTools/kpt/pull/2927