### PR TITLE
Cleanup `set-namespace` output message

### DIFF
--- a/functions/go/set-namespace/transformer/namespace.go
+++ b/functions/go/set-namespace/transformer/namespace.go
@@ -41,16 +41,6 @@ func SetNamespace(rl *fn.ResourceList) (bool, error) {
 	}
 
 	rl.Results = append(rl.Results, result)
-	rl.Results = append(rl.Results, &fn.Result{
-		Message: fmt.Sprintf("set image from %s to %s", tc.NamespaceMatcher, tc.NewNamespace),
-		Field: &fn.Field{
-			Path:          "",
-			CurrentValue:  tc.NamespaceMatcher,
-			ProposedValue: tc.NewNamespace,
-		},
-		File:     &fn.File{Path: "test", Index: 0},
-		Severity: fn.Info,
-	})
 	return true, nil
 }
 

--- a/tests/set-namespace/ns-unset/.expected/results.yaml
+++ b/tests/set-namespace/ns-unset/.expected/results.yaml
@@ -9,10 +9,3 @@ items:
     results:
       - message: could not find any namespace fields to update. This function requires at least one of Namespace objects or namespace-scoped resources to have their namespace field set.
         severity: error
-      - message: set image from  to example-ns
-        severity: info
-        field:
-          currentValue: ""
-          proposedValue: example-ns
-        file:
-          path: test


### PR DESCRIPTION
Current set-namespace gives redundant message as below
```bash
  Results:
    [info]: namespace "example" updated to "example", 0 values changed
    [info] : set image from example to example
```
The second line is per KubeObject level info and should be removed. 