### PR TITLE
fix: ensure IMAGE_REPO is lowercase

### DIFF
--- a/dev/cd/after-push-to-branch
+++ b/dev/cd/after-push-to-branch
@@ -20,6 +20,9 @@ echo "BRANCH is ${BRANCH}"
 REF=$(git rev-parse --short HEAD)
 echo "REF is ${REF}"
 
+IMAGE_REPO=$(echo $IMAGE_REPO | tr '[:upper:]' '[:lower:]')
+echo "IMAGE_REPO is ${IMAGE_REPO}"
+
 # We push two tags, <branchname>-latest and <branchname>-git-$GITSHA
 # The idea is that if you want the latest version from that branch,
 # you'll use the first form, if you want a particular version


### PR DESCRIPTION
Fixes https://github.com/GoogleContainerTools/kpt/issues/3864
It appears `after-push-to-branch` is failing as IMAGE_REPO includes uppercase

```
Error: error creating publisher: failed to parse "ghcr.io/GoogleContainerTools/kpt-functions-catalog" as repository: repository can only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-./`: GoogleContainerTools/kpt-functions-catalog
```