### PR TITLE
fix: `set-image` with more matching rules

### DIFF
--- a/tests/set-image/containerName-mismatch/.expected/diff.patch
+++ b/tests/set-image/containerName-mismatch/.expected/diff.patch
@@ -1,0 +1,14 @@
+diff --git a/resources.yaml b/resources.yaml
+index f674e0b..ae7d829 100644
+--- a/resources.yaml
++++ b/resources.yaml
+@@ -5,6 +5,6 @@ metadata:
+ spec:
+   containers:
+     - name: server
+-      image: nginx:1.20.2
++      image: bar:v1.0
+     - name: store
+-      image: nginx:14.1
+\ No newline at end of file
++      image: bar:v1.0

--- a/tests/set-image/containerName-mismatch/.expected/results.yaml
+++ b/tests/set-image/containerName-mismatch/.expected/results.yaml
@@ -1,0 +1,19 @@
+apiVersion: kpt.dev/v1
+kind: FunctionResultList
+metadata:
+  name: fnresults
+exitCode: 0
+items:
+  - image: gcr.io/kpt-fn/set-image:unstable
+    exitCode: 0
+    results:
+      - message: '[warning]: container name `server` does not match `store`, only image name matches'
+        severity: error
+        resourceRef:
+          apiVersion: v1
+          kind: Pod
+          name: app1
+        file:
+          path: resources.yaml
+      - message: 'summary: updated a total of 2 image(s)'
+        severity: info

--- a/tests/set-image/containerName-mismatch/.krmignore
+++ b/tests/set-image/containerName-mismatch/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/tests/set-image/containerName-mismatch/Kptfile
+++ b/tests/set-image/containerName-mismatch/Kptfile
@@ -1,0 +1,12 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: example
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/set-image:unstable
+      configMap:
+        imageName: nginx
+        containerName: server
+        newName: bar
+        newTag: v1.0

--- a/tests/set-image/containerName-mismatch/resources.yaml
+++ b/tests/set-image/containerName-mismatch/resources.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app1
+spec:
+  containers:
+    - name: server
+      image: nginx:1.20.2
+    - name: store
+      image: nginx:14.1

--- a/tests/set-image/no-image-name/.expected/config.yaml
+++ b/tests/set-image/no-image-name/.expected/config.yaml
@@ -2,4 +2,4 @@ apiVersion: kpt.dev/v1
 kind: FunctionResultList
 metadata:
   name: fnresults
-exitCode: 1
+exitCode: 0

--- a/tests/set-image/no-image-name/.expected/diff.patch
+++ b/tests/set-image/no-image-name/.expected/diff.patch
@@ -1,0 +1,14 @@
+diff --git a/resources.yaml b/resources.yaml
+index f674e0b..ae7d829 100644
+--- a/resources.yaml
++++ b/resources.yaml
+@@ -5,6 +5,6 @@ metadata:
+ spec:
+   containers:
+     - name: server
+-      image: nginx:1.20.2
++      image: bar:v1.0
+     - name: store
+-      image: nginx:14.1
+\ No newline at end of file
++      image: bar:v1.0

--- a/tests/set-image/no-image-name/.expected/results.yaml
+++ b/tests/set-image/no-image-name/.expected/results.yaml
@@ -2,13 +2,10 @@ apiVersion: kpt.dev/v1
 kind: FunctionResultList
 metadata:
   name: fnresults
-exitCode: 1
+exitCode: 0
 items:
   - image: gcr.io/kpt-fn/set-image:unstable
-    stderr: 'failed to evaluate function: function is terminated: must specify `name`'
-    exitCode: 1
+    exitCode: 0
     results:
-      - message: must specify `name`
-        severity: error
-      - message: 'function is terminated: must specify `name`'
-        severity: error
+      - message: 'summary: updated a total of 2 image(s)'
+        severity: info

--- a/tests/set-image/no-image-name/resources.yaml
+++ b/tests/set-image/no-image-name/resources.yaml
@@ -1,7 +1,10 @@
-apiVersion: config.kubernetes.io/v1
-kind: ResourceList
+apiVersion: v1
+kind: Pod
 metadata:
-  name: my-resource
-items:
-- apiVersion: v1
-  kind: ConfigMap
+  name: app1
+spec:
+  containers:
+    - name: server
+      image: nginx:1.20.2
+    - name: store
+      image: nginx:14.1


### PR DESCRIPTION
to fix issue https://github.com/GoogleContainerTools/kpt/issues/3444
provide `containerName` and `imageName` as input, support `containerName` matching, support `imageName` omission inside input