### PR TITLE
fix example path parsing issue in site gen

### DIFF
--- a/scripts/generate_catalog/generate_catalog.go
+++ b/scripts/generate_catalog/generate_catalog.go
@@ -298,17 +298,17 @@ func copyExamples(b string, exampleSources []string, versionDest, minorVersion s
 	}
 
 	for _, exampleSource := range exampleSources {
-		// We will split something like "https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-namespace/v0.3.2/examples/set-namespace-simple" by something like "v0.3"
-		splitedPaths := strings.SplitN(exampleSource, minorVersion, 2)
+		// We will split something like "https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-namespace/v0.3.2/examples/set-namespace-simple" by something like "v0.3/" or "v0.3.2/"
+		splitedPaths := regexp.MustCompile(fmt.Sprintf("%v(.[0-9])?/", minorVersion)).Split(exampleSource, 2)
 		if len(splitedPaths) != 2 {
 			return fmt.Errorf("expect 2 substring after spliting %q by %q", exampleSource, minorVersion)
 		}
 		relativePath := splitedPaths[1]
 		// Fetch example into temporary directory.
 		cmd := exec.Command("git", fmt.Sprintf("--work-tree=%v", tempDir), "checkout", b, "--", relativePath)
-		err = cmd.Run()
+		out, err := cmd.CombinedOutput()
 		if err != nil {
-			return fmt.Errorf("Error running %v: %v", cmd, err)
+			return fmt.Errorf("Error running %v: %v\nCombined output: %v", cmd, err, string(out))
 		}
 
 		exampleName := filepath.Base(relativePath)


### PR DESCRIPTION
It turned out https://github.com/GoogleContainerTools/kpt-functions-catalog/pull/810 doesn't really fix the issue, but this PR should.