### PR TITLE
Update site sidebar with gitops and guides links

### DIFF
--- a/site/sidebar.md
+++ b/site/sidebar.md
@@ -5,5 +5,7 @@
 - [Functions Catalog](/)
   - [Curated](/)
   - [Contrib](/contrib/)
+- [GitOps](https://kpt.dev/gitops/ ':crossorgin :target=_self')
+- [Guides](https://kpt.dev/guides/ ':crossorgin :target=_self')
 - [FAQ](https://kpt.dev/faq/ ':crossorgin :target=_self')
 - [Contact](https://kpt.dev/contact/ ':crossorgin :target=_self')


### PR DESCRIPTION
This pull request brings the site sidebar back into sync with the kpt.dev sidebar.