### PR TITLE
remove KUBEVAL_BUILDER_IMAGE from generic defaults

### DIFF
--- a/build/docker/ts/defaults.env
+++ b/build/docker/ts/defaults.env
@@ -1,3 +1,2 @@
 BUILDER_IMAGE=node:14.19-alpine3.15
-KUBEVAL_BUILDER_IMAGE=golang:1.17-alpine3.15
 BASE_IMAGE=node:14.19-alpine3.15

--- a/functions/ts/kubeval/build/kubeval.Dockerfile
+++ b/functions/ts/kubeval/build/kubeval.Dockerfile
@@ -1,6 +1,5 @@
 ARG BUILDER_IMAGE
 ARG BASE_IMAGE
-ARG KUBEVAL_BUILDER_IMAGE
 
 FROM --platform=$BUILDPLATFORM $BUILDER_IMAGE AS builder
 
@@ -24,7 +23,7 @@ RUN npm run build && \
 
 #############################################
 
-FROM --platform=$BUILDPLATFORM $KUBEVAL_BUILDER_IMAGE AS kubeval-builder
+FROM --platform=$BUILDPLATFORM golang:1.17-alpine3.15 AS kubeval-builder
 
 ARG TARGETOS TARGETARCH
 ARG KUBEVAL_VERSION="v0.16.1"

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -56,12 +56,8 @@ function docker_build {
   [[ -f "${defaults}" ]] || err "defaults file does not exist: ${defaults}"
   # shellcheck source=/dev/null
   source "${defaults}"
-  # build_args+=(--build-arg "KUBEVAL_BUILDER_IMAGE=${KUBEVAL_BUILDER_IMAGE}")
   build_args+=(--build-arg "BUILDER_IMAGE=${BUILDER_IMAGE}")
   build_args+=(--build-arg "BASE_IMAGE=${BASE_IMAGE}")
-  if [ "$name" = "kubeval" ]; then
-    build_args+=(--build-arg "KUBEVAL_BUILDER_IMAGE=${KUBEVAL_BUILDER_IMAGE}")
-  fi
 
   echo "building ${GCR_REGISTRY}/${name}:${tag}"
 


### PR DESCRIPTION
The defaults file is intended for generic default values that can be
shared for Dockerfiles across multiple functions. In this case
KUBEVAL_BUILDER_IMAGE is specific to the kubeval function and can simply
be defined in the dockerfile for that function.