### PR TITLE
Update precommit hook to pass shellcheck

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -2,11 +2,11 @@
 
 echo "Updating docs..."
 make generate;
-diff=`git diff`
+diff=$(git diff)
 
 if [[ $diff != "" ]];
 then 
-        echo "Found unstaged changes [$diff]. Make sure to run `make generate` for updating the docs before you commit the changes."
+        echo "Found unstaged changes [$diff]. Make sure to run \`make generate\` for updating the docs before you commit the changes."
         exit 1
 else 
         exit 0


### PR DESCRIPTION
In particular, the backticks around make generate would try to run
make generate!
