### PR TITLE
feat: support routes in export-terraform

### DIFF
--- a/functions/go/export-terraform/README.md
+++ b/functions/go/export-terraform/README.md
@@ -27,6 +27,7 @@ The following KCC resources are supported:
 - ComputeNetwork
 - ComputeSubnetwork
 - ComputeFirewall
+- ComputeRoute
 - ComputeRouter
 - ComputeRouterNAT
 - ComputeAddress

--- a/functions/go/export-terraform/terraformgenerator/templates/network.tf
+++ b/functions/go/export-terraform/terraformgenerator/templates/network.tf
@@ -22,6 +22,17 @@ module "{{ $vpc.GetResourceName }}" {
             subnet_flow_logs_interval = "{{ $subnet.GetStringFromObject "spec" "logConfig" "aggregationInterval" }}"{{end}}
         },{{end}}
     ]
+    {{if $vpc.GetChildrenByKind "ComputeRoute"}}
+    routes = [
+      {{range $route := $vpc.GetChildrenByKind "ComputeRoute" }}{
+        name = "{{ $route.GetResourceName }}"{{ with $route.GetStringFromObject "spec" "description" }}
+        description = "{{ . }}"{{end}}{{ with $route.GetStringFromObject "spec" "destRange" }}
+        destination_range = "{{ . }}"{{end}}{{ with $route.GetInt "spec" "priority" }}
+        priority = "{{ . }}"{{end}}{{ with $route.GetStringFromObject "spec" "nextHopGateway" }}{{if eq . "default-internet-gateway"}}
+        next_hop_internet = "true"{{end}}{{end}}{{ with $route.GetStringsFromObject "spec" "tags" }}
+        tags = "{{ . | strSliceToCommaSepStr }}"{{end}}
+      },{{end}}
+    ]{{end}}
 }
 # Firewall Rules{{range $fw := $vpc.GetChildrenByKind "ComputeFirewall" }}
 resource "google_compute_firewall" "{{ $fw.GetResourceName }}" {

--- a/functions/go/export-terraform/terraformgenerator/terraform.go
+++ b/functions/go/export-terraform/terraformgenerator/terraform.go
@@ -24,8 +24,9 @@ import (
 
 func (rs *terraformResources) getHCL() (map[string]string, error) {
 	tmplUtilFns := template.FuncMap{
-		"msToDays": msToDays,
-		"sToDays":  func(t int) (float64, error) { return msToDays(t * 1000) },
+		"msToDays":              msToDays,
+		"sToDays":               func(t int) (float64, error) { return msToDays(t * 1000) },
+		"strSliceToCommaSepStr": func(s []string) string { return strings.Join(s, ",") },
 	}
 
 	tmpl, err := template.New("").Funcs(tmplUtilFns).ParseFS(templates, "templates/*")

--- a/functions/go/export-terraform/terraformgenerator/terraform_generator.go
+++ b/functions/go/export-terraform/terraformgenerator/terraform_generator.go
@@ -48,6 +48,7 @@ func Processor(rl *sdk.ResourceList) error {
 		"IAMAuditConfig":              true,
 		"ComputeNetwork":              true,
 		"ComputeSubnetwork":           true,
+		"ComputeRoute":                true,
 		"ComputeRouter":               true,
 		"ComputeRouterNAT":            true,
 		"ComputeAddress":              true,

--- a/functions/go/export-terraform/testdata/multi-network/tf/network.tf
+++ b/functions/go/export-terraform/testdata/multi-network/tf/network.tf
@@ -31,6 +31,7 @@ module "vpc-shared-dev" {
             subnet_flow_logs_interval = "INTERVAL_10_MIN"
         },
     ]
+    
 }
 # Firewall Rules
 resource "google_compute_firewall" "vpc-shared-dev-allow-iap-rdp" {
@@ -198,6 +199,7 @@ module "vpc-shared-prod" {
             subnet_flow_logs_interval = "INTERVAL_10_MIN"
         },
     ]
+    
 }
 # Firewall Rules
 resource "google_compute_firewall" "vpc-shared-prod-allow-iap-rdp" {

--- a/functions/go/export-terraform/testdata/network/input/routes.yaml
+++ b/functions/go/export-terraform/testdata/network/input/routes.yaml
@@ -1,0 +1,46 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeRoute
+metadata:
+  name: rt-vpc-shared-base-1000-all-default-private-api # kpt-set: rt-${network-name}-1000-all-default-private-api
+  namespace: config-control # kpt-set: ${namespace}
+  annotations:
+    cnrm.cloud.google.com/blueprint: 'kpt-fn-live'
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  description: "Route through IGW to allow private google api access."
+  destRange: 199.36.153.8/30
+  networkRef:
+    name: vpc-shared-base # kpt-set: ${network-name}
+  priority: 1000
+  nextHopGateway: "default-internet-gateway"
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeRoute
+metadata:
+  name: rt-vpc-shared-base-1000-egress-internet-default # kpt-set: rt-${network-name}-1000-egress-internet-default
+  namespace: config-control # kpt-set: ${namespace}
+  annotations:
+    cnrm.cloud.google.com/blueprint: 'kpt-fn-live'
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+spec:
+  description: "Tag based route through IGW to access internet"
+  destRange: 0.0.0.0/0
+  networkRef:
+    name: vpc-shared-base # kpt-set: ${network-name}
+  priority: 1000
+  nextHopGateway: "default-internet-gateway"
+  tags:
+  - "egress-internet"

--- a/functions/go/export-terraform/testdata/network/tf/network.tf
+++ b/functions/go/export-terraform/testdata/network/tf/network.tf
@@ -31,6 +31,23 @@ module "vpc-shared-base" {
             subnet_flow_logs_interval = "INTERVAL_10_MIN"
         },
     ]
+    
+    routes = [
+      {
+        name = "rt-vpc-shared-base-1000-all-default-private-api"
+        description = "Route through IGW to allow private google api access."
+        destination_range = "199.36.153.8/30"
+        priority = "1000"
+        next_hop_internet = "true"
+      },{
+        name = "rt-vpc-shared-base-1000-egress-internet-default"
+        description = "Tag based route through IGW to access internet"
+        destination_range = "0.0.0.0/0"
+        priority = "1000"
+        next_hop_internet = "true"
+        tags = "egress-internet"
+      },
+    ]
 }
 # Firewall Rules
 resource "google_compute_firewall" "vpc-shared-base-allow-iap-rdp" {


### PR DESCRIPTION
This adds support for exporting ComputeRoute.
b/243555859