### PR TITLE
Skip set-name-prefix branch when generating the function catalog

### DIFF
--- a/scripts/generate_catalog/generate_catalog.go
+++ b/scripts/generate_catalog/generate_catalog.go
@@ -56,6 +56,7 @@ var keywordsPool = []string{
 
 var (
 	branchesToSkip = []string{
+		"set-name-prefix/v0.0",
 		"sops/v0.2",
 	}
 )


### PR DESCRIPTION
This allows the site to be generated successfully. Currently `site-generate` make command fails with `Error getting metadata for "set-name-prefix" from "remotes/origin/set-name-prefix/v0.0"` preventing the CI `Generate Site` step from completing successfully.