### PR TITLE
fix: make 'gcloud' as optional in Makefile for ko push

### DIFF
--- a/functions/go/bind/Makefile
+++ b/functions/go/bind/Makefile
@@ -1,5 +1,7 @@
 # GCP project to use for development
-export GCP_PROJECT_ID ?= $(shell gcloud config get-value project)
+export GCP_PROJECT_ID ?= \
+	$(if $(shell which gcloud),$(shell gcloud config get-value project), \
+	gcr.io/kpt-fn)
 export IMAGE_REPO ?= gcr.io/$(GCP_PROJECT_ID)
 export IMAGE_TAG ?= latest
 

--- a/functions/go/set-gcp-resource-ids/Makefile
+++ b/functions/go/set-gcp-resource-ids/Makefile
@@ -1,5 +1,7 @@
 # GCP project to use for development
-export GCP_PROJECT_ID ?= $(shell gcloud config get-value project)
+export GCP_PROJECT_ID ?= \
+	$(if $(shell which gcloud),$(shell gcloud config get-value project), \
+	gcr.io/kpt-fn)
 export IMAGE_REPO ?= gcr.io/$(GCP_PROJECT_ID)
 export IMAGE_TAG ?= latest
 

--- a/functions/go/set-name-prefix/Makefile
+++ b/functions/go/set-name-prefix/Makefile
@@ -1,5 +1,7 @@
 # GCP project to use for development
-export GCP_PROJECT_ID ?= $(shell gcloud config get-value project)
+export GCP_PROJECT_ID ?= \
+	$(if $(shell which gcloud),$(shell gcloud config get-value project), \
+	gcr.io/kpt-fn)
 export IMAGE_REPO ?= gcr.io/$(GCP_PROJECT_ID)
 export IMAGE_TAG ?= latest
 


### PR DESCRIPTION
fix louhi release pipeline which does not have `gcloud` installed in its build image. https://louhi.dev/?projectId=5662083073179648#/execution-detail/6327051601313792