### PR TITLE
add local-config annotation to local resources in examples

### DIFF
--- a/examples/apply-replacements-simple/Kptfile
+++ b/examples/apply-replacements-simple/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/apply-replacements:unstable

--- a/examples/apply-setters-simple/Kptfile
+++ b/examples/apply-setters-simple/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/apply-setters:unstable

--- a/examples/create-setters-simple/Kptfile
+++ b/examples/create-setters-simple/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/create-setters:unstable

--- a/examples/enable-gcp-services-advanced/Kptfile
+++ b/examples/enable-gcp-services-advanced/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: enable-gcp-services-advanced
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/enable-gcp-services:unstable

--- a/examples/enable-gcp-services-simple/Kptfile
+++ b/examples/enable-gcp-services-simple/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: enable-gcp-services-simple
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/enable-gcp-services:unstable

--- a/examples/ensure-name-substring-advanced/.expected/diff.patch
+++ b/examples/ensure-name-substring-advanced/.expected/diff.patch
@@ -1,5 +1,5 @@
 diff --git a/fn-config.yaml b/fn-config.yaml
-index 12939e5..0ee2f64 100644
+index d0a96a3..c191e3d 100644
 --- a/fn-config.yaml
 +++ b/fn-config.yaml
 @@ -1,7 +1,7 @@
@@ -8,9 +8,9 @@ index 12939e5..0ee2f64 100644
  metadata:
 -  name: my-config
 +  name: prod-my-config
+   annotations:
+     config.kubernetes.io/local-config: "true"
  additionalNameFields:
-   - kind: MyResource
-     group: dev.example.com
 diff --git a/resources.yaml b/resources.yaml
 index 8e037c3..ffd583b 100644
 --- a/resources.yaml

--- a/examples/ensure-name-substring-advanced/Kptfile
+++ b/examples/ensure-name-substring-advanced/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/ensure-name-substring:unstable

--- a/examples/ensure-name-substring-advanced/fn-config.yaml
+++ b/examples/ensure-name-substring-advanced/fn-config.yaml
@@ -2,6 +2,8 @@ apiVersion: fn.kpt.dev/v1alpha1
 kind: EnsureNameSubstring
 metadata:
   name: my-config
+  annotations:
+    config.kubernetes.io/local-config: "true"
 additionalNameFields:
   - kind: MyResource
     group: dev.example.com

--- a/examples/ensure-name-substring-depends-on/Kptfile
+++ b/examples/ensure-name-substring-depends-on/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/ensure-name-substring:unstable

--- a/examples/ensure-name-substring-prefix/Kptfile
+++ b/examples/ensure-name-substring-prefix/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/ensure-name-substring:unstable

--- a/examples/ensure-name-substring-suffix/Kptfile
+++ b/examples/ensure-name-substring-suffix/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/ensure-name-substring:unstable

--- a/examples/fix-simple/.expected/diff.patch
+++ b/examples/fix-simple/.expected/diff.patch
@@ -1,13 +1,15 @@
 diff --git a/Kptfile b/Kptfile
-index a8e7f27..30e5250 100644
+index 1cc6b93..a0041c1 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -1,20 +1,24 @@
+@@ -1,22 +1,26 @@
 -apiVersion: kpt.dev/v1alpha1
 +apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: nginx
+   annotations:
+     config.kubernetes.io/local-config: "true"
 -packageMetadata:
 -  shortDescription: describe this package
  upstream:

--- a/examples/fix-simple/Kptfile
+++ b/examples/fix-simple/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1alpha1
 kind: Kptfile
 metadata:
   name: nginx
+  annotations:
+    config.kubernetes.io/local-config: "true"
 packageMetadata:
   shortDescription: describe this package
 upstream:

--- a/examples/gatekeeper-disallow-root-user/Kptfile
+++ b/examples/gatekeeper-disallow-root-user/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   validators:
     - image: gcr.io/kpt-fn/gatekeeper:unstable

--- a/examples/gatekeeper-invalid-configmap/Kptfile
+++ b/examples/gatekeeper-invalid-configmap/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   validators:
     - image: gcr.io/kpt-fn/gatekeeper:unstable

--- a/examples/gatekeeper-warning-only/Kptfile
+++ b/examples/gatekeeper-warning-only/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   validators:
     - image: gcr.io/kpt-fn/gatekeeper:unstable

--- a/examples/generate-folders-resourcehierarchy-v1/.expected/diff.patch
+++ b/examples/generate-folders-resourcehierarchy-v1/.expected/diff.patch
@@ -1,9 +1,13 @@
 diff --git a/Kptfile b/Kptfile
-index bfbf712..6dd3f52 100644
+index d8e547b..dadae4c 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -4,4 +4,4 @@ metadata:
+@@ -3,7 +3,7 @@ kind: Kptfile
+ metadata:
    name: example
+   annotations:
+-    config.kubernetes.io/local-config: "true"
++    config.kubernetes.io/local-config: 'true'
  pipeline:
    mutators:
 -    - image: gcr.io/kpt-fn/generate-folders:unstable

--- a/examples/generate-folders-resourcehierarchy-v1/Kptfile
+++ b/examples/generate-folders-resourcehierarchy-v1/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/generate-folders:unstable

--- a/examples/generate-folders-resourcehierarchy-v2/.expected/diff.patch
+++ b/examples/generate-folders-resourcehierarchy-v2/.expected/diff.patch
@@ -1,9 +1,13 @@
 diff --git a/Kptfile b/Kptfile
-index bfbf712..6dd3f52 100644
+index d8e547b..dadae4c 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -4,4 +4,4 @@ metadata:
+@@ -3,7 +3,7 @@ kind: Kptfile
+ metadata:
    name: example
+   annotations:
+-    config.kubernetes.io/local-config: "true"
++    config.kubernetes.io/local-config: 'true'
  pipeline:
    mutators:
 -    - image: gcr.io/kpt-fn/generate-folders:unstable

--- a/examples/generate-folders-resourcehierarchy-v2/Kptfile
+++ b/examples/generate-folders-resourcehierarchy-v2/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/generate-folders:unstable

--- a/examples/generate-folders-resourcehierarchy-v3/.expected/diff.patch
+++ b/examples/generate-folders-resourcehierarchy-v3/.expected/diff.patch
@@ -1,9 +1,13 @@
 diff --git a/Kptfile b/Kptfile
-index bfbf712..6dd3f52 100644
+index d8e547b..dadae4c 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -4,4 +4,4 @@ metadata:
+@@ -3,7 +3,7 @@ kind: Kptfile
+ metadata:
    name: example
+   annotations:
+-    config.kubernetes.io/local-config: "true"
++    config.kubernetes.io/local-config: 'true'
  pipeline:
    mutators:
 -    - image: gcr.io/kpt-fn/generate-folders:unstable

--- a/examples/generate-folders-resourcehierarchy-v3/Kptfile
+++ b/examples/generate-folders-resourcehierarchy-v3/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/generate-folders:unstable

--- a/examples/generate-kpt-pkg-docs-simple/Kptfile
+++ b/examples/generate-kpt-pkg-docs-simple/Kptfile
@@ -4,6 +4,7 @@ metadata:
   name: bucket
   annotations:
     blueprints.cloud.google.com/title: Google Cloud Storage Bucket blueprint
+    config.kubernetes.io/local-config: "true"
 upstream:
   type: git
   git:

--- a/examples/kubeval-simple/Kptfile
+++ b/examples/kubeval-simple/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   validators:
     - image: gcr.io/kpt-fn/kubeval:unstable

--- a/examples/search-replace-simple/Kptfile
+++ b/examples/search-replace-simple/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/search-replace:unstable

--- a/examples/set-annotations-advanced/Kptfile
+++ b/examples/set-annotations-advanced/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/set-annotations:unstable

--- a/examples/set-annotations-simple/Kptfile
+++ b/examples/set-annotations-simple/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/set-annotations:unstable

--- a/examples/set-enforcement-action-simple/Kptfile
+++ b/examples/set-enforcement-action-simple/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: cis-k8s-1.5.1
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/set-enforcement-action:unstable

--- a/examples/set-image-advanced/Kptfile
+++ b/examples/set-image-advanced/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/set-image:unstable

--- a/examples/set-image-advanced/fn-config.yaml
+++ b/examples/set-image-advanced/fn-config.yaml
@@ -2,6 +2,8 @@ apiVersion: fn.kpt.dev/v1alpha1
 kind: SetImage
 metadata:
   name: my-func-config
+  annotations:
+    config.kubernetes.io/local-config: "true"
 image:
   name: nginx
   newName: bitnami/nginx

--- a/examples/set-image-digest/Kptfile
+++ b/examples/set-image-digest/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/set-image:unstable

--- a/examples/set-image-simple/Kptfile
+++ b/examples/set-image-simple/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/set-image:unstable

--- a/examples/set-labels-simple/Kptfile
+++ b/examples/set-labels-simple/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/set-labels:unstable

--- a/examples/set-namespace-depends-on/Kptfile
+++ b/examples/set-namespace-depends-on/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/set-namespace:unstable

--- a/examples/set-namespace-simple/Kptfile
+++ b/examples/set-namespace-simple/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/set-namespace:unstable

--- a/examples/set-project-id-advanced/Kptfile
+++ b/examples/set-project-id-advanced/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: test-blueprint
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/apply-setters:v0.2

--- a/examples/set-project-id-simple/Kptfile
+++ b/examples/set-project-id-simple/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: test-blueprint
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/apply-setters:v0.2

--- a/examples/starlark-inject-sidecar/Kptfile
+++ b/examples/starlark-inject-sidecar/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/starlark:unstable

--- a/examples/starlark-inject-sidecar/fn-config.yaml
+++ b/examples/starlark-inject-sidecar/fn-config.yaml
@@ -2,6 +2,8 @@ apiVersion: fn.kpt.dev/v1alpha1
 kind: StarlarkRun
 metadata:
   name: inject-sidecar-to-depl
+  annotations:
+    config.kubernetes.io/local-config: "true"
 source: |
   def ensure_inject_sidecar_to_depl(r):
     if r["apiVersion"] == "apps/v1" and r["kind"] == "Deployment":

--- a/examples/starlark-load-library/Kptfile
+++ b/examples/starlark-load-library/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/starlark:unstable

--- a/examples/starlark-load-library/fn-config.yaml
+++ b/examples/starlark-load-library/fn-config.yaml
@@ -2,6 +2,8 @@ apiVersion: fn.kpt.dev/v1alpha1
 kind: StarlarkRun
 metadata:
   name: set-namespace-to-prod
+  annotations:
+    config.kubernetes.io/local-config: "true"
 source: |
   load('encoding/json.star', 'json')
 

--- a/examples/starlark-poddisruptionbudget/Kptfile
+++ b/examples/starlark-poddisruptionbudget/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/starlark:unstable

--- a/examples/starlark-poddisruptionbudget/fn-config.yaml
+++ b/examples/starlark-poddisruptionbudget/fn-config.yaml
@@ -2,6 +2,8 @@ apiVersion: fn.kpt.dev/v1alpha1
 kind: StarlarkRun
 metadata:
   name: pdb-for-depl
+  annotations:
+    config.kubernetes.io/local-config: "true"
 params:
   pdb:
     apiVersion: policy/v1beta1

--- a/examples/starlark-set-namespace/Kptfile
+++ b/examples/starlark-set-namespace/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
     - image: gcr.io/kpt-fn/starlark:unstable

--- a/examples/starlark-set-namespace/fn-config.yaml
+++ b/examples/starlark-set-namespace/fn-config.yaml
@@ -2,6 +2,8 @@ apiVersion: fn.kpt.dev/v1alpha1
 kind: StarlarkRun
 metadata:
   name: set-namespace-to-prod
+  annotations:
+    config.kubernetes.io/local-config: "true"
 source: |
   # set the namespace on all resources except Kptfile and StarlarkRun kind.
   for resource in ctx.resource_list["items"]:

--- a/examples/starlark-validation/Kptfile
+++ b/examples/starlark-validation/Kptfile
@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
 pipeline:
   validators:
     - image: gcr.io/kpt-fn/starlark:unstable

--- a/examples/starlark-validation/fn-config.yaml
+++ b/examples/starlark-validation/fn-config.yaml
@@ -2,6 +2,8 @@ apiVersion: fn.kpt.dev/v1alpha1
 kind: StarlarkRun
 metadata:
   name: no-private-key
+  annotations:
+    config.kubernetes.io/local-config: "true"
 source: |
   def contains_private_key(r):
     return r["apiVersion"] == "v1" and r["kind"] == "ConfigMap" and r["data"]["private-key"]


### PR DESCRIPTION
Fixes https://github.com/GoogleContainerTools/kpt/issues/3844

Our examples should have the `local-config` annotation on Kptfile and functionConfigs so that they can be used correctly out of the box.