### PR TITLE
`render-helm-chart`: add example with local values files and fix error message

### DIFF
--- a/examples/render-helm-chart-kustomize-values-files/README.md
+++ b/examples/render-helm-chart-kustomize-values-files/README.md
@@ -8,8 +8,13 @@ function with kustomize using multiple values files.
 ### Function invocation
 
 To use the function with kustomize, you can specify the `functionConfig`
-in your kustomization's `generators` field. This example specifies multiple remote
-values files to use instead of the default values accompanying the chart:
+in your kustomization's `generators` field. This example specifies multiple
+values files to use instead of the default values accompanying the chart.
+These values files can either be remote or local.
+
+#### Remote values files
+
+Here is an example kustomization file with remote values files:
 
 kustomization.yaml:
 ```yaml
@@ -36,6 +41,59 @@ generators:
         valuesFiles:
           - https://raw.githubusercontent.com/natasha41575/kpt-functions-catalog/a9c9cd765a05f7a7fb6923dbde4651b62c9c229c/examples/render-helm-chart-kustomize-values-files/file1.yaml
           - https://raw.githubusercontent.com/natasha41575/kpt-functions-catalog/a9c9cd765a05f7a7fb6923dbde4651b62c9c229c/examples/render-helm-chart-kustomize-values-files/file2.yaml
+```
+
+Then, to build the kustomization with kustomize v4:
+
+```shell
+kustomize build --enable-alpha-plugins --network .
+```
+
+#### Local values files
+
+If your values files are local, you must mount them into the `/tmp` directory of your container.
+If you mount them into some place other than under `/tmp`, you may get some permission issues.
+
+You can download the example remote files to your local directory like so:
+```shell
+curl https://raw.githubusercontent.com/natasha41575/kpt-functions-catalog/a9c9cd765a05f7a7fb6923dbde4651b62c9c229c/examples/render-helm-chart-kustomize-values-files/file1.yaml > file1.yaml
+curl https://raw.githubusercontent.com/natasha41575/kpt-functions-catalog/a9c9cd765a05f7a7fb6923dbde4651b62c9c229c/examples/render-helm-chart-kustomize-values-files/file2.yaml > file2.yaml
+```
+
+Your kustomization file with the local values files should look like this:
+
+kustomization.yaml:
+```yaml
+generators:
+- |-
+  apiVersion: fn.kpt.dev/v1alpha1
+  kind: RenderHelmChart
+  metadata:
+    name: demo
+    annotations:
+      config.kubernetes.io/function: |
+        container:
+          network: true
+          image: gcr.io/kpt-fn/render-helm-chart:unstable
+          mounts:
+            - type: bind
+              src: ./file1.yaml
+              dst: /tmp/file1.yaml
+            - type: bind
+              src: ./file2.yaml
+              dst: /tmp/file2.yaml
+  helmCharts:
+  - chartArgs:
+      name: ocp-pipeline
+      version: 0.1.16
+      repo: https://bcgov.github.io/helm-charts
+    templateOptions:
+      namespace: mynamespace
+      releaseName: moria
+      values:
+        valuesFiles:
+          - tmp/file1.yaml
+          - tmp/file2.yaml
 ```
 
 Then, to build the kustomization with kustomize v4:

--- a/functions/go/render-helm-chart/third_party/sigs.k8s.io/kustomize/api/builtins/HelmChartInflationGenerator.go
+++ b/functions/go/render-helm-chart/third_party/sigs.k8s.io/kustomize/api/builtins/HelmChartInflationGenerator.go
@@ -184,7 +184,10 @@ func (p *HelmChartInflationGeneratorPlugin) createNewMergedValuesFiles(path stri
 					return "", err
 				}
 			} else { // url scheme is not http or https
-				return "", fmt.Errorf("unsupported URL scheme: %s", path)
+				schemeErr := fmt.Errorf("unsupported URL scheme: %s", path)
+				return "", fmt.Errorf(
+					"could not read provided values file %q: when reading as file path, received error %v; when reading as URL, received error %v",
+					path, err, schemeErr)
 			}
 		} else { // invalid path and invalid URL
 			return "", fmt.Errorf(


### PR DESCRIPTION
From discussion in https://kubernetes.slack.com/archives/C0155NSPJSZ/p1666107163910269

Add example for `render-helm-chart` of remote chart with local values file. Also improve the error message when the local file is not available. 