### PR TITLE
render-helm-chart: split on yaml document end markers

### DIFF
--- a/functions/go/render-helm-chart/third_party/sigs.k8s.io/kustomize/api/builtins/HelmChartInflationGenerator.go
+++ b/functions/go/render-helm-chart/third_party/sigs.k8s.io/kustomize/api/builtins/HelmChartInflationGenerator.go
@@ -290,14 +290,15 @@ func (p *HelmChartInflationGeneratorPlugin) Generate() (objects fn.KubeObjects, 
 		return nil, err
 	}
 
-	s := strings.Split(string(stdout), "---")
+	s := strings.Split(string(stdout), "\n---\n")
 	for i := range s {
 		if len(s[i]) == 0 {
 			continue
 		}
 		o, err := fn.ParseKubeObject([]byte(s[i]))
 		if err != nil {
-			if strings.Contains(err.Error(), "expected exactly one object, got 0") {
+			if strings.Contains(err.Error(), "expected exactly one object, got 0") ||
+				strings.Contains(err.Error(), "failed to extract objects: unhandled node kind") {
 				// sometimes helm produces some messages in between resources, we can safely
 				// ignore these
 				continue


### PR DESCRIPTION
As per the [yaml spec](https://yaml.org/spec/1.2.2/#912-document-markers), split on document end markers (e.g. - `---` on line by itself) as opposed to `---` anywhere in the string. The latter was splitting in the bodies of configmaps, [CRD description fields](https://github.com/rook/rook/pull/11332), etc.

Thanks