### PR TITLE
update Dockerfile used in the release pipeline

### DIFF
--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -19,10 +19,10 @@
 FROM docker
 
 # Install gcc, bash, make and curl
-RUN apk add --no-cache build-base
-RUN apk add --no-cache bash
-RUN apk add --no-cache make
-RUN apk add --no-cache curl
+RUN apk add --no-cache build-base bash make curl
+
+# Install buildx
+COPY --from=docker/buildx-bin:latest /buildx /usr/libexec/docker/cli-plugins/docker-buildx
 
 # Install golang
 COPY --from=golang:1.17-alpine /usr/local/go/ /usr/local/go/


### PR DESCRIPTION
We use Louhi in our release pipeline. It underneath uses GCB.
We use this Dockerfile to build an image that contains go toolchain and node runtime so that we can use it in GCB.
