### PR TITLE
docs: Update tags for go/render-helm-chart/v0.2.0 (#879)

### DIFF
--- a/examples/starlark-configmap-as-functionconfig/README.md
+++ b/examples/starlark-configmap-as-functionconfig/README.md
@@ -12,7 +12,7 @@ line arguments.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/GoogleContainerTools/kpt-functions-catalog.git/examples/starlark-configmap-as-functionconfig
+$ kpt pkg get https://github.com/GoogleContainerTools/kpt-functions-catalog.git/examples/starlark-configmap-as-functionconfig@starlark/v0.5.0
 ```
 
 We are going to use the following starlark script:
@@ -33,11 +33,11 @@ setReplicas(ctx.resource_list["items"], replicas)
 Invoke the function by running the following commands:
 
 ```shell
-$ kpt fn eval --image gcr.io/kpt-fn/starlark:unstable -- source="$(cat set-replicas.star)" replicas=5
+$ kpt fn eval --image gcr.io/kpt-fn/starlark:v0.5.0 -- source="$(cat set-replicas.star)" replicas=5
 ```
 
 ### Expected result
 
 Check the `spec.replicas` field has been set to `5` in the `Deployment`.
 
-[`starlark`]: https://catalog.kpt.dev/starlark/v0.1/
+[`starlark`]: https://catalog.kpt.dev/starlark/v0.5/

--- a/examples/starlark-inject-sidecar/Kptfile
+++ b/examples/starlark-inject-sidecar/Kptfile
@@ -6,5 +6,5 @@ metadata:
     config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/starlark:unstable
+    - image: gcr.io/kpt-fn/starlark:v0.5.0
       configPath: fn-config.yaml

--- a/examples/starlark-inject-sidecar/README.md
+++ b/examples/starlark-inject-sidecar/README.md
@@ -11,7 +11,7 @@ to inject sidecar container to `Deployment`.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/GoogleContainerTools/kpt-functions-catalog.git/examples/starlark-inject-sidecar
+$ kpt pkg get https://github.com/GoogleContainerTools/kpt-functions-catalog.git/examples/starlark-inject-sidecar@starlark/v0.5.0
 ```
 
 We are going to use the following `Kptfile` and `fn-config.yaml` to configure
@@ -24,7 +24,7 @@ metadata:
   name: example
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/starlark:unstable
+    - image: gcr.io/kpt-fn/starlark:v0.5.0
       configPath: fn-config.yaml
 ```
 
@@ -68,4 +68,4 @@ $ kpt fn render starlark-inject-sidecar
 
 The logging agent container should have been injected. 
 
-[`starlark`]: https://catalog.kpt.dev/starlark/v0.1/
+[`starlark`]: https://catalog.kpt.dev/starlark/v0.5/

--- a/examples/starlark-load-library/Kptfile
+++ b/examples/starlark-load-library/Kptfile
@@ -6,5 +6,5 @@ metadata:
     config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/starlark:unstable
+    - image: gcr.io/kpt-fn/starlark:v0.5.0
       configPath: fn-config.yaml

--- a/examples/starlark-load-library/README.md
+++ b/examples/starlark-load-library/README.md
@@ -10,7 +10,7 @@ In this example, we are going to demonstrate how to load a library in the
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/GoogleContainerTools/kpt-functions-catalog.git/examples/starlark-load-library
+$ kpt pkg get https://github.com/GoogleContainerTools/kpt-functions-catalog.git/examples/starlark-load-library@starlark/v0.5.0
 ```
 
 We are going to use the following `Kptfile` and `fn-config.yaml` to configure
@@ -23,7 +23,7 @@ metadata:
   name: example
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/starlark:unstable
+    - image: gcr.io/kpt-fn/starlark:v0.5.0
       configPath: fn-config.yaml
 ```
 
@@ -59,4 +59,4 @@ $ kpt fn render starlark-load-library
 
 Check the `.spec.replicas` field should have been updated to 4.
 
-[`starlark`]: https://catalog.kpt.dev/starlark/v0.1/
+[`starlark`]: https://catalog.kpt.dev/starlark/v0.5/

--- a/examples/starlark-poddisruptionbudget/Kptfile
+++ b/examples/starlark-poddisruptionbudget/Kptfile
@@ -6,5 +6,5 @@ metadata:
     config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/starlark:unstable
+    - image: gcr.io/kpt-fn/starlark:v0.5.0
       configPath: fn-config.yaml

--- a/examples/starlark-poddisruptionbudget/README.md
+++ b/examples/starlark-poddisruptionbudget/README.md
@@ -12,7 +12,7 @@ the `functionConfig` and use it in the script.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/GoogleContainerTools/kpt-functions-catalog.git/examples/starlark-poddisruptionbudget
+$ kpt pkg get https://github.com/GoogleContainerTools/kpt-functions-catalog.git/examples/starlark-poddisruptionbudget@starlark/v0.5.0
 ```
 
 We are going to use the following `Kptfile` and `fn-config.yaml` to configure
@@ -26,7 +26,7 @@ metadata:
   name: example
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/starlark:unstable
+    - image: gcr.io/kpt-fn/starlark:v0.5.0
       configPath: fn-config.yaml
 ```
 
@@ -78,4 +78,4 @@ $ kpt fn render starlark-poddisruptionbudget
 A new file should have been created, and it should contain a
 `PodDisruptionBudget` object.
 
-[`starlark`]: https://catalog.kpt.dev/starlark/v0.1/
+[`starlark`]: https://catalog.kpt.dev/starlark/v0.5/

--- a/examples/starlark-set-namespace/Kptfile
+++ b/examples/starlark-set-namespace/Kptfile
@@ -6,5 +6,5 @@ metadata:
     config.kubernetes.io/local-config: "true"
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/starlark:unstable
+    - image: gcr.io/kpt-fn/starlark:v0.5.0
       configPath: fn-config.yaml

--- a/examples/starlark-set-namespace/README.md
+++ b/examples/starlark-set-namespace/README.md
@@ -11,7 +11,7 @@ to set namespaces to KRM resources.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/GoogleContainerTools/kpt-functions-catalog.git/examples/starlark-set-namespace
+$ kpt pkg get https://github.com/GoogleContainerTools/kpt-functions-catalog.git/examples/starlark-set-namespace@starlark/v0.5.0
 ```
 
 We are going to use the following `Kptfile` and `fn-config.yaml` to configure
@@ -24,7 +24,7 @@ metadata:
   name: example
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/starlark:unstable
+    - image: gcr.io/kpt-fn/starlark:v0.5.0
       configPath: fn-config.yaml
 ```
 
@@ -61,4 +61,4 @@ $ kpt fn render starlark-set-namespace
 
 Check the `.metadata.namespace` field has been set to `prod` for every resource.
 
-[`starlark`]: https://catalog.kpt.dev/starlark/v0.1/
+[`starlark`]: https://catalog.kpt.dev/starlark/v0.5/

--- a/examples/starlark-validation/Kptfile
+++ b/examples/starlark-validation/Kptfile
@@ -6,5 +6,5 @@ metadata:
     config.kubernetes.io/local-config: "true"
 pipeline:
   validators:
-    - image: gcr.io/kpt-fn/starlark:unstable
+    - image: gcr.io/kpt-fn/starlark:v0.5.0
       configPath: fn-config.yaml

--- a/examples/starlark-validation/README.md
+++ b/examples/starlark-validation/README.md
@@ -11,7 +11,7 @@ to validate a `ConfigMap`.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/GoogleContainerTools/kpt-functions-catalog.git/examples/starlark-validation
+$ kpt pkg get https://github.com/GoogleContainerTools/kpt-functions-catalog.git/examples/starlark-validation@starlark/v0.5.0
 ```
 
 We are going to use the following `Kptfile` and `fn-config.yaml` to configure
@@ -24,7 +24,7 @@ metadata:
   name: example
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/starlark:unstable
+    - image: gcr.io/kpt-fn/starlark:v0.5.0
       configPath: fn-config.yaml
 ```
 
@@ -67,7 +67,7 @@ metadata:
   name: fnresults
 exitCode: 1
 items:
-  - image: gcr.io/kpt-fn/starlark:unstable
+  - image: gcr.io/kpt-fn/starlark:v0.5.0
     stderr: 'fail: it is prohibited to have private key in a configmap'
     exitCode: 1
     results:
@@ -79,4 +79,4 @@ To pass validation, let's replace the key `private-key` in the `ConfigMap` with
 something else e.g. `public_key`.
 Rerun the command. It will succeed.
 
-[`starlark`]: https://catalog.kpt.dev/starlark/v0.1/
+[`starlark`]: https://catalog.kpt.dev/starlark/v0.5/

--- a/functions/go/starlark/README.md
+++ b/functions/go/starlark/README.md
@@ -119,14 +119,14 @@ There are 2 ways to run the function imperatively.
   starlark script lives in `main.star` file.
 
 ```shell
-$ kpt fn eval --image gcr.io/kpt-fn/starlark:unstable -- source="$(cat main.star)" param1=value1 param2=value2
+$ kpt fn eval --image gcr.io/kpt-fn/starlark:v0.5.0 -- source="$(cat main.star)" param1=value1 param2=value2
 ```
 
 - Run it using `--fn-config` with either a `ConfigMap` or a `StarlarkRun` that
   lives in `fn-config.yaml`.
 
 ```shell
-$ kpt fn eval --image gcr.io/kpt-fn/starlark:unstable --fn-config fn-config.yaml
+$ kpt fn eval --image gcr.io/kpt-fn/starlark:v0.5.0 --fn-config fn-config.yaml
 ```
 
 ### Developing Starlark Script

--- a/functions/go/starlark/metadata.yaml
+++ b/functions/go/starlark/metadata.yaml
@@ -3,14 +3,14 @@ description: Run a Starlark script to mutate or validate resources.
 tags:
   - mutator
   - validator
-sourceURL: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/functions/go/starlark
+sourceURL: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.5/functions/go/starlark
 examplePackageURLs:
-  - https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/examples/starlark-set-namespace
-  - https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/examples/starlark-inject-sidecar
-  - https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/examples/starlark-poddisruptionbudget
-  - https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/examples/starlark-validation
-  - https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/examples/starlark-configmap-as-functionconfig
-  - https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/examples/starlark-load-library
+  - https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.5/examples/starlark-set-namespace
+  - https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.5/examples/starlark-inject-sidecar
+  - https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.5/examples/starlark-poddisruptionbudget
+  - https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.5/examples/starlark-validation
+  - https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.5/examples/starlark-configmap-as-functionconfig
+  - https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/starlark/v0.5/examples/starlark-load-library
 emails:
   - kpt-team@google.com
 license: Apache-2.0


### PR DESCRIPTION
release render-helm-charts v0.2 for private repo authentication and OCI support