### PR TITLE
feat: support log export in export-terraform

### DIFF
--- a/functions/go/export-terraform/README.md
+++ b/functions/go/export-terraform/README.md
@@ -1,4 +1,4 @@
-# export-terraform-resources
+# export-terraform
 
 ## Overview
 

--- a/functions/go/export-terraform/README.md
+++ b/functions/go/export-terraform/README.md
@@ -19,6 +19,10 @@ The following KCC resources are supported:
 - IAMPartialPolicy
 - IAMPolicy
 - IAMPolicyMember
+- LoggingLogSink
+- BigQueryDataset
+- PubSubTopic
+- StorageBucket
 
 The output Terraform will be saved to a `ConfigMap` in `terraform.yaml` at the root of the package.
 Each key in the `ConfigMap` corresponds to a different file which is part of the Terraform module.

--- a/functions/go/export-terraform/terraformgenerator/resources.go
+++ b/functions/go/export-terraform/terraformgenerator/resources.go
@@ -149,6 +149,9 @@ func (resource *terraformResource) attachReferences() error {
 	resource.References = make(map[string]*terraformResource)
 	paths := []referencePath{
 		{kind: "BillingAccount", path: []string{"spec", "billingAccountRef", "external"}},
+		{kind: "BigQueryDataset", path: []string{"spec", "destination", "bigQueryDatasetRef", "name"}},
+		{kind: "PubSubTopic", path: []string{"spec", "destination", "pubSubTopicRef", "name"}},
+		{kind: "StorageBucket", path: []string{"spec", "destination", "storageBucketRef", "name"}},
 	}
 	for _, path := range paths {
 		kind := path.kind
@@ -199,7 +202,7 @@ func (resource *terraformResource) getParentRef(path ...string) (string, string,
 		{kind: "Folder", path: []string{"spec", "folderRef", "name"}},
 		{kind: "Folder", path: []string{"spec", "folderRef", "external"}},
 		{kind: "Organization", path: []string{"spec", "organizationRef", "external"}},
-		{kind: "Project", path: []string{"metadata", "annotations", "cnrm.cloud.google.com/project-id", "name"}},
+		{kind: "Project", path: []string{"metadata", "annotations", "cnrm.cloud.google.com/project-id"}},
 		{path: []string{"spec", "resourceRef", "external"}},
 		{path: []string{"spec", "resourceRef", "name"}},
 	}

--- a/functions/go/export-terraform/terraformgenerator/resources.go
+++ b/functions/go/export-terraform/terraformgenerator/resources.go
@@ -115,10 +115,18 @@ func (resource *terraformResource) GetBool(path ...string) bool {
 	return boolValue
 }
 
+// Retrieve an int from the resource
+func (resource *terraformResource) GetInt(path ...string) int {
+	num, found, err := resource.Item.GetInt(path...)
+	if err != nil || !found {
+		return 0
+	}
+	return num
+}
+
 // Look up a referenced resource at a given path
 func (resource *terraformResource) GetStringFromObject(path ...string) string {
-	var ref string
-	found, err := resource.Item.Get(&ref, path...)
+	ref, found, err := resource.Item.GetString(path...)
 	if err != nil || !found {
 		return ""
 	}

--- a/functions/go/export-terraform/terraformgenerator/templates/log-export.tf
+++ b/functions/go/export-terraform/terraformgenerator/templates/log-export.tf
@@ -1,0 +1,45 @@
+{{range $logsink := .LoggingLogSink}}{{ if $logsink.ShouldCreate }}
+module "logsink-{{ $logsink.GetResourceName }}" {
+  source  = "terraform-google-modules/log-export/google"
+  version = "~> 7.3.0"
+
+  destination_uri      = module.{{with or $logsink.References.BigQueryDataset $logsink.References.PubSubTopic $logsink.References.StorageBucket }}{{.GetResourceName}}{{end}}-destination.destination_uri
+  log_sink_name        = "{{ $logsink.GetDisplayName }}"
+  parent_resource_id   = {{ $logsink.GetOrganization.GetTerraformId false }}
+  parent_resource_type = "organization"
+  include_children     = true
+}
+{{end}}{{with $logsink.References.BigQueryDataset }}
+module "{{ .GetResourceName }}-destination" {
+  source  = "terraform-google-modules/log-export/google//modules/bigquery"
+  version = "~> 7.3.0"
+
+  project_id               = module.{{ .Parent.GetResourceName }}.project_id
+  dataset_name             = "{{ .GetResourceName }}"
+  log_sink_writer_identity = module.logsink-{{ $logsink.GetResourceName }}.writer_identity
+  expiration_days          = "365"
+  location                 = "US"
+}
+{{end}}{{with $logsink.References.PubSubTopic }}
+module "{{ .GetResourceName }}-destination" {
+  source  = "terraform-google-modules/log-export/google//modules/pubsub"
+  version = "~> 7.3.0"
+
+  project_id               = module.{{ .Parent.GetResourceName }}.project_id
+  topic_name               = "{{ .GetResourceName }}"
+  log_sink_writer_identity = module.logsink-{{ $logsink.GetResourceName }}.writer_identity
+}
+{{end}}{{with $logsink.References.StorageBucket }}
+module "{{ .GetResourceName }}-destination" {
+  source  = "terraform-google-modules/log-export/google//modules/storage"
+  version = "~> 7.3.0"
+
+  project_id                  = module.{{ .Parent.GetResourceName }}.project_id
+  storage_bucket_name         = "{{ .GetResourceName }}"
+  log_sink_writer_identity    = module.logsink-{{ $logsink.GetResourceName }}.writer_identity
+  uniform_bucket_level_access = true
+  location                    = "US"
+  storage_class               = "MULTI_REGIONAL"
+  retention_policy            = { retention_period_days = 365, is_locked = false }
+}
+{{end}}{{end}}

--- a/functions/go/export-terraform/terraformgenerator/terraform.go
+++ b/functions/go/export-terraform/terraformgenerator/terraform.go
@@ -28,7 +28,7 @@ func (rs *terraformResources) getHCL() (map[string]string, error) {
 	groupedResources := rs.getGrouped()
 
 	data := make(map[string]string)
-	resourceFiles := []string{"folders.tf", "iam.tf", "projects.tf"}
+	resourceFiles := []string{"folders.tf", "iam.tf", "projects.tf", "log-export.tf"}
 	for _, file := range resourceFiles {
 		err := addFile(tmpl, file, groupedResources, data)
 		if err != nil {

--- a/functions/go/export-terraform/terraformgenerator/terraform.go
+++ b/functions/go/export-terraform/terraformgenerator/terraform.go
@@ -15,12 +15,20 @@
 package terraformgenerator
 
 import (
+	"fmt"
+	"math"
 	"strings"
 	"text/template"
+	"time"
 )
 
 func (rs *terraformResources) getHCL() (map[string]string, error) {
-	tmpl, err := template.New("").ParseFS(templates, "templates/*")
+	tmplUtilFns := template.FuncMap{
+		"msToDays": msToDays,
+		"sToDays":  func(t int) (float64, error) { return msToDays(t * 1000) },
+	}
+
+	tmpl, err := template.New("").Funcs(tmplUtilFns).ParseFS(templates, "templates/*")
 	if err != nil {
 		return nil, err
 	}
@@ -69,4 +77,13 @@ func addFile(tmpl *template.Template, name string, inputData interface{}, data m
 	data[name] = content
 
 	return nil
+}
+
+// msToDays converts milliseconds to days rounded to two decimal places
+func msToDays(t int) (float64, error) {
+	d, err := time.ParseDuration(fmt.Sprintf("%dms", t))
+	if err != nil {
+		return 0, err
+	}
+	return math.Round((d.Hours()/24)*100) / 100, nil
 }

--- a/functions/go/export-terraform/terraformgenerator/terraform_generator.go
+++ b/functions/go/export-terraform/terraformgenerator/terraform_generator.go
@@ -41,6 +41,10 @@ func Processor(rl *sdk.ResourceList) error {
 		"IAMPartialPolicy": true,
 		"IAMPolicy":        true,
 		"Project":          true,
+		"LoggingLogSink":   true,
+		"BigQueryDataset":  true,
+		"PubSubTopic":      true,
+		"StorageBucket":    true,
 	}
 
 	for _, item := range rl.Items {

--- a/functions/go/export-terraform/terraformgenerator/terraform_generator_test.go
+++ b/functions/go/export-terraform/terraformgenerator/terraform_generator_test.go
@@ -55,6 +55,10 @@ var testCases = []TerraformTest{
 		Name: "projects",
 		Mode: "terraform",
 	},
+	{
+		Name: "log",
+		Mode: "terraform",
+	},
 }
 
 func TestTerraformGeneration(t *testing.T) {

--- a/functions/go/export-terraform/testdata/log/input/bq.yaml
+++ b/functions/go/export-terraform/testdata/log/input/bq.yaml
@@ -39,7 +39,7 @@ metadata:
     cnrm.cloud.google.com/project-id: prj-logging # kpt-set: ${project-id}
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.4.0
 spec:
-  defaultTableExpirationMs: 3600000 # kpt-set: ${default-table-expiration-ms}
+  defaultTableExpirationMs: 31536000000 # kpt-set: ${default-table-expiration-ms}
   description: "BigQuery audit logs for folder" # kpt-set: ${dataset-description}
   friendlyName: audit-logs # kpt-set: ${dataset-name}
   location: US # kpt-set: ${dataset-location}

--- a/functions/go/export-terraform/testdata/log/input/bq.yaml
+++ b/functions/go/export-terraform/testdata/log/input/bq.yaml
@@ -1,0 +1,45 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# IAM Policy Member
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogSink
+metadata:
+  name: 123456789012-bqsink # kpt-set: ${org-id}-bqsink
+  namespace: logging # kpt-set: ${namespace}
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.4.0
+spec:
+  destination:
+    bigQueryDatasetRef:
+      name: bqlogexportdataset
+  filter: "" # kpt-set: ${filter}
+  includeChildren: true
+  organizationRef:
+    external: "123456789012" # kpt-set: ${org-id}
+---
+# BQ Dataset
+apiVersion: bigquery.cnrm.cloud.google.com/v1beta1
+kind: BigQueryDataset
+metadata:
+  name: bqlogexportdataset
+  namespace: logging # kpt-set: ${namespace}
+  annotations:
+    cnrm.cloud.google.com/delete-contents-on-destroy: "false" # kpt-set: ${delete-contents-on-destroy}
+    cnrm.cloud.google.com/project-id: prj-logging # kpt-set: ${project-id}
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.4.0
+spec:
+  defaultTableExpirationMs: 3600000 # kpt-set: ${default-table-expiration-ms}
+  description: "BigQuery audit logs for folder" # kpt-set: ${dataset-description}
+  friendlyName: audit-logs # kpt-set: ${dataset-name}
+  location: US # kpt-set: ${dataset-location}

--- a/functions/go/export-terraform/testdata/log/input/iam.yaml
+++ b/functions/go/export-terraform/testdata/log/input/iam.yaml
@@ -1,0 +1,47 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# IAM Policy Member
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: bq-project-iam-policy
+  namespace: logging # kpt-set: ${namespace}
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.4.0
+spec:
+  memberFrom:
+    logSinkRef:
+      name: 123456789012-bqsink # kpt-set: ${org-id}-bqsink
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    external: projects/my-project-id # kpt-set: projects/${project-id}
+  role: roles/bigquery.dataEditor
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPartialPolicy
+metadata:
+  name: logging-sa-iam-permissions
+  namespace: config-control # kpt-set: ${management-namespace}
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.4.0
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    external: projects/my-project-id # kpt-set: projects/${project-id}
+  bindings:
+    - role: roles/resourcemanager.projectIamAdmin
+      members:
+        - member: "serviceAccount:logging-sa@management-project-id.iam.gserviceaccount.com" # kpt-set: serviceAccount:logging-sa@${management-project-id}.iam.gserviceaccount.com

--- a/functions/go/export-terraform/testdata/log/input/projects.yaml
+++ b/functions/go/export-terraform/testdata/log/input/projects.yaml
@@ -1,0 +1,27 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# IAM Policy Member
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Project
+metadata:
+  name: prj-logging
+  namespace: projects
+  annotations:
+    cnrm.cloud.google.com/auto-create-network: "true"
+spec:
+  name: prj-logging
+  billingAccountRef:
+    external: AAAAAA-AAAAAA-AAAAAA
+  organizationRef:
+    external: '123456789012'

--- a/functions/go/export-terraform/testdata/log/input/pubsub.yaml
+++ b/functions/go/export-terraform/testdata/log/input/pubsub.yaml
@@ -1,0 +1,39 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# IAM Policy Member
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogSink
+metadata:
+  name: 123456789012-pubsubsink # kpt-set: ${org-id}-pubsubsink
+  namespace: my-namespace # kpt-set: ${namespace}
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.4.0
+spec:
+  destination:
+    pubSubTopicRef:
+      name: pubsub-logexport-dataset # kpt-set: ${topic-name}
+  filter: "" # kpt-set: ${filter}
+  includeChildren: true
+  organizationRef:
+    external: "123456789012" # kpt-set: ${org-id}
+---
+# Pubsub Topic
+apiVersion: pubsub.cnrm.cloud.google.com/v1beta1
+kind: PubSubTopic
+metadata:
+  name: pubsub-logexport-dataset # kpt-set: ${topic-name}
+  namespace: my-namespace # kpt-set: ${namespace}
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.4.0
+    cnrm.cloud.google.com/project-id: prj-logging # kpt-set: ${project-id}

--- a/functions/go/export-terraform/testdata/log/input/storage.yaml
+++ b/functions/go/export-terraform/testdata/log/input/storage.yaml
@@ -1,0 +1,48 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# IAM Policy Member
+# Organization Sink to Storage
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogSink
+metadata:
+  name: 123456789012-storagesink # kpt-set: ${org-id}-storagesink
+  namespace: my-namespace # kpt-set: ${namespace}
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.4.0
+spec:
+  destination:
+    storageBucketRef:
+      name: my-storage-bucket # kpt-set: ${storage-bucket-name}
+  filter: "" # kpt-set: ${filter}
+  includeChildren: true
+  organizationRef:
+    external: "123456789012" # kpt-set: ${org-id}
+---
+# Storage Dataset
+apiVersion: storage.cnrm.cloud.google.com/v1beta1
+kind: StorageBucket
+metadata:
+  name: my-storage-bucket # kpt-set: ${storage-bucket-name}
+  namespace: my-namespace # kpt-set: ${namespace}
+  annotations:
+    cnrm.cloud.google.com/force-destroy: "true"
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:log-export/v0.4.0
+    cnrm.cloud.google.com/project-id: prj-logging # kpt-set: ${project-id}
+spec:
+  bucketPolicyOnly: false # kpt-set: ${bucket-policy-only}
+  location: US # kpt-set: ${location}
+  storageClass: MULTI_REGIONAL # kpt-set: ${storage-class}
+  retentionPolicy:
+    retentionPeriod: 31536000
+    isLocked: false

--- a/functions/go/export-terraform/testdata/log/tf/README.md
+++ b/functions/go/export-terraform/testdata/log/tf/README.md
@@ -1,0 +1,38 @@
+# Google Cloud Foundation Blueprint
+
+This directory contains Terraform configuration for a foundational environment on Google Cloud.
+
+It includes a subset of resources configured via the [setup checklist](https://cloud.google.com/docs/enterprise/setup-checklist)
+and is based on the [security foundations blueprint](https://cloud.google.com/architecture/security-foundations).
+
+## Prerequisites
+
+To run the commands described in this document, you need the following:
+
+1. Install the [Google Cloud SDK](https://cloud.google.com/sdk/install) version 319.0.0 or later
+1. Install [Terraform](https://www.terraform.io/downloads.html) version 0.13.7 or later.
+1. Set up a Google Cloud
+   [organization](https://cloud.google.com/resource-manager/docs/creating-managing-organization).
+1. Set up a Google Cloud
+   [billing account](https://cloud.google.com/billing/docs/how-to/manage-billing-account).
+1. For the user who will run the Terraform install, grant the
+   following roles:
+   -  The `roles/billing.admin` role on the billing account.
+   -  The `roles/resourcemanager.organizationAdmin` role on the Google
+      Cloud organization.
+   -  The `roles/resourcemanager.folderCreator` role on the Google
+      Cloud organization.
+   -  The `roles/resourcemanager.projectCreator` role on the Google
+      Cloud organization.
+
+## Deploying
+
+1. Run `terraform init`.
+1. Run `terraform plan` and review the output.
+1. Run `terraform apply`.
+
+## Next steps
+
+Once you have the basic foundation deployed, you should explore:
+1. Building an [advanced foundation](https://github.com/terraform-google-modules/terraform-example-foundation) using the security blueprint
+2. Automatically deploying Terraform with [Cloud Build](https://cloud.google.com/architecture/managing-infrastructure-as-code)

--- a/functions/go/export-terraform/testdata/log/tf/log-export.tf
+++ b/functions/go/export-terraform/testdata/log/tf/log-export.tf
@@ -58,8 +58,11 @@ module "my-storage-bucket-destination" {
   project_id                  = module.prj-logging.project_id
   storage_bucket_name         = "my-storage-bucket"
   log_sink_writer_identity    = module.logsink-123456789012-storagesink.writer_identity
-  uniform_bucket_level_access = true
+  uniform_bucket_level_access = false
   location                    = "US"
   storage_class               = "MULTI_REGIONAL"
-  retention_policy            = { retention_period_days = 365, is_locked = false }
+  retention_policy = {
+    retention_period_days = 365,
+    is_locked             = false
+  }
 }

--- a/functions/go/export-terraform/testdata/log/tf/log-export.tf
+++ b/functions/go/export-terraform/testdata/log/tf/log-export.tf
@@ -1,0 +1,65 @@
+module "logsink-123456789012-bqsink" {
+  source  = "terraform-google-modules/log-export/google"
+  version = "~> 7.3.0"
+
+  destination_uri      = module.bqlogexportdataset-destination.destination_uri
+  log_sink_name        = "123456789012-bqsink"
+  parent_resource_id   = var.org_id
+  parent_resource_type = "organization"
+  include_children     = true
+}
+
+module "bqlogexportdataset-destination" {
+  source  = "terraform-google-modules/log-export/google//modules/bigquery"
+  version = "~> 7.3.0"
+
+  project_id               = module.prj-logging.project_id
+  dataset_name             = "bqlogexportdataset"
+  log_sink_writer_identity = module.logsink-123456789012-bqsink.writer_identity
+  expiration_days          = "365"
+  location                 = "US"
+}
+
+module "logsink-123456789012-pubsubsink" {
+  source  = "terraform-google-modules/log-export/google"
+  version = "~> 7.3.0"
+
+  destination_uri      = module.pubsub-logexport-dataset-destination.destination_uri
+  log_sink_name        = "123456789012-pubsubsink"
+  parent_resource_id   = var.org_id
+  parent_resource_type = "organization"
+  include_children     = true
+}
+
+module "pubsub-logexport-dataset-destination" {
+  source  = "terraform-google-modules/log-export/google//modules/pubsub"
+  version = "~> 7.3.0"
+
+  project_id               = module.prj-logging.project_id
+  topic_name               = "pubsub-logexport-dataset"
+  log_sink_writer_identity = module.logsink-123456789012-pubsubsink.writer_identity
+}
+
+module "logsink-123456789012-storagesink" {
+  source  = "terraform-google-modules/log-export/google"
+  version = "~> 7.3.0"
+
+  destination_uri      = module.my-storage-bucket-destination.destination_uri
+  log_sink_name        = "123456789012-storagesink"
+  parent_resource_id   = var.org_id
+  parent_resource_type = "organization"
+  include_children     = true
+}
+
+module "my-storage-bucket-destination" {
+  source  = "terraform-google-modules/log-export/google//modules/storage"
+  version = "~> 7.3.0"
+
+  project_id                  = module.prj-logging.project_id
+  storage_bucket_name         = "my-storage-bucket"
+  log_sink_writer_identity    = module.logsink-123456789012-storagesink.writer_identity
+  uniform_bucket_level_access = true
+  location                    = "US"
+  storage_class               = "MULTI_REGIONAL"
+  retention_policy            = { retention_period_days = 365, is_locked = false }
+}

--- a/functions/go/export-terraform/testdata/log/tf/projects.tf
+++ b/functions/go/export-terraform/testdata/log/tf/projects.tf
@@ -1,0 +1,10 @@
+module "prj-logging" {
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 12.0"
+
+  name       = "prj-logging"
+  org_id     = var.org_id
+
+  billing_account = var.billing_account
+  auto_create_network = true
+}

--- a/functions/go/export-terraform/testdata/log/tf/variables.tf
+++ b/functions/go/export-terraform/testdata/log/tf/variables.tf
@@ -1,0 +1,11 @@
+variable "billing_account" {
+  description = "The ID of the billing account to associate projects with"
+  type        = string
+  default     = "AAAAAA-AAAAAA-AAAAAA"
+}
+
+variable "org_id" {
+  description = "The organization id for the associated resources"
+  type        = string
+  default     = "123456789012"
+}

--- a/functions/go/export-terraform/testdata/log/tf/versions.tf
+++ b/functions/go/export-terraform/testdata/log/tf/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">=0.13"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.0.0"
+    }
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/exported-krm/v0.1.0"
+  }
+}


### PR DESCRIPTION
This add support for converting KRM [log-export blueprints](https://github.com/GoogleCloudPlatform/blueprints/tree/main/catalog/log-export/org) to [Terraform blueprints](https://github.com/terraform-google-modules/terraform-google-log-export).