### PR TITLE
fix: GitHub Action deprecates Node.js 12

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -12,17 +12,13 @@ jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '16'
-      - name: Merge gob branch
-        run: git worktree add ./gob gob && cp -r gob/* .
+          node-version: 16
       - name: Generate Site
         run: make site-generate
-      - uses: FirebaseExtended/action-hosting-deploy@276388dd6c2cde23455b30293105cc866c22282d # v0
+      - uses: FirebaseExtended/action-hosting-deploy@4d0d0023f1d92b9b7d16dda64b3d7abd2c98974b
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_KPT_DEV }}'


### PR DESCRIPTION
- Verified on [yuwenma/kpt-functions-catalog@master](https://github.com/yuwenma/kpt-functions-catalog/actions/runs/3372127124/jobs/5595188400) via `workflow_dispatch`: The `actions/checkout` and `actions/setup-node` now pass. 
- Clean up the "Merge GoB branch" which is for some specific functions that are not actively developing.

cc @natasha41575 