### PR TITLE
updating helm to 3.11

### DIFF
--- a/functions/go/render-helm-chart/Dockerfile
+++ b/functions/go/render-helm-chart/Dockerfile
@@ -14,7 +14,7 @@ ARG TARGETOS TARGETARCH
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /usr/local/bin/function ./
 
 RUN apk update && apk add --no-cache curl
-ARG HELM_VERSION="v3.8.0"
+ARG HELM_VERSION="v3.11.1"
 RUN curl -fsSL -o /helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz https://get.helm.sh/helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz && \
      tar -zxvf /helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz && \
      mv ./${TARGETOS}-${TARGETARCH}/helm /usr/local/bin/helm


### PR DESCRIPTION
Just been using the updated `render-helm-chart` version just released in https://github.com/GoogleContainerTools/kpt-functions-catalog/pull/1024 (Thanks for the super fast turnaround on this btw!)

I ran into some version issues in the traefik chart and noticed the helm version could do with an update https://github.com/traefik/traefik-helm-chart/blob/master/traefik/templates/deployment.yaml#L2 |
