### PR TITLE
Optimize openapi parsing in starlark

### DIFF
--- a/tests/starlark/openapi/.expected/config.yaml
+++ b/tests/starlark/openapi/.expected/config.yaml
@@ -1,0 +1,1 @@
+stdErr: Deployment

--- a/tests/starlark/openapi/.expected/exec.sh
+++ b/tests/starlark/openapi/.expected/exec.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+kpt fn eval --image gcr.io/kpt-fn/starlark:unstable --fn-config fn-config.yaml --image-pull-policy never

--- a/tests/starlark/openapi/.krmignore
+++ b/tests/starlark/openapi/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/tests/starlark/openapi/app.yaml
+++ b/tests/starlark/openapi/app.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-cm
+data:
+  some-key: some-value

--- a/tests/starlark/openapi/fn-config.yaml
+++ b/tests/starlark/openapi/fn-config.yaml
@@ -1,0 +1,6 @@
+apiVersion: fn.kpt.dev/v1alpha1
+kind: StarlarkRun
+metadata:
+  name: read-openapi-print
+source: |
+  print(ctx.open_api["definitions"]["io.k8s.api.apps.v1.Deployment"]["x-kubernetes-group-version-kind"][0]["kind"])


### PR DESCRIPTION
Added a wrapper to enable lazy initialization for openapi schema.
The schema is parsed only when the script tries to read it.

When the starlark script doesn't need to read openapi, it saves 0.7s.
