### PR TITLE
Fix external link on apply replacements documentation

### DIFF
--- a/functions/go/apply-replacements/README.md
+++ b/functions/go/apply-replacements/README.md
@@ -41,4 +41,4 @@ replacements:
 ```
 <!--mdtogo-->
 
-[kustomize replacements]: https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/replacements/
+[kustomize replacements]: https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/replacements/ ':target=_blank'


### PR DESCRIPTION
Fixes the external link on the apply replacements function documentation in reference to  GoogleContainerTools/kpt/issues/3594.