### PR TITLE
Fix some incorrect/duplicate go.mod paths

### DIFF
--- a/functions/go/remove-local-config-resources/go.mod
+++ b/functions/go/remove-local-config-resources/go.mod
@@ -1,4 +1,4 @@
-module github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/format
+module github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/remove-local-config-resources
 
 go 1.18
 

--- a/functions/go/set-enforcement-action/go.mod
+++ b/functions/go/set-enforcement-action/go.mod
@@ -1,4 +1,4 @@
-module github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/format
+module github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/set-enforcement-action
 
 go 1.18
 

--- a/scripts/generate_catalog/go.mod
+++ b/scripts/generate_catalog/go.mod
@@ -1,4 +1,4 @@
-module github.com/GoogleContainerTools/kpt-functions-catalog
+module github.com/GoogleContainerTools/kpt-functions-catalog/scripts/generate_catalog
 
 go 1.17
 

--- a/scripts/update_function_docs/go.mod
+++ b/scripts/update_function_docs/go.mod
@@ -1,4 +1,4 @@
-module github.com/GoogleContainerTools/kpt-functions-catalog
+module github.com/GoogleContainerTools/kpt-functions-catalog/scripts/update_function_docs
 
 go 1.17
 


### PR DESCRIPTION
This was causing some IDE warnings.
