### PR TITLE
fix:adds log-sink writer id to the export-terraform fn

### DIFF
--- a/functions/go/export-terraform/terraformgenerator/templates/log-export.tf
+++ b/functions/go/export-terraform/terraformgenerator/templates/log-export.tf
@@ -48,7 +48,7 @@ module "{{ .GetResourceName }}-destination" {
 {{end}}{{with $logsink.References.LoggingLogBucket }}
 module "{{ .GetResourceName }}-destination" {
   source  = "terraform-google-modules/log-export/google//modules/logbucket"
-  version = "~> 7.4.0"
+  version = "~> 7.4.1"
 
   project_id               = module.{{ .Parent.GetResourceName }}.project_id
   name                     = "{{ .GetResourceName }}"{{ with .GetStringFromObject "spec" "location" }}

--- a/functions/go/export-terraform/terraformgenerator/templates/log-export.tf
+++ b/functions/go/export-terraform/terraformgenerator/templates/log-export.tf
@@ -50,9 +50,10 @@ module "{{ .GetResourceName }}-destination" {
   source  = "terraform-google-modules/log-export/google//modules/logbucket"
   version = "~> 7.4.0"
 
-  project_id      = module.{{ .Parent.GetResourceName }}.project_id
-  name            = "{{ .GetResourceName }}"{{ with .GetStringFromObject "spec" "location" }}
-  location        = "{{.}}"{{end}}{{ if .GetInt "spec" "retentionDays" }}
-  retention_days  = {{ .GetInt "spec" "retentionDays" }}{{end}}
+  project_id               = module.{{ .Parent.GetResourceName }}.project_id
+  name                     = "{{ .GetResourceName }}"{{ with .GetStringFromObject "spec" "location" }}
+  location                 = "{{.}}"{{end}}{{ if .GetInt "spec" "retentionDays" }}
+  retention_days           = {{ .GetInt "spec" "retentionDays" }}{{end}}
+  log_sink_writer_identity = module.logsink-{{ $logsink.GetResourceName }}.writer_identity
 }
 {{end}}{{end}}

--- a/functions/go/export-terraform/testdata/log/tf/log-export.tf
+++ b/functions/go/export-terraform/testdata/log/tf/log-export.tf
@@ -35,10 +35,11 @@ module "my-log-k8s-bucket-destination" {
   source  = "terraform-google-modules/log-export/google//modules/logbucket"
   version = "~> 7.4.0"
 
-  project_id      = module.prj-logging.project_id
-  name            = "my-log-k8s-bucket"
-  location        = "global"
-  retention_days  = 30
+  project_id               = module.prj-logging.project_id
+  name                     = "my-log-k8s-bucket"
+  location                 = "global"
+  retention_days           = 30
+  log_sink_writer_identity = module.logsink-123456789012-orglogbucketsink.writer_identity
 }
 
 module "logsink-123456789012-pubsubsink" {

--- a/functions/go/export-terraform/testdata/log/tf/log-export.tf
+++ b/functions/go/export-terraform/testdata/log/tf/log-export.tf
@@ -33,7 +33,7 @@ module "logsink-123456789012-orglogbucketsink" {
 
 module "my-log-k8s-bucket-destination" {
   source  = "terraform-google-modules/log-export/google//modules/logbucket"
-  version = "~> 7.4.0"
+  version = "~> 7.4.1"
 
   project_id               = module.prj-logging.project_id
   name                     = "my-log-k8s-bucket"


### PR DESCRIPTION
This extends the terraform-export fn template to include `log_sink_writer_identity` for the log-bucket destination.