### PR TITLE
fix: Revert the Gob cleanup for `preview-hierarchy` function

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -16,6 +16,9 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
+      - name: Merge gob branch
+        run: git worktree add ./gob gob && cp -r gob/* .
+          node-version: 16
       - name: Generate Site
         run: make site-generate
       - uses: FirebaseExtended/action-hosting-deploy@4d0d0023f1d92b9b7d16dda64b3d7abd2c98974b


### PR DESCRIPTION
this "merge gob" is removed in https://github.com/GoogleContainerTools/kpt-functions-catalog/pull/940/files, which is aimed at discontinuing the development of those functions that  are out of the current repo. 

However, `preview-hierarchy` function  (from GOB) has been released and the "Doc deployment" GitHub action" requests the existence of the  `preview-hierarchy` source code (achieved from "merge gob").

As a quick fix to "Doc deployment", this PR adds back the "merge gob" step.
In the long term, we should only support the functions whose source code is in the kpt-functions-catalog repo, and not mirror the external repos. 