### PR TITLE
support building multi-arch image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,9 +7,9 @@ on:
   pull_request:
     branches:
       - master
-      - '*/v[0-9]+.[0-9]+'
+      - "*/v[0-9]+.[0-9]+"
   schedule:
-    - cron:  '0 17 * * *'
+    - cron: "0 17 * * *"
 
 concurrency:
   # If a job with a concurrency group is running with cancel-in-progress, that job is cancelled when a new job with same concurrency group is started.
@@ -17,7 +17,7 @@ concurrency:
   # Concurrency group will be of form ${{ github.head_ref }}-ci when triggered via PR creating 1 group per PR. Older jobs are cancelled when new commits are pushed to that PR branch.
   # Concurrency group will be of form ${{ github.ref }}-ci when triggered from repo branch or tag ref. Older jobs are cancelled when new jobs are triggered from that same branch/tag.
   # `-ci` suffix is to namespace the concurrency group incase you want to add a group for another workflow in the future.
-  group: '${{ github.head_ref || github.ref }}-ci'
+  group: "${{ github.head_ref || github.ref }}-ci"
   cancel-in-progress: true
 
 jobs:
@@ -27,11 +27,11 @@ jobs:
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-    - uses: actions/checkout@v2
-    - name: Lint shell scripts, ignoring third-party files
-      run: |
-        find . -name "*.sh" > shell_files.out
-        shellcheck $(cat shell_files.out)
+      - uses: actions/checkout@v2
+      - name: Lint shell scripts, ignoring third-party files
+        run: |
+          find . -name "*.sh" > shell_files.out
+          shellcheck $(cat shell_files.out)
 
   ts-unit-test-ci:
     strategy:
@@ -40,18 +40,18 @@ jobs:
         node-version: [14.x]
     runs-on: ${{ matrix.platform }}
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Run unit tests
-      run: |
-        make unit-test-ts
-    - name: Check licenses
-      run: |
-        cd functions/ts
-        make check-licenses
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Run unit tests
+        run: |
+          make unit-test-ts
+      - name: Check licenses
+        run: |
+          cd functions/ts
+          make check-licenses
 
   go-unit-test-ci:
     runs-on: ubuntu-latest
@@ -59,25 +59,25 @@ jobs:
       GOPATH: /home/runner/work/kpt-functions-catalog/functions/go
       GO111MODULE: on
     steps:
-    - name: Set up Go 1.17
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.17
-      id: go
-    - name: Check out code into GOPATH
-      uses: actions/checkout@v1
-      with:
-        path: go/src/github.com/${{ github.repository }}
-    - name: Run unit tests
-      run: |
-        make unit-test-go
-    - name: Check licenses
-      run: |
-        cd functions/go
-        make check-licenses
+      - name: Set up Go 1.17
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+        id: go
+      - name: Check out code into GOPATH
+        uses: actions/checkout@v1
+        with:
+          path: go/src/github.com/${{ github.repository }}
+      - name: Run unit tests
+        run: |
+          make unit-test-go
+      - name: Check licenses
+        run: |
+          cd functions/go
+          make check-licenses
 
   e2e-ci:
-    needs: [ts-unit-test-ci, go-unit-test-ci]
+    timeout-minutes: 60
     strategy:
       matrix:
         platform: [ubuntu-latest]
@@ -87,23 +87,23 @@ jobs:
       GOPATH: /home/runner/work/kpt-functions-catalog/functions/go
       GO111MODULE: on
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Set up Go 1.17
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.17
-    - name: Install kpt
-      run: |
-        go install github.com/GoogleContainerTools/kpt@main
-    - name: Build node and Go docker images
-      if: matrix.platform == 'ubuntu-latest'
-      run: |
-        make build
-    - name: Run all tests
-      if: matrix.platform == 'ubuntu-latest'
-      run: |
-        make e2e-test
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Set up Go 1.17
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Install kpt
+        run: |
+          go install github.com/GoogleContainerTools/kpt@main
+      - name: Build node and Go docker images
+        if: matrix.platform == 'ubuntu-latest'
+        run: |
+          make build
+      - name: Run all tests
+        if: matrix.platform == 'ubuntu-latest'
+        run: |
+          make e2e-test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,8 @@ $ make unit-test
 
 #### Building a function image
 
