### PR TITLE
feat: error handling for http

### DIFF
--- a/functions/go/render-helm-chart/third_party/sigs.k8s.io/kustomize/api/builtins/HelmChartInflationGenerator.go
+++ b/functions/go/render-helm-chart/third_party/sigs.k8s.io/kustomize/api/builtins/HelmChartInflationGenerator.go
@@ -178,6 +178,9 @@ func (p *HelmChartInflationGeneratorPlugin) createNewMergedValuesFiles(path stri
 				if err != nil {
 					return "", err
 				}
+				if resp.StatusCode != http.StatusOK {
+					return "", fmt.Errorf("non-ok http status: %d returned", resp.StatusCode)
+				}
 				defer resp.Body.Close()
 				pValues, err = ioutil.ReadAll(resp.Body)
 				if err != nil {


### PR DESCRIPTION
Signed-off-by: emirot <emirot.nolan@gmail.com>

# What

Add error handling when getting http value files.

# Why

Fails silently and renders without interpolating or notifying.


# Tests 

Didn't find test files, so I tested manually.

```
docker build -t helmtest  --build-arg BUILDER_IMAGE=golang:1.18-alpine3.15    --build-arg  BASE_IMAGE=alpine:3.15 .
```

Then
```
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization


secretGenerator:
  - name: mysecret
    files:
      - username
      - password
    options:
      disableNameSuffixHash: true
      annotations:
        config.kubernetes.io/local-config: "true"

transformers:
  - |-
    apiVersion: fn.kpt.dev/v1alpha1
    kind: RenderHelmChart
    metadata:
      name: demo
      annotations:
        config.kubernetes.io/function: |
          container:
            network: true
            image: helmtest
    helmCharts:
    - chartArgs:
        name: mychart
        version: v2.4
        registry: myregistry
        auth:
          kind: Secret
          name: mysecret
      templateOptions:
        namespace: argocd
        releaseName: argocd
        values:
          valuesFiles:
            - https://gist.github.com/emirot/1234567
```

Testing
```
kustomize build --enable-alpha-plugins --network . 
failed to evaluate function: failed to run function: failed to run generator: non-ok http status: 404 returnedError: couldn't execute function: exit status 1 
```