### PR TITLE
add keywords and types to function meta (catalog-v2.json)

### DIFF
--- a/scripts/generate_catalog/generate_catalog.go
+++ b/scripts/generate_catalog/generate_catalog.go
@@ -35,6 +35,25 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+var keywordsPool = []string{
+	"setters",
+	"replacement",
+	"setters",
+	"name",
+	"gcp",
+	"terraform",
+	"gatekeeper",
+	"generate",
+	"kubeval",
+	"helm",
+	"annotation",
+	"image",
+	"label",
+	"namespace",
+	"project-id",
+	"starlark",
+}
+
 var (
 	branchesToSkip = []string{
 		"sops/v0.2",
@@ -81,7 +100,6 @@ func main() {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
-
 	err = writeExampleIndex(contribFns, source, filepath.Join(dest, "contrib"))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
@@ -104,6 +122,8 @@ type function struct {
 	Description       string
 	Tags              string
 	Gcp               bool
+	Types             []string
+	Keywords          []string
 }
 
 type example struct {
@@ -119,6 +139,8 @@ type metadata struct {
 	SourceUrl          string   `yaml:"sourceURL"`
 	ExamplePackageUrls []string `yaml:"examplePackageURLs"`
 	Hidden             bool
+	Types              []string `yaml:"types"`
+	Keywords           []string `yaml:"keywords"`
 }
 
 type catalogEntry struct {
@@ -126,6 +148,9 @@ type catalogEntry struct {
 	LatestPatchVersion string
 	// Examples maps exampleName->example
 	Examples map[string]example
+	// Types are the function types, only `validator` and `mutator` are accepted.
+	Types    []string
+	Keywords []string
 }
 
 var (
@@ -406,6 +431,9 @@ func parseMetadata(f function, md metadata, version string, versionDest string) 
 	f.Path = versionDest
 	f.Description = md.Description
 	functionTags := make([]string, 0)
+	if len(md.Types) != 0 {
+		addType(&f, md.Types...)
+	}
 	for _, tag := range md.Tags {
 		normalizedTag := strings.ToLower(tag)
 		if normalizedTag == "gcp" {
@@ -413,12 +441,72 @@ func parseMetadata(f function, md metadata, version string, versionDest string) 
 		} else {
 			functionTags = append(functionTags, normalizedTag)
 		}
+		// If function type is not given, read the "types" from "tags". The types have to be `mutator` or/and `validator`.
+		// While "tags" can be custom field like `config sync`, `gcp`
+		addType(&f, tag)
 	}
 	sort.Strings(functionTags)
 	f.Tags = strings.Join(functionTags, ", ")
 	f.ImagePath = md.Image
-
+	addKeywordsFromTag(&f, md.Tags, md.Keywords)
 	return f
+}
+
+// Ideally, we should read the keywords from the function metadata. However, each function has its own git release branch,
+// so adding a single meta field requires code changing and releasing for each function branch.
+// As a workaround before we take advantage of the "keywords" meta, we get keywords from two sources
+// 1. For horizontal functions, we keep a KeywordPool and find keywords if it's a substring of the function.
+// 2. For product specific functions, we use its `tags` excluding `mutator` and `validator` as keywords. These keywords can be
+// `gcp`, `config-sync`, `terraform` etc.
+func addKeywordsFromTag(f *function, tags []string, customKeywords []string) {
+	var newKeywords []string
+	keywordMap := map[string]bool{}
+	keywords := append(tags, customKeywords...)
+	for _, kw := range keywords {
+		kw = strings.ToLower(kw)
+		kw = strings.ReplaceAll(kw, " ", "-")
+		if kw == "mutator" {
+			continue
+		}
+		if kw == "validator" {
+			continue
+		}
+		if ok := keywordMap[kw]; !ok {
+			newKeywords = append(newKeywords, kw)
+			keywordMap[kw] = true
+		}
+	}
+	for _, kw := range keywordsPool {
+		if strings.Contains(f.FunctionName, kw) {
+			if ok := keywordMap[kw]; !ok {
+				newKeywords = append(newKeywords, kw)
+				keywordMap[kw] = true
+			}
+		}
+	}
+	f.Keywords = newKeywords
+}
+
+func addType(f *function, fnTypes ...string) {
+	uniqueMap := map[string]bool{}
+	allTypes := append(fnTypes, f.Types...)
+	var newTypes []string
+	for _, fnType := range allTypes {
+		var k string
+		switch strings.ToLower(fnType) {
+		case "validator":
+			k = "validator"
+		case "mutator":
+			k = "mutator"
+		default:
+			continue
+		}
+		if ok := uniqueMap[k]; !ok {
+			uniqueMap[k] = true
+			newTypes = append(newTypes, k)
+		}
+	}
+	f.Types = newTypes
 }
 
 func getRelativeFunctionPath(source string, funcName string) (string, error) {
@@ -546,6 +634,8 @@ func writeExampleIndexV2(functions []function, source string, dest string) error
 			catalogEntryMap[majorMinor] = catalogEntry{
 				LatestPatchVersion: patch,
 				Examples:           exampleMap,
+				Types:              f.Types,
+				Keywords:           f.Keywords,
 			}
 		}
 		functionVersionMap[f.FunctionName] = catalogEntryMap


### PR DESCRIPTION
### UPDATES: 
the `keywords` come from two  sources. One is the keywordpool match (original, described below),the other is the metadata "tags" excluding "mutator" and "validator". keyword from tag is reformatted to lower case, dash replace empty space.  like "Config Sync" as "config-sync"

### description
The PR is aimed to add the function `types` and `keywords` to `https://catalog.kpt.dev/catalog-v2.json`, so as `kpt fn eval` can filter functions by `--types` and `--keywords` flags.  

Ideally, we want the "types" and "keywords" to be configurable fields in each function's metadata.yaml. like below 
```yaml
image: gcr.io/kpt-fn/set-namespace
description: Update namespace.
types:
 - mutator # New!
keywords:
 - namespace # New!
 - some-custom-fields  # New!
tags:
  - mutator
sourceURL: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/functions/go/set-namespace
examplePackageURLs:
  - https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/examples/set-namespace-simple
  - https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/examples/set-namespace-imperative
  - https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/examples/set-namespace-depends-on
emails:
  - kpt-team@google.com
license: Apache-2.0
```

However, the way  kpt-functions-catalog releases is to fetch the metadata.yaml for each function in their own git release branch. This means,  we need X PRs and X release to update the X  curated and contrib functions. 

### For keywords
Since we haven't finalized the usage of "keywords" meta, I use a workaround solution which keeps a keyword pool, and matches the keyword to functions if function name contains the keywords. 

### For types
`types` are different from `tags`. Types can only be `mutator` and/or `validator` because it refers to the Kptfile pipeline type. While `tags` can be custom symbols like gcp, configsync, viewer.

### Output
The catalog-v2.json from running `make site-generate` is (changed to YAML for easy readability):
```yaml
---
apply-replacements:
  v0.1:
    LatestPatchVersion: v0.1.0
    Examples:
      apply-replacements-simple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/apply-replacements/v0.1/apply-replacements-simple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/apply-replacements/v0.1/examples/apply-replacements-simple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/apply-replacements/v0.1/functions/go/apply-replacements
    Types:
    - mutator
    Keywords:
    - replacement
apply-setters:
  v0.1:
    LatestPatchVersion: v0.1.0
    Examples:
      apply-setters-simple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/apply-setters/v0.1/apply-setters-simple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/apply-setters/v0.1/examples/apply-setters-simple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/apply-setters/v0.1/functions/go/apply-setters
      simple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/apply-setters/v0.1/simple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/apply-setters/v0.1/examples/apply-setters/simple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/apply-setters/v0.1/functions/go/apply-setters
    Types:
    - mutator
    Keywords:
    - setters
  v0.2:
    LatestPatchVersion: v0.2.0
    Examples:
      apply-setters-simple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/apply-setters/v0.2/apply-setters-simple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/apply-setters/v0.2/examples/apply-setters-simple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/apply-setters/v0.2/functions/go/apply-setters
    Types:
    - mutator
    Keywords:
    - setters
create-setters:
  v0.1:
    LatestPatchVersion: v0.1.0
    Examples:
      create-setters-simple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/create-setters/v0.1/create-setters-simple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/create-setters/v0.1/examples/create-setters-simple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/create-setters/v0.1/functions/go/create-setters
    Types:
    - mutator
    Keywords:
    - setters
enable-gcp-services:
  v0.1:
    LatestPatchVersion: v0.1.0
    Examples:
      enable-gcp-services-advanced:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/enable-gcp-services/v0.1/enable-gcp-services-advanced"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/enable-gcp-services/v0.1/examples/enable-gcp-services-advanced
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/enable-gcp-services/v0.1/functions/go/enable-gcp-services
      enable-gcp-services-simple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/enable-gcp-services/v0.1/enable-gcp-services-simple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/enable-gcp-services/v0.1/examples/enable-gcp-services-simple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/enable-gcp-services/v0.1/functions/go/enable-gcp-services
    Types:
    - mutator
    Keywords:
    - generator
    - gcp
ensure-name-substring:
  v0.1:
    LatestPatchVersion: v0.1.1
    Examples:
      advanced:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/ensure-name-substring/v0.1/advanced"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/ensure-name-substring/v0.1/examples/ensure-name-substring/advanced
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/ensure-name-substring/v0.1/functions/go/ensure-name-substring
      ensure-name-substring-advanced:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/ensure-name-substring/v0.1/ensure-name-substring-advanced"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/ensure-name-substring/v0.1/examples/ensure-name-substring-advanced
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/ensure-name-substring/v0.1/functions/go/ensure-name-substring
      ensure-name-substring-imperative:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/ensure-name-substring/v0.1/ensure-name-substring-imperative"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/ensure-name-substring/v0.1/examples/ensure-name-substring-imperative
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/ensure-name-substring/v0.1/functions/go/ensure-name-substring
      ensure-name-substring-prefix:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/ensure-name-substring/v0.1/ensure-name-substring-prefix"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/ensure-name-substring/v0.1/examples/ensure-name-substring-prefix
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/ensure-name-substring/v0.1/functions/go/ensure-name-substring
      ensure-name-substring-suffix:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/ensure-name-substring/v0.1/ensure-name-substring-suffix"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/ensure-name-substring/v0.1/examples/ensure-name-substring-suffix
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/ensure-name-substring/v0.1/functions/go/ensure-name-substring
      prefix:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/ensure-name-substring/v0.1/prefix"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/ensure-name-substring/v0.1/examples/ensure-name-substring/prefix
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/ensure-name-substring/v0.1/functions/go/ensure-name-substring
      suffix:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/ensure-name-substring/v0.1/suffix"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/ensure-name-substring/v0.1/examples/ensure-name-substring/suffix
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/ensure-name-substring/v0.1/functions/go/ensure-name-substring
    Types:
    - mutator
    Keywords:
    - name-prefix
    - name-suffix
    - name
  v0.2:
    LatestPatchVersion: v0.2.0
    Examples:
      ensure-name-substring-advanced:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/ensure-name-substring/v0.2/ensure-name-substring-advanced"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/ensure-name-substring/v0.2/examples/ensure-name-substring-advanced
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/ensure-name-substring/v0.2/functions/go/ensure-name-substring
      ensure-name-substring-depends-on:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/ensure-name-substring/v0.2/ensure-name-substring-depends-on"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/ensure-name-substring/v0.2/examples/ensure-name-substring-depends-on
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/ensure-name-substring/v0.2/functions/go/ensure-name-substring
      ensure-name-substring-imperative:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/ensure-name-substring/v0.2/ensure-name-substring-imperative"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/ensure-name-substring/v0.2/examples/ensure-name-substring-imperative
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/ensure-name-substring/v0.2/functions/go/ensure-name-substring
      ensure-name-substring-prefix:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/ensure-name-substring/v0.2/ensure-name-substring-prefix"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/ensure-name-substring/v0.2/examples/ensure-name-substring-prefix
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/ensure-name-substring/v0.2/functions/go/ensure-name-substring
      ensure-name-substring-suffix:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/ensure-name-substring/v0.2/ensure-name-substring-suffix"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/ensure-name-substring/v0.2/examples/ensure-name-substring-suffix
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/ensure-name-substring/v0.2/functions/go/ensure-name-substring
    Types:
    - mutator
    Keywords:
    - name-prefix
    - name-suffix
    - name
export-terraform:
  v0.1:
    LatestPatchVersion: v0.1.0
    Examples:
      export-terraform-advanced:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/export-terraform/v0.1/export-terraform-advanced"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/export-terraform/v0.1/examples/export-terraform-advanced
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/export-terraform/v0.1/functions/go/export-terraform
      export-terraform-imperative:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/export-terraform/v0.1/export-terraform-imperative"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/export-terraform/v0.1/examples/export-terraform-imperative
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/export-terraform/v0.1/functions/go/export-terraform
    Types:
    - mutator
    Keywords:
    - gcp
    - terraform
fix:
  v0.2:
    LatestPatchVersion: v0.2.1
    Examples:
      fix-simple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/fix/v0.2/fix-simple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/fix/v0.2/examples/fix-simple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/fix/v0.2/functions/go/fix
    Types:
    - mutator
    Keywords:
gatekeeper:
  v0.1:
    LatestPatchVersion: v0.1.3
    Examples:
      gatekeeper-disallow-root-user:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/gatekeeper/v0.1/gatekeeper-disallow-root-user"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/gatekeeper/v0.1/examples/gatekeeper-disallow-root-user
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/gatekeeper/v0.1/functions/go/gatekeeper
      gatekeeper-imperative:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/gatekeeper/v0.1/gatekeeper-imperative"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/gatekeeper/v0.1/examples/gatekeeper-imperative
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/gatekeeper/v0.1/functions/go/gatekeeper
      gatekeeper-invalid-configmap:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/gatekeeper/v0.1/gatekeeper-invalid-configmap"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/gatekeeper/v0.1/examples/gatekeeper-invalid-configmap
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/gatekeeper/v0.1/functions/go/gatekeeper
      gatekeeper-warning-only:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/gatekeeper/v0.1/gatekeeper-warning-only"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/gatekeeper/v0.1/examples/gatekeeper-warning-only
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/gatekeeper/v0.1/functions/go/gatekeeper
    Types:
    - validator
    Keywords:
    - gatekeeper
  v0.2:
    LatestPatchVersion: v0.2.1
    Examples:
      gatekeeper-disallow-root-user:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/gatekeeper/v0.2/gatekeeper-disallow-root-user"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/gatekeeper/v0.2/examples/gatekeeper-disallow-root-user
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/gatekeeper/v0.2/functions/go/gatekeeper
      gatekeeper-imperative:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/gatekeeper/v0.2/gatekeeper-imperative"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/gatekeeper/v0.2/examples/gatekeeper-imperative
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/gatekeeper/v0.2/functions/go/gatekeeper
      gatekeeper-invalid-configmap:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/gatekeeper/v0.2/gatekeeper-invalid-configmap"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/gatekeeper/v0.2/examples/gatekeeper-invalid-configmap
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/gatekeeper/v0.2/functions/go/gatekeeper
      gatekeeper-warning-only:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/gatekeeper/v0.2/gatekeeper-warning-only"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/gatekeeper/v0.2/examples/gatekeeper-warning-only
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/gatekeeper/v0.2/functions/go/gatekeeper
    Types:
    - validator
    Keywords:
    - gatekeeper
generate-folders:
  v0.1:
    LatestPatchVersion: v0.1.1
    Examples:
      generate-folders-resourcehierarchy-v1:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/generate-folders/v0.1/generate-folders-resourcehierarchy-v1"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/generate-folders/v0.1/examples/generate-folders-resourcehierarchy-v1
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/generate-folders/v0.1/functions/ts/generate-folders
      generate-folders-resourcehierarchy-v2:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/generate-folders/v0.1/generate-folders-resourcehierarchy-v2"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/generate-folders/v0.1/examples/generate-folders-resourcehierarchy-v2
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/generate-folders/v0.1/functions/ts/generate-folders
      generate-folders-resourcehierarchy-v3:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/generate-folders/v0.1/generate-folders-resourcehierarchy-v3"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/generate-folders/v0.1/examples/generate-folders-resourcehierarchy-v3
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/generate-folders/v0.1/functions/ts/generate-folders
    Types:
    - mutator
    Keywords:
    - gcp
    - generator
    - generate
kubeval:
  v0.1:
    LatestPatchVersion: v0.1.2
    Examples:
      kubeval-imperative:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/kubeval/v0.1/kubeval-imperative"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/kubeval/v0.1/examples/kubeval-imperative
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/kubeval/v0.1/functions/ts/kubeval
      kubeval-simple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/kubeval/v0.1/kubeval-simple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/kubeval/v0.1/examples/kubeval-simple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/kubeval/v0.1/functions/ts/kubeval
    Types:
    - validator
    Keywords:
    - kubeval
  v0.2:
    LatestPatchVersion: v0.2.0
    Examples:
      kubeval-imperative:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/kubeval/v0.2/kubeval-imperative"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/kubeval/v0.2/examples/kubeval-imperative
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/kubeval/v0.2/functions/ts/kubeval
      kubeval-mount-schema:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/kubeval/v0.2/kubeval-mount-schema"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/kubeval/v0.2/examples/kubeval-mount-schema
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/kubeval/v0.2/functions/ts/kubeval
      kubeval-simple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/kubeval/v0.2/kubeval-simple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/kubeval/v0.2/examples/kubeval-simple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/kubeval/v0.2/functions/ts/kubeval
    Types:
    - validator
    Keywords:
    - kubeval
list-setters:
  v0.1:
    LatestPatchVersion: v0.1.0
    Examples:
      list-setters-simple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/list-setters/v0.1/list-setters-simple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/list-setters/v0.1/examples/list-setters-simple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/list-setters/v0.1/functions/go/list-setters
    Types:
    Keywords:
    - viewer
    - setters
remove-local-config-resources:
  v0.1:
    LatestPatchVersion: v0.1.0
    Examples:
      remove-local-config-resources-imperative:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/remove-local-config-resources/v0.1/remove-local-config-resources-imperative"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/remove-local-config-resources/v0.1/examples/remove-local-config-resources-imperative
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/remove-local-config-resources/v0.1/functions/go/remove-local-config-resources
    Types:
    - mutator
    Keywords:
    - gcp
    - config-sync
render-helm-chart:
  v0.1:
    LatestPatchVersion: v0.1.0
    Examples:
      render-helm-chart-crds:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/render-helm-chart/v0.1/render-helm-chart-crds"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/render-helm-chart/v0.1/examples/render-helm-chart-crds
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/render-helm-chart/v0.1/functions/go/render-helm-chart
      render-helm-chart-kustomize-inline-values:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/render-helm-chart/v0.1/render-helm-chart-kustomize-inline-values"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/render-helm-chart/v0.1/examples/render-helm-chart-kustomize-inline-values
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/render-helm-chart/v0.1/functions/go/render-helm-chart
      render-helm-chart-local:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/render-helm-chart/v0.1/render-helm-chart-local"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/render-helm-chart/v0.1/examples/render-helm-chart-local
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/render-helm-chart/v0.1/functions/go/render-helm-chart
      render-helm-chart-remote:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/render-helm-chart/v0.1/render-helm-chart-remote"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/render-helm-chart/v0.1/examples/render-helm-chart-remote
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/render-helm-chart/v0.1/functions/go/render-helm-chart
      render-helm-chart-remote-values-file:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/render-helm-chart/v0.1/render-helm-chart-remote-values-file"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/render-helm-chart/v0.1/examples/render-helm-chart-remote-values-file
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/render-helm-chart/v0.1/functions/go/render-helm-chart
    Types:
    - mutator
    Keywords:
    - helm
search-replace:
  v0.1:
    LatestPatchVersion: v0.1.1
    Examples:
      search-replace-create-setters:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/search-replace/v0.1/search-replace-create-setters"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/search-replace/v0.1/examples/search-replace-create-setters
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/search-replace/v0.1/functions/go/search-replace
      search-replace-simple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/search-replace/v0.1/search-replace-simple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/search-replace/v0.1/examples/search-replace-simple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/search-replace/v0.1/functions/go/search-replace
      simple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/search-replace/v0.1/simple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/search-replace/v0.1/examples/search-replace/simple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/search-replace/v0.1/functions/go/search-replace
    Types:
    - mutator
    Keywords:
  v0.2:
    LatestPatchVersion: v0.2.0
    Examples:
      search-replace-create-setters:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/search-replace/v0.2/search-replace-create-setters"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/search-replace/v0.2/examples/search-replace-create-setters
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/search-replace/v0.2/functions/go/search-replace
      search-replace-simple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/search-replace/v0.2/search-replace-simple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/search-replace/v0.2/examples/search-replace-simple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/search-replace/v0.2/functions/go/search-replace
    Types:
    - mutator
    Keywords:
set-annotations:
  v0.1:
    LatestPatchVersion: v0.1.4
    Examples:
      advanced:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-annotations/v0.1/advanced"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-annotations/v0.1/examples/set-annotations/advanced
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-annotations/v0.1/functions/go/set-annotations
      set-annotations-advanced:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-annotations/v0.1/set-annotations-advanced"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-annotations/v0.1/examples/set-annotations-advanced
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-annotations/v0.1/functions/go/set-annotations
      set-annotations-imperative:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-annotations/v0.1/set-annotations-imperative"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-annotations/v0.1/examples/set-annotations-imperative
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-annotations/v0.1/functions/go/set-annotations
      set-annotations-simple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-annotations/v0.1/set-annotations-simple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-annotations/v0.1/examples/set-annotations-simple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-annotations/v0.1/functions/go/set-annotations
      simple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-annotations/v0.1/simple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-annotations/v0.1/examples/set-annotations/simple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-annotations/v0.1/functions/go/set-annotations
    Types:
    - mutator
    Keywords:
    - annotation
set-enforcement-action:
  v0.1:
    LatestPatchVersion: v0.1.0
    Examples:
      set-enforcement-action-simple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-enforcement-action/v0.1/set-enforcement-action-simple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-enforcement-action/v0.1/examples/set-enforcement-action-simple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-enforcement-action/v0.1/functions/go/set-enforcement-action
    Types:
    - mutator
    Keywords:
    - config-sync
set-image:
  v0.1:
    LatestPatchVersion: v0.1.0
    Examples:
      set-image-advanced:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-image/v0.1/set-image-advanced"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-image/v0.1/examples/set-image-advanced
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-image/v0.1/functions/go/set-image
      set-image-digest:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-image/v0.1/set-image-digest"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-image/v0.1/examples/set-image-digest
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-image/v0.1/functions/go/set-image
      set-image-imperative:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-image/v0.1/set-image-imperative"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-image/v0.1/examples/set-image-imperative
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-image/v0.1/functions/go/set-image
      set-image-simple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-image/v0.1/set-image-simple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-image/v0.1/examples/set-image-simple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-image/v0.1/functions/go/set-image
    Types:
    - mutator
    Keywords:
    - image
set-labels:
  v0.1:
    LatestPatchVersion: v0.1.5
    Examples:
      advanced:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-labels/v0.1/advanced"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-labels/v0.1/examples/set-labels/advanced
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-labels/v0.1/functions/go/set-labels
      set-labels-advanced:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-labels/v0.1/set-labels-advanced"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-labels/v0.1/examples/set-labels-advanced
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-labels/v0.1/functions/go/set-labels
      set-labels-imperative:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-labels/v0.1/set-labels-imperative"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-labels/v0.1/examples/set-labels-imperative
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-labels/v0.1/functions/go/set-labels
      set-labels-simple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-labels/v0.1/set-labels-simple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-labels/v0.1/examples/set-labels-simple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-labels/v0.1/functions/go/set-labels
      simple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-labels/v0.1/simple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-labels/v0.1/examples/set-labels/simple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-labels/v0.1/functions/go/set-labels
    Types:
    - mutator
    Keywords:
    - label
set-namespace:
  v0.1:
    LatestPatchVersion: v0.1.4
    Examples:
      advanced:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-namespace/v0.1/advanced"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-namespace/v0.1/examples/set-namespace/advanced
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-namespace/v0.1/functions/go/set-namespace
      set-namespace-advanced:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-namespace/v0.1/set-namespace-advanced"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-namespace/v0.1/examples/set-namespace-advanced
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-namespace/v0.1/functions/go/set-namespace
      set-namespace-imperative:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-namespace/v0.1/set-namespace-imperative"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-namespace/v0.1/examples/set-namespace-imperative
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-namespace/v0.1/functions/go/set-namespace
      set-namespace-simple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-namespace/v0.1/set-namespace-simple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-namespace/v0.1/examples/set-namespace-simple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-namespace/v0.1/functions/go/set-namespace
      simple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-namespace/v0.1/simple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-namespace/v0.1/examples/set-namespace/simple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-namespace/v0.1/functions/go/set-namespace
    Types:
    - mutator
    Keywords:
    - name
    - namespace
  v0.2:
    LatestPatchVersion: v0.2.0
    Examples:
      set-namespace-advanced:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-namespace/v0.2/set-namespace-advanced"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-namespace/v0.2/examples/set-namespace-advanced
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-namespace/v0.2/functions/go/set-namespace
      set-namespace-imperative:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-namespace/v0.2/set-namespace-imperative"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-namespace/v0.2/examples/set-namespace-imperative
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-namespace/v0.2/functions/go/set-namespace
      set-namespace-simple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-namespace/v0.2/set-namespace-simple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-namespace/v0.2/examples/set-namespace-simple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-namespace/v0.2/functions/go/set-namespace
    Types:
    - mutator
    Keywords:
    - name
    - namespace
  v0.3:
    LatestPatchVersion: v0.3.3
    Examples:
      set-namespace-depends-on:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-namespace/v0.3/set-namespace-depends-on"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-namespace/v0.3.3/examples/set-namespace-depends-on
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-namespace/v0.3.3/functions/go/set-namespace
      set-namespace-imperative:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-namespace/v0.3/set-namespace-imperative"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-namespace/v0.3.3/examples/set-namespace-imperative
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-namespace/v0.3.3/functions/go/set-namespace
      set-namespace-simple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-namespace/v0.3/set-namespace-simple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-namespace/v0.3.3/examples/set-namespace-simple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-namespace/v0.3.3/functions/go/set-namespace
    Types:
    - mutator
    Keywords:
    - name
    - namespace
set-project-id:
  v0.1:
    LatestPatchVersion: v0.1.0
    Examples:
      set-project-id-advanced:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-project-id/v0.1/set-project-id-advanced"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-project-id/v0.1/examples/set-project-id-advanced
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-project-id/v0.1/functions/go/set-project-id
      set-project-id-simple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-project-id/v0.1/set-project-id-simple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-project-id/v0.1/examples/set-project-id-simple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-project-id/v0.1/functions/go/set-project-id
    Types:
    - mutator
    Keywords:
    - gcp
    - project-id
  v0.2:
    LatestPatchVersion: v0.2.0
    Examples:
      set-project-id-advanced:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-project-id/v0.2/set-project-id-advanced"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-project-id/v0.2/examples/set-project-id-advanced
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-project-id/v0.2/functions/go/set-project-id
      set-project-id-simple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/set-project-id/v0.2/set-project-id-simple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-project-id/v0.2/examples/set-project-id-simple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/set-project-id/v0.2/functions/go/set-project-id
    Types:
    - mutator
    Keywords:
    - gcp
    - project-id
starlark:
  v0.1:
    LatestPatchVersion: v0.1.2
    Examples:
      simple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/starlark/v0.1/simple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.1/examples/starlark/simple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.1/functions/go/starlark
      starlark-inject-sidecar:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/starlark/v0.1/starlark-inject-sidecar"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.1/examples/starlark-inject-sidecar
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.1/functions/go/starlark
      starlark-poddisruptionbudget:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/starlark/v0.1/starlark-poddisruptionbudget"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.1/examples/starlark-poddisruptionbudget
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.1/functions/go/starlark
      starlark-set-namespace:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/starlark/v0.1/starlark-set-namespace"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.1/examples/starlark-set-namespace
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.1/functions/go/starlark
      starlark-validation:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/starlark/v0.1/starlark-validation"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.1/examples/starlark-validation
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.1/functions/go/starlark
    Types:
    - validator
    - mutator
    Keywords:
    - starlark
  v0.2:
    LatestPatchVersion: v0.2.2
    Examples:
      starlark-configmap-as-functionconfig:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/starlark/v0.2/starlark-configmap-as-functionconfig"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.2/examples/starlark-configmap-as-functionconfig
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.2/functions/go/starlark
      starlark-inject-sidecar:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/starlark/v0.2/starlark-inject-sidecar"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.2/examples/starlark-inject-sidecar
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.2/functions/go/starlark
      starlark-poddisruptionbudget:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/starlark/v0.2/starlark-poddisruptionbudget"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.2/examples/starlark-poddisruptionbudget
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.2/functions/go/starlark
      starlark-set-namespace:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/starlark/v0.2/starlark-set-namespace"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.2/examples/starlark-set-namespace
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.2/functions/go/starlark
      starlark-validation:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/starlark/v0.2/starlark-validation"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.2/examples/starlark-validation
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.2/functions/go/starlark
    Types:
    - validator
    - mutator
    Keywords:
    - starlark
  v0.3:
    LatestPatchVersion: v0.3.0
    Examples:
      starlark-configmap-as-functionconfig:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/starlark/v0.3/starlark-configmap-as-functionconfig"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.3/examples/starlark-configmap-as-functionconfig
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.3/functions/go/starlark
      starlark-inject-sidecar:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/starlark/v0.3/starlark-inject-sidecar"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.3/examples/starlark-inject-sidecar
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.3/functions/go/starlark
      starlark-load-library:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/starlark/v0.3/starlark-load-library"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.3/examples/starlark-load-library
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.3/functions/go/starlark
      starlark-poddisruptionbudget:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/starlark/v0.3/starlark-poddisruptionbudget"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.3/examples/starlark-poddisruptionbudget
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.3/functions/go/starlark
      starlark-set-namespace:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/starlark/v0.3/starlark-set-namespace"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.3/examples/starlark-set-namespace
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.3/functions/go/starlark
      starlark-validation:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/starlark/v0.3/starlark-validation"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.3/examples/starlark-validation
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.3/functions/go/starlark
    Types:
    - validator
    - mutator
    Keywords:
    - starlark
  v0.4:
    LatestPatchVersion: v0.4.0
    Examples:
      starlark-configmap-as-functionconfig:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/starlark/v0.4/starlark-configmap-as-functionconfig"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.4/examples/starlark-configmap-as-functionconfig
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.4/functions/go/starlark
      starlark-inject-sidecar:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/starlark/v0.4/starlark-inject-sidecar"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.4/examples/starlark-inject-sidecar
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.4/functions/go/starlark
      starlark-load-library:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/starlark/v0.4/starlark-load-library"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.4/examples/starlark-load-library
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.4/functions/go/starlark
      starlark-poddisruptionbudget:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/starlark/v0.4/starlark-poddisruptionbudget"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.4/examples/starlark-poddisruptionbudget
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.4/functions/go/starlark
      starlark-set-namespace:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/starlark/v0.4/starlark-set-namespace"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.4/examples/starlark-set-namespace
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.4/functions/go/starlark
      starlark-validation:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/starlark/v0.4/starlark-validation"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.4/examples/starlark-validation
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.4/functions/go/starlark
    Types:
    - validator
    - mutator
    Keywords:
    - starlark
upsert-resource:
  v0.1:
    LatestPatchVersion: v0.1.0
    Examples:
      upsert-resource-simple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/upsert-resource/v0.1/upsert-resource-simple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/upsert-resource/v0.1/examples/upsert-resource-simple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/upsert-resource/v0.1/functions/go/upsert-resource
    Types:
    - mutator
    Keywords:
  v0.2:
    LatestPatchVersion: v0.2.0
    Examples:
      upsert-resource-at-path:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/upsert-resource/v0.2/upsert-resource-at-path"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/upsert-resource/v0.2/examples/upsert-resource-at-path
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/upsert-resource/v0.2/functions/go/upsert-resource
      upsert-resource-multiple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/upsert-resource/v0.2/upsert-resource-multiple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/upsert-resource/v0.2/examples/upsert-resource-multiple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/upsert-resource/v0.2/functions/go/upsert-resource
      upsert-resource-simple:
        LocalExamplePath: "/Users/yuwenma/go/src/github.com/GoogleContainerTools/kpt-functions-catalog/yuyu/upsert-resource/v0.2/upsert-resource-simple"
        RemoteExamplePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/upsert-resource/v0.2/examples/upsert-resource-simple
        RemoteSourcePath: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/upsert-resource/v0.2/functions/go/upsert-resource
    Types:
    - mutator
    Keywords:
```