### PR TITLE
Add inline yaml support for setters

### DIFF
--- a/functions/go/apply-setters/applysetters/apply_setters_test.go
+++ b/functions/go/apply-setters/applysetters/apply_setters_test.go
@@ -434,6 +434,40 @@ roles: # kpt-set: ${roles}
   - prod
 `,
 		},
+		{
+			// TODO(annasong): Handle inline yaml and fix test
+			// so that `path: new-placeholder` replaces 
+			// `path: placeholder # kpt-set: ${some-json-pointer}`
+			name: "inline yaml",
+			config: `
+data:
+  some-json-pointer: new-placeholder
+`,
+			input: `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: test
+patches:
+  - target:
+      kind: Deployment
+    patch: |-
+      - op: add
+        path: placeholder # kpt-set: ${some-json-pointer}
+        value: known
+`,
+			expectedResources: `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: test
+patches:
+  - target:
+      kind: Deployment
+    patch: |-
+      - op: add
+        path: placeholder # kpt-set: ${some-json-pointer}
+        value: known
+`,			
+		},
 	}
 	for i := range tests {
 		test := tests[i]


### PR DESCRIPTION
This PR aims to fix [kpt issue #1342](https://github.com/GoogleContainerTools/kpt/issues/1342) by adding support for inline yaml in 
* `create-setters`, which should add the "kpt-set" comment to matching values in the inline yaml
* `apply-setters`, which should set values followed by the "kpt-set" comment in the inline yaml