### PR TITLE
Create build scripts that are compatible with github actions (and others)

### DIFF
--- a/.github/workflows/after-push-to-branch.yaml
+++ b/.github/workflows/after-push-to-branch.yaml
@@ -1,0 +1,36 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Run the CD script after pushes to branches
+on:
+  push:
+    branches:
+    - "master"
+
+jobs:
+  build:
+    name: after-push-to-branch
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v3
+      with:
+        go-version: '1.19.3'
+    - run: go version
+    - name: dev/cd/after-branch-push
+      run: GIT_REF=${GITHUB_REF} IMAGE_REPO=ghcr.io/${{ github.repository }} dev/cd/after-push-to-branch
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/after-tag-with-version.yaml
+++ b/.github/workflows/after-tag-with-version.yaml
@@ -1,0 +1,36 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Run the CD script after tags that look like versions
+on:
+  push:
+    tags:
+    - "**/v[0-9]+.*"
+
+jobs:
+  build:
+    name: after-tag-with-version
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v3
+      with:
+        go-version: '1.19.3'
+    - run: go version
+    - name: dev/cd/after-tag-push
+      run: GIT_REF=${GITHUB_REF} IMAGE_REPO=ghcr.io/${{ github.repository }} dev/cd/after-tag-with-version
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/dev/cd/after-push-to-branch
+++ b/dev/cd/after-push-to-branch
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [ -z "${GIT_REF}" ]; then
+  echo "GIT_REF must be set"
+  exit 1
+fi
+
+if [[ ! "${GIT_REF}" =~ ^refs/heads/.* ]]; then
+  echo "GIT_REF=${GIT_REF} is not of the expected format refs/heads/*"
+  exit 1
+fi
+
+BRANCH=${GIT_REF/refs\/heads\//}
+echo "BRANCH is ${BRANCH}"
+
+REF=$(git rev-parse --short HEAD)
+echo "REF is ${REF}"
+
+# We push two tags, <branchname>-latest and <branchname>-git-$GITSHA
+# The idea is that if you want the latest version from that branch,
+# you'll use the first form, if you want a particular version
+# you can use the second form.
+#
+# We also map main-latest to just "latest" (another reason for people to rename master -> main)
+BRANCH_IMAGE_TAG="${BRANCH}-latest"
+if [[ "${BRANCH_IMAGE_TAG}" == "main-latest" ]]; then
+  BRANCH_IMAGE_TAG="latest"
+fi
+REF_IMAGE_TAG="${BRANCH}-git-${REF}"
+export IMAGE_TAG="${REF_IMAGE_TAG},${BRANCH_IMAGE_TAG}"
+echo "IMAGE_TAG is ${IMAGE_TAG}"
+
+# We identify functions that follow this new approach by the presence of the krm-fn-metadata.yaml file.
+find . -type f -name "krm-fn-metadata.yaml" -print0 | while IFS= read -r -d '' f; do
+  dir=$(dirname "${f}")
+  echo "directory: ${dir}"
+  pushd "${dir}"
+    make push
+  popd
+done

--- a/dev/cd/after-tag-with-version
+++ b/dev/cd/after-tag-with-version
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [ -z "${GIT_REF}" ]; then
+  echo "GIT_REF must be set"
+  exit 1
+fi
+
+if [[ ! "${GIT_REF}" =~ ^refs/tags/.* ]]; then
+  echo "GIT_REF=${GIT_REF} is not of the expected format refs/tags/*"
+  exit 1
+fi
+
+TAG=${GIT_REF/refs\/tags\//}
+echo "TAG is ${TAG}"
+
+VERSION=${TAG##*/}
+PREFIX=${TAG%/*}
+echo "PREFIX is ${PREFIX}, VERSION is ${VERSION}"
+
+if [[ ! -d "${PREFIX}" ]]; then
+  echo "Directory ${PREFIX} is not found"
+  exit 1
+fi
+
+export IMAGE_TAG=${VERSION}
+cd "${PREFIX}"
+make push

--- a/functions/go/set-name-prefix/Makefile
+++ b/functions/go/set-name-prefix/Makefile
@@ -1,17 +1,12 @@
 # GCP project to use for development
 GOBIN := $(shell go env GOPATH)/bin
 
-export GCP_PROJECT_ID ?= \
-	$(if $(shell which gcloud),$(shell gcloud config get-value project), \
-	gcr.io/kpt-fn)
+export GCP_PROJECT_ID ?= $(shell gcloud config get-value project)
 export IMAGE_REPO ?= gcr.io/$(GCP_PROJECT_ID)
 export IMAGE_TAG ?= latest
 
-build: install-ko
-	KO_DOCKER_REPO=ko.local $(GOBIN)/ko build -B --tags=${IMAGE_TAG} .
+build:
+	KO_DOCKER_REPO=ko.local go run github.com/google/ko@v0.12.0 build -B --tags=${IMAGE_TAG} .
 
-push: install-ko
-	KO_DOCKER_REPO=${IMAGE_REPO} $(GOBIN)/ko build -B --tags=${IMAGE_TAG} .
-
-install-ko:
-	(which ko || GOBIN=$(GOBIN) go install github.com/google/ko@latest)
+push:
+	KO_DOCKER_REPO=${IMAGE_REPO} go run github.com/google/ko@v0.12.0 build -B --tags=${IMAGE_TAG} .

--- a/functions/go/set-name-prefix/krm-fn-metadata.yaml
+++ b/functions/go/set-name-prefix/krm-fn-metadata.yaml
@@ -1,0 +1,6 @@
+description: Set a prefix on all object names.
+tags:
+  - mutator
+emails:
+  - kpt-team@google.com
+license: Apache-2.0


### PR DESCRIPTION
We create some simple scripts that aim to support a reasonable CD process.

* On each push to the master branch, we push every function at that version.

* On each tag, we match that to a function directory and push that to
  the container repo.  As with kpt functions, the format is:
  `<directory path>/<version>`

The goal is that github actions should bind variables like IMAGE_REPO
and GIT_REF to the correct version, but otherwise we try to minimize
the amount of work we do in github actions.  Most of the logic should
be in a script in `dev/cd/`, that clearly corresponds to the trigger
(e.g. `after-branch-push` for pushes to the main branch,
`after-tag-push` for when a tag is pushed).

If we need to run in other CI/CD systems, it should suffice to hook up
the trigger to the same scripts under `dev/cd/`.
