### PR TITLE
[starlark] builtin match_gvkn function

### DIFF
--- a/functions/go/starlark/krmfn/krmfn.go
+++ b/functions/go/starlark/krmfn/krmfn.go
@@ -26,8 +26,6 @@ func matchGVKN(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple
 	if err != nil {
 		return nil, err
 	}
-	if obj.GetAPIVersion() == apiVersion && obj.GetKind() == kind && obj.GetName() == name {
-		return starlark.Bool(true), nil
-	}
-	return starlark.Bool(false), nil
+	match := obj.GetAPIVersion() == apiVersion && obj.GetKind() == kind && obj.GetName() == name
+	return starlark.Bool(match), nil
 }

--- a/functions/go/starlark/krmfn/krmfn.go
+++ b/functions/go/starlark/krmfn/krmfn.go
@@ -11,21 +11,48 @@ const ModuleName = "krmfn.star"
 var Module = &starlarkstruct.Module{
 	Name: "krmfn",
 	Members: starlark.StringDict{
-		"match_gvkn": starlark.NewBuiltin("match_gvkn", matchGVKN),
+		"match_gvk":       starlark.NewBuiltin("match_gvk", matchGVK),
+		"match_name":      starlark.NewBuiltin("match_name", matchName),
+		"match_namespace": starlark.NewBuiltin("match_namespace", matchNamespace),
 	},
 }
 
-func matchGVKN(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+func matchGVK(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var resourceList starlark.Value
-	var apiVersion, kind, name string
-	if err := starlark.UnpackPositionalArgs("match_gvkn", args, kwargs, 4,
-		&resourceList, &apiVersion, &kind, &name); err != nil {
+	var apiVersion, kind string
+	if err := starlark.UnpackPositionalArgs("match_gvk", args, kwargs, 3,
+		&resourceList, &apiVersion, &kind); err != nil {
 		return nil, err
 	}
 	obj, err := fn.ParseKubeObject([]byte(resourceList.String()))
 	if err != nil {
 		return nil, err
 	}
-	match := obj.GetAPIVersion() == apiVersion && obj.GetKind() == kind && obj.GetName() == name
-	return starlark.Bool(match), nil
+	return starlark.Bool(obj.IsGVK(apiVersion, kind)), nil
+}
+
+func matchName(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var resourceList starlark.Value
+	var name string
+	if err := starlark.UnpackPositionalArgs("match_name", args, kwargs, 2, &resourceList, &name); err != nil {
+		return nil, err
+	}
+	obj, err := fn.ParseKubeObject([]byte(resourceList.String()))
+	if err != nil {
+		return nil, err
+	}
+	return starlark.Bool(obj.GetName() == name), nil
+}
+
+func matchNamespace(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var resourceList starlark.Value
+	var namespace string
+	if err := starlark.UnpackPositionalArgs("match_namespace", args, kwargs, 2, &resourceList, &namespace); err != nil {
+		return nil, err
+	}
+	obj, err := fn.ParseKubeObject([]byte(resourceList.String()))
+	if err != nil {
+		return nil, err
+	}
+	return starlark.Bool(obj.GetNamespace() == namespace), nil
 }

--- a/functions/go/starlark/krmfn/krmfn.go
+++ b/functions/go/starlark/krmfn/krmfn.go
@@ -1,0 +1,33 @@
+package krmfn
+
+import (
+	"github.com/GoogleContainerTools/kpt-functions-sdk/go/fn"
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+)
+
+const ModuleName = "krmfn.star"
+
+var Module = &starlarkstruct.Module{
+	Name: "krmfn",
+	Members: starlark.StringDict{
+		"match_gvkn": starlark.NewBuiltin("match_gvkn", matchGVKN),
+	},
+}
+
+func matchGVKN(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var resourceList starlark.Value
+	var apiVersion, kind, name string
+	if err := starlark.UnpackPositionalArgs("match_gvkn", args, kwargs, 4,
+		&resourceList, &apiVersion, &kind, &name); err != nil {
+		return nil, err
+	}
+	obj, err := fn.ParseKubeObject([]byte(resourceList.String()))
+	if err != nil {
+		return nil, err
+	}
+	if obj.GetAPIVersion() == apiVersion && obj.GetKind() == kind && obj.GetName() == name {
+		return starlark.Bool(true), nil
+	}
+	return starlark.Bool(false), nil
+}

--- a/functions/go/starlark/third_party/sigs.k8s.io/kustomize/kyaml/fn/runtime/starlark/loadlib.go
+++ b/functions/go/starlark/third_party/sigs.k8s.io/kustomize/kyaml/fn/runtime/starlark/loadlib.go
@@ -1,6 +1,7 @@
 package starlark
 
 import (
+	"github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/starlark/krmfn"
 	"github.com/qri-io/starlib/bsoup"
 	"github.com/qri-io/starlib/encoding/base64"
 	"github.com/qri-io/starlib/encoding/csv"
@@ -18,7 +19,8 @@ import (
 	"go.starlark.net/starlark"
 )
 
-// load loads starlark libraries from https://github.com/qri-io/starlib#packages.
+// load loads starlark libraries from https://github.com/qri-io/starlib#packages and from
+// our own custom libraries.
 func load(_ *starlark.Thread, module string) (starlark.StringDict, error) {
 	switch module {
 	case bsoup.ModuleName:
@@ -49,6 +51,8 @@ func load(_ *starlark.Thread, module string) (starlark.StringDict, error) {
 		return xlsx.LoadModule()
 	case zipfile.ModuleName:
 		return zipfile.LoadModule()
+	case krmfn.ModuleName:
+		return starlark.StringDict{"krmfn": krmfn.Module}, nil
 	}
 	return nil, nil
 }

--- a/tests/starlark/load-library/.expected/diff.patch
+++ b/tests/starlark/load-library/.expected/diff.patch
@@ -1,0 +1,11 @@
+diff --git a/app.yaml b/app.yaml
+index 95ea181..cbd25e7 100644
+--- a/app.yaml
++++ b/app.yaml
+@@ -2,5 +2,6 @@ apiVersion: apps/v1
+ kind: ConfigMap
+ metadata:
+   name: my-nginx
++  namespace: my-ns
+ data:
+   foo: bar

--- a/tests/starlark/load-library/fn-config.yaml
+++ b/tests/starlark/load-library/fn-config.yaml
@@ -19,3 +19,7 @@ source: |
   load('xlsx.star', 'xlsx')
   load('zipfile.star', 'ZipFile')
   load('krmfn.star', 'krmfn')
+
+  for r in ctx.resource_list["items"]:
+      if not krmfn.match_gvk(r, "kpt.dev/v1", "Kptfile") and krmfn.match_name(r, "my-nginx"):
+        r["metadata"]["namespace"] = "my-ns"

--- a/tests/starlark/load-library/fn-config.yaml
+++ b/tests/starlark/load-library/fn-config.yaml
@@ -18,3 +18,4 @@ source: |
   load('time.star', 'time')
   load('xlsx.star', 'xlsx')
   load('zipfile.star', 'ZipFile')
+  load('krmfn.star', 'krmfn')


### PR DESCRIPTION
This adds a builtin to the starlark runtime called `match_gvkn`. Example usage in the value propagation demo: https://github.com/natasha41575/rolebinding-replacement/blob/9c26aedae15c36dfe9912ffa9706b4d49288a1f2/starlark-and-replacements-function/generate-rolebinding-group.yaml#L14

This needs to be rebased on https://github.com/GoogleContainerTools/kpt-functions-catalog/pull/778 for CI to pass (some dependency issues).

Some questions:
- What do we want to call the module? I named it "krmfn", but wondering should it be "fn" to be consistent with the go SDK?
- Eventually we are moving this code and the forked starlark lib here to the kpt-functions-sdk. If I should change the directory structure to make moving it easier, let me know. Or if we want to move it over first before making this change, let me know.
- How do we document these builtin starlark functions? Docstrings in the Go code, a page on the kpt website, somewhere else?

cc @yuwenma 