+Note: We use `docker buildx` to build images. Please ensure you have it installed.
+
 To build all function images
 ```shell
 $ make build

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 SHELL=/bin/bash
-TAG := dev
+TAG := unstable
 
 .DEFAULT_GOAL := help
 .PHONY: help

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -16,7 +16,6 @@
 
 repo_base=$(cd "$(dirname "$(dirname "$0")")" || exit ; pwd)
 
-UNSTABLE_TAG=unstable
 DEFAULT_GCR=${DEFAULT_GCR:-gcr.io/kpt-fn-contrib}
 GCR_REGISTRY=${GCR_REGISTRY:-${DEFAULT_GCR}}
 
@@ -26,9 +25,11 @@ function err {
 }
 
 function docker_build {
-  type=$1 # function type, e.g. contrib, curated
-  lang=$2 # function language, e.g. go, ts
-  name=$3 # function name, e.g. apply-setters
+  action=$1 # docker buildx operation, it should be either load or push.
+  type=$2 # function type, e.g. contrib, curated
+  lang=$3 # function language, e.g. go, ts
+  name=$4 # function name, e.g. apply-setters
+  tag=$5 # function tag, e.g. v1.2.3
 
   build_args=()
 
@@ -58,26 +59,28 @@ function docker_build {
   build_args+=(--build-arg "BUILDER_IMAGE=${BUILDER_IMAGE}")
   build_args+=(--build-arg "BASE_IMAGE=${BASE_IMAGE}")
 
-  # Use + conditional parameter expansion to protect from unbound array variable
-  docker build \
-    -t "${GCR_REGISTRY}/${name}:${UNSTABLE_TAG}" \
-    -f "${dockerfile}" \
-    "${build_args[@]+"${build_args[@]}"}" \
-    "${function_dir}"
-}
+  echo "building ${GCR_REGISTRY}/${name}:${tag}"
 
-function docker_push {
-  name=$1 # function name, e.g. apply-setters
-  version=$2 # function version, e.g. v0.1.1
-
-  docker push "${GCR_REGISTRY}/${name}:${version}"
-}
-
-
-function docker_tag {
-  name=$1 # function name, e.g. apply-setters
-  version=$2 # function version, e.g. v0.1.1
-
-  echo tagging "${GCR_REGISTRY}/${name}:${version}"
-  docker tag "${GCR_REGISTRY}/${name}:${UNSTABLE_TAG}" "${GCR_REGISTRY}/${name}:${version}"
+  case "${action}" in
+    load)
+      # Use + conditional parameter expansion to protect from unbound array variable
+      docker buildx build --load \
+        -t "${GCR_REGISTRY}/${name}:${tag}" \
+        -f "${dockerfile}" \
+        "${build_args[@]+"${build_args[@]}"}" \
+        "${function_dir}"    
+      ;;
+    push)
+      # build and push multi-arch image.
+      docker buildx build --push \
+        -t "${GCR_REGISTRY}/${name}:${tag}" \
+        -f "${dockerfile}" \
+        --platform "linux/amd64,linux/arm64" \
+        "${build_args[@]+"${build_args[@]}"}" \
+        "${function_dir}"    
+      ;;
+    *)
+      echo "action must be load or push"
+      exit 1
+  esac
 }

--- a/scripts/function-release.sh
+++ b/scripts/function-release.sh
@@ -43,7 +43,7 @@ if [ -d "${scripts_dir}/../functions/${fn_lang}/${fn_name}" ]; then
   if [ "${fn_lang}" == "go" ]; then
     make install-mdtogo
   fi
-  DEFAULT_GCR=gcr.io/kpt-fn
+  DEFAULT_GCR="${DEFAULT_GCR:=gcr.io/kpt-fn}"
 fi
 
 if [ -d "${scripts_dir}/../contrib/functions/${fn_lang}/${fn_name}" ]; then
@@ -51,7 +51,7 @@ if [ -d "${scripts_dir}/../contrib/functions/${fn_lang}/${fn_name}" ]; then
   if [ "${fn_lang}" == "go" ]; then
     make install-mdtogo
   fi
-  DEFAULT_GCR=gcr.io/kpt-fn-contrib
+  DEFAULT_GCR="${DEFAULT_GCR:=gcr.io/kpt-fn-contrib}"
 fi
 
 case "$1" in

--- a/scripts/go-function-release.sh
+++ b/scripts/go-function-release.sh
@@ -50,14 +50,13 @@ FUNCTION_TYPE="$2"
 
 case "$1" in
   build)
-    docker_build "${FUNCTION_TYPE}" "go" "${CURRENT_FUNCTION}"
     for version in ${versions}; do
-      docker_tag "${CURRENT_FUNCTION}" "${version}"
+      docker_build "load" "${FUNCTION_TYPE}" "go" "${CURRENT_FUNCTION}" "${version}"
     done
     ;;
   push)
     for version in ${versions}; do
-      docker_push "${CURRENT_FUNCTION}" "${version}"
+      docker_build "push" "${FUNCTION_TYPE}" "go" "${CURRENT_FUNCTION}" "${version}"
     done
     ;;
   *)

--- a/scripts/ts-function-release.sh
+++ b/scripts/ts-function-release.sh
@@ -53,15 +53,13 @@ export npm_package_kpt_docker_repo_base="${GCR_REGISTRY}"
 
 case "$1" in
   build)
-    docker_build "${FUNCTION_TYPE}" "ts" "${CURRENT_FUNCTION}"
     for version in ${versions}; do
-      docker_tag "${CURRENT_FUNCTION}" "${version}"
+      docker_build "load" "${FUNCTION_TYPE}" "ts" "${CURRENT_FUNCTION}" "${version}"
     done
     ;;
   push)
     for version in ${versions}; do
-      docker_tag "${CURRENT_FUNCTION}" "${version}"
-      docker_push "${CURRENT_FUNCTION}" "${version}"
+      docker_build "push" "${FUNCTION_TYPE}" "ts" "${CURRENT_FUNCTION}" "${version}"
     done
     ;;
   *)


### PR DESCRIPTION
In the `build` target, we only build the matching one. This is because `docker buildx` doesn't support exporting an multi-arch image to local. And building multi-arch image locally is not useful for users and it's more time consuming.
In the `push` target, we build for both amd64 and arm64.

fixes: https://github.com/GoogleContainerTools/kpt/issues/2874
fixes: https://github.com/GoogleContainerTools/kpt/issues/2775