### PR TITLE
convert starlark to wasm

### DIFF
--- a/functions/go/starlark/main.go
+++ b/functions/go/starlark/main.go
@@ -2,13 +2,10 @@ package main
 
 import (
 	"os"
-
-	"github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/starlark/starlark"
-	"github.com/GoogleContainerTools/kpt-functions-sdk/go/fn"
 )
 
 func main() {
-	if err := fn.AsMain(fn.ResourceListProcessorFunc(starlark.Process)); err != nil {
+	if err := run(); err != nil {
 		os.Exit(1)
 	}
 }

--- a/functions/go/starlark/run.go
+++ b/functions/go/starlark/run.go
@@ -1,0 +1,26 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !(js && wasm)
+
+package main
+
+import (
+	"github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/starlark/starlark"
+	"github.com/GoogleContainerTools/kpt-functions-sdk/go/fn"
+)
+
+func run() error {
+	return fn.AsMain(fn.ResourceListProcessorFunc(starlark.Process))
+}

--- a/functions/go/starlark/run_js.go
+++ b/functions/go/starlark/run_js.go
@@ -1,0 +1,55 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build js && wasm
+
+package main
+
+import (
+	"fmt"
+	"syscall/js"
+
+	"github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/starlark/starlark"
+	"github.com/GoogleContainerTools/kpt-functions-sdk/go/fn"
+)
+
+func run() error {
+	// Register js function processResourceList to the globals.
+	js.Global().Set("processResourceList", resourceListProcessorWrapper())
+	// We need to ensure that the Go program is running when JavaScript calls it.
+	// Otherwise, it will complain the Go program has already exited.
+	<-make(chan bool)
+	return nil
+}
+
+func executeStarlark(input []byte) ([]byte, error) {
+	return fn.Run(fn.ResourceListProcessorFunc(starlark.Process), []byte(input))
+}
+
+func resourceListProcessorWrapper() js.Func {
+	// TODO: figure out a better way to surface a golang error to JS environment.
+	// Currently error is surfaced as a string.
+	jsonFunc := js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		if len(args) != 1 {
+			return "Invalid number of arguments passed"
+		}
+		input := args[0].String()
+		applied, err := executeStarlark([]byte(input))
+		if err != nil {
+			return fmt.Errorf("unable to process resource list:", err.Error())
+		}
+		return string(applied)
+	})
+	return jsonFunc
+}


### PR DESCRIPTION
Like https://github.com/GoogleContainerTools/kpt-functions-catalog/pull/898 and https://github.com/GoogleContainerTools/kpt-functions-catalog/pull/911 - this PR adds wasm functionality to the starlark function.

I validated the working of this function by running the examples from https://catalog.kpt.dev/starlark/v0.4/ (bottom of the page), and compare the output of the current function with a manually compiled and pushed version. 