### PR TITLE
docs: Update tags for go/render-helm-chart/v0.2.0 (#879)

### DIFF
--- a/examples/render-helm-chart-crds/README.md
+++ b/examples/render-helm-chart-crds/README.md
@@ -10,7 +10,7 @@ function to render a helm chart that contains CRDs in the templated output.
 First, let's render a terraform chart without CRDs:
 
 ```shell
-$ kpt fn eval --image gcr.io/kpt-fn/render-helm-chart:v0.2.1 --network -- \
+$ kpt fn eval --image gcr.io/kpt-fn/render-helm-chart:v0.2.2 --network -- \
 name=terraform \
 repo=https://helm.releases.hashicorp.com \
 version=1.0.0 \
@@ -35,7 +35,7 @@ $ kpt pkg tree
 Now, let's run the command again, this time including CRDs:
 
 ```shell
-$ kpt fn eval --image gcr.io/kpt-fn/render-helm-chart:v0.2.1 --network -- \
+$ kpt fn eval --image gcr.io/kpt-fn/render-helm-chart:v0.2.2 --network -- \
 name=terraform \
 repo=https://helm.releases.hashicorp.com \
 version=1.0.0 \

--- a/examples/render-helm-chart-kustomize-inline-values/README.md
+++ b/examples/render-helm-chart-kustomize-inline-values/README.md
@@ -23,7 +23,7 @@ generators:
       config.kubernetes.io/function: |
         container:
           network: true
-          image: gcr.io/kpt-fn/render-helm-chart:v0.2.1
+          image: gcr.io/kpt-fn/render-helm-chart:v0.2.2
   helmCharts:
   - name: ocp-pipeline
     namespace: mynamespace

--- a/examples/render-helm-chart-kustomize-private-git/README.md
+++ b/examples/render-helm-chart-kustomize-private-git/README.md
@@ -32,7 +32,7 @@ transformers:
         config.kubernetes.io/function: |
           container:
             network: true
-            image: gcr.io/kpt-fn/render-helm-chart:v0.2.1
+            image: gcr.io/kpt-fn/render-helm-chart:v0.2.2
     helmCharts:
       - chartArgs:
           name: mychart

--- a/examples/render-helm-chart-kustomize-private-oci/README.md
+++ b/examples/render-helm-chart-kustomize-private-oci/README.md
@@ -34,7 +34,7 @@ transformers:
         config.kubernetes.io/function: |
           container:
             network: true
-            image: gcr.io/kpt-fn/render-helm-chart:v0.2.1
+            image: gcr.io/kpt-fn/render-helm-chart:v0.2.2
     helmCharts:
       - chartArgs:
         name: mychart # change this to the name of your chart

--- a/examples/render-helm-chart-kustomize-values-files/README.md
+++ b/examples/render-helm-chart-kustomize-values-files/README.md
@@ -28,7 +28,7 @@ generators:
       config.kubernetes.io/function: |
         container:
           network: true
-          image: gcr.io/kpt-fn/render-helm-chart:v0.2.1
+          image: gcr.io/kpt-fn/render-helm-chart:v0.2.2
   helmCharts:
   - chartArgs:
       name: ocp-pipeline
@@ -74,7 +74,7 @@ generators:
       config.kubernetes.io/function: |
         container:
           network: true
-          image: gcr.io/kpt-fn/render-helm-chart:v0.2.1
+          image: gcr.io/kpt-fn/render-helm-chart:v0.2.2
           mounts:
             - type: bind
               src: ./file1.yaml

--- a/examples/render-helm-chart-local/README.md
+++ b/examples/render-helm-chart-local/README.md
@@ -10,7 +10,7 @@ function to render a helm chart that lives in your local filesystem.
 Run the following command to fetch the example package:
 
 ```shell
-$ kpt pkg get https://github.com/GoogleContainerTools/kpt-functions-catalog.git/examples/render-helm-chart-local@render-helm-chart/v0.2.1
+$ kpt pkg get https://github.com/GoogleContainerTools/kpt-functions-catalog.git/examples/render-helm-chart-local@render-helm-chart/v0.2.2
 ```
 
 ```shell
@@ -21,7 +21,7 @@ Run the following commands to render the helm chart in your local
 filesystem.
 
 ```shell
-$ kpt fn eval --image gcr.io/kpt-fn/render-helm-chart:v0.2.1 \
+$ kpt fn eval --image gcr.io/kpt-fn/render-helm-chart:v0.2.2 \
 --mount type=bind,src=$(pwd),dst=/tmp/charts \
 -- name=helloworld-chart \
 releaseName=test
@@ -30,7 +30,7 @@ releaseName=test
 You can optionally provide your own values files using `valuesFile`.
 
 ```shell
-$ kpt fn eval --image gcr.io/kpt-fn/render-helm-chart:v0.2.1 \
+$ kpt fn eval --image gcr.io/kpt-fn/render-helm-chart:v0.2.2 \
 --mount type=bind,src=$(pwd),dst=/tmp/charts -- \
 name=helloworld-chart \
 releaseName=test \
@@ -40,7 +40,7 @@ valuesFile=/tmp/charts/helloworld-values/values.yaml
 You can optionally skip tests in the templated output with `skipTests`.
 
 ```shell
-$ kpt fn eval --image gcr.io/kpt-fn/render-helm-chart:v0.2.1 \
+$ kpt fn eval --image gcr.io/kpt-fn/render-helm-chart:v0.2.2 \
 --mount type=bind,src=$(pwd),dst=/tmp/charts -- \
 name=helloworld-chart \
 releaseName=test \

--- a/examples/render-helm-chart-remote-values-file/README.md
+++ b/examples/render-helm-chart-remote-values-file/README.md
@@ -10,14 +10,14 @@ function with a remote values file.
 Run the following command to fetch the example package:
 
 ```shell
-$ kpt pkg get https://github.com/GoogleContainerTools/kpt-functions-catalog.git/examples/render-helm-chart-remote-values-file@render-helm-chart/v0.2.1
+$ kpt pkg get https://github.com/GoogleContainerTools/kpt-functions-catalog.git/examples/render-helm-chart-remote-values-file@render-helm-chart/v0.2.2
 ```
 
 Run the following commands to render the helm chart in your local
 filesystem with the remote values file.
 
 ```shell
-$ kpt fn eval render-helm-chart-remote-values-file --image gcr.io/kpt-fn/render-helm-chart:v0.2.1 \
+$ kpt fn eval render-helm-chart-remote-values-file --image gcr.io/kpt-fn/render-helm-chart:v0.2.2 \
 --network \
 --mount type=bind,src="$(pwd)"/render-helm-chart-remote-values-file,dst=/tmp/charts -- \
 name=helloworld-chart \

--- a/examples/render-helm-chart-remote/README.md
+++ b/examples/render-helm-chart-remote/README.md
@@ -10,7 +10,7 @@ function to render a helm chart that lives in a remote repo.
 Run the following command to render a minecraft chart.
 
 ```shell
-$ kpt fn eval --image gcr.io/kpt-fn/render-helm-chart:v0.2.1 --network -- \
+$ kpt fn eval --image gcr.io/kpt-fn/render-helm-chart:v0.2.2 --network -- \
 name=minecraft \
 repo=https://itzg.github.io/minecraft-server-charts \
 version=3.1.3 \

--- a/functions/go/render-helm-chart/README.md
+++ b/functions/go/render-helm-chart/README.md
@@ -135,7 +135,7 @@ helmCharts:
 To render a remote minecraft chart, you can run the following command: 
 
 ```shell
-$ kpt fn eval --image gcr.io/kpt-fn/render-helm-chart:v0.2.1 --network -- \
+$ kpt fn eval --image gcr.io/kpt-fn/render-helm-chart:v0.2.2 --network -- \
 name=minecraft \
 repo=https://itzg.github.io/minecraft-server-charts \
 releaseName=test


### PR DESCRIPTION
release render-helm-charts v0.2 for private repo authentication and OCI support