### PR TITLE
preprocessing step for render-helm-chart private repo tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,6 +103,12 @@ jobs:
         if: matrix.platform == 'ubuntu-latest'
         run: |
           make build
+      - name: Write creds to files for render-helm-chart tests
+        if: matrix.platform == 'ubuntu-latest'
+        run: |
+          echo -e 'username=${{ secrets.RENDER_HELM_CHART_BOT_TOKEN }}\npassword=${{ secrets.RENDER_HELM_CHART_BOT_TOKEN }}' \
+          > ./examples/render-helm-chart-kustomize-private-git/credentials.env
+          echo ${{ secrets.RENDER_HELM_CHART_GCP_SERVICE_ACCOUNT }} | base64 -d > ./examples/render-helm-chart-kustomize-private-oci/password
       - name: Run all tests
         if: matrix.platform == 'ubuntu-latest'
         run: |

--- a/examples/render-helm-chart-kustomize-private-git/credentials.env
+++ b/examples/render-helm-chart-kustomize-private-git/credentials.env
@@ -1,3 +1,4 @@
-# This will contain credentials for accessing the private Git repo.
+# This will contain credentials for accessing the private Git repo. The <GH_TOKEN> is populated by
+# the CI, so this test won't work locally.
 username=<GH_TOKEN>
 password=<GH_TOKEN>

--- a/examples/render-helm-chart-kustomize-private-git/credentials.env
+++ b/examples/render-helm-chart-kustomize-private-git/credentials.env
@@ -1,0 +1,3 @@
+# This will contain credentials for accessing the private Git repo.
+username=<GH_TOKEN>
+password=<GH_TOKEN>

--- a/examples/render-helm-chart-kustomize-private-oci/password
+++ b/examples/render-helm-chart-kustomize-private-oci/password
@@ -1,1 +1,2 @@
-# This will contain the SA key for acessing the private OCI registry.
+# This will contain the SA key for acessing the private OCI registry. This file will be populated
+# by the CI, so this test won't work locally.

--- a/examples/render-helm-chart-kustomize-private-oci/password
+++ b/examples/render-helm-chart-kustomize-private-oci/password
@@ -1,0 +1,1 @@
+# This will contain the SA key for acessing the private OCI registry.

--- a/functions/go/render-helm-chart/metadata.yaml
+++ b/functions/go/render-helm-chart/metadata.yaml
@@ -10,6 +10,8 @@ examplePackageURLs:
   - https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/examples/render-helm-chart-remote-values-file
   - https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/examples/render-helm-chart-kustomize-inline-values
   - https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/examples/render-helm-chart-kustomize-values-files
+  - https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/examples/render-helm-chart-kustomize-private-git
+  - https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/examples/render-helm-chart-kustomize-private-oci
 emails:
   - kpt-team@google.com
 license: Apache-2.0

--- a/scripts/verify-docs.py
+++ b/scripts/verify-docs.py
@@ -35,7 +35,7 @@ directories_to_skip = ['_template', 'dist', 'node_modules']
 examples_directory = 'examples'
 functions_directory = 'functions'
 lang_dirs = ['go', 'ts']
-examples_directories_to_skip = ['_template']
+examples_directories_to_skip = ['_template', 'render-helm-chart-kustomize-private-oci', 'render-helm-chart-kustomize-private-git']
 fn_directories_to_skip = ['inflate-helm-chart']
 required_fields = ['image', 'description', 'tags', 'sourceURL', 'examplePackageURLs', 'emails', 'license']
 kpt_team_email = 'kpt-team@google.com'
@@ -62,6 +62,8 @@ def validate_examples_dir_for_master_branch(fn_name_to_examples, contrib):
             examples_seen.add(example_name)
             if not example_name.startswith(fn_name):
                 raise Exception(f'example name {example_name} must start with the function name {fn_name}')
+            if example_name in examples_directories_to_skip:
+                continue
             validate_example_md(fn_name, curr_examples_dir, example_name, 'master')
             if not eval_or_exec_script(os.path.join(curr_examples_dir, example_name)):
                 validate_example_kptfile(fn_name, curr_examples_dir, example_name, 'master', contrib)


### PR DESCRIPTION
Related to https://github.com/GoogleContainerTools/kpt-functions-catalog/pull/875

Writes the Secrets to the necessary files as a preprocessing step. I'm doing this separately from https://github.com/GoogleContainerTools/kpt-functions-catalog/pull/875 because PRs from forks cannot access Github Secrets. So this needs to go in first, then https://github.com/GoogleContainerTools/kpt-functions-catalog/pull/875 can use it. 