### PR TITLE
fix: properly set github urls to minor version

### DIFF
--- a/scripts/update_function_docs/function_release.go
+++ b/scripts/update_function_docs/function_release.go
@@ -295,7 +295,7 @@ func (fr *functionRelease) replaceGithubURLs(contents []byte) []byte {
 		suffixes = append(suffixes, fmt.Sprintf(`/%s/%s`, exampleSubPath, ex))
 	}
 	suffixGroup := strings.Join(suffixes, "|")
-	refGroup := fmt.Sprintf(`master|%s/v\d*\.\d*`, fr.FunctionName)
+	refGroup := fmt.Sprintf(`master|%[1]s/v\d*\.\d*\.\d*|%[1]s/v\d*\.\d*`, fr.FunctionName)
 	githubURLPattern := regexp.MustCompile(
 		fmt.Sprintf(`(https://github\.com/GoogleContainerTools/kpt-functions-catalog/tree/)(%s)(%s)`,
 			refGroup, suffixGroup))


### PR DESCRIPTION
This change applies a fix to the update-function-docs script to properly
set github urls to the minor release version of the function, which
points to the release branch. This conforms to the expected format of
verify-docs.

The refGroup pattern needs to accept minor version in case the version
string has already been set to the minor version (which can happen due
to the replaceTags transform running first).