### PR TITLE
fix: typo stalark -> starlark

### DIFF
--- a/functions/go/starlark/starlark/config.go
+++ b/functions/go/starlark/starlark/config.go
@@ -21,7 +21,7 @@ const (
 
 	sourceKey = "source"
 
-	defaultProgramName = "stalark-function-run"
+	defaultProgramName = "starlark-function-run"
 )
 
 type StarlarkRun struct {


### PR DESCRIPTION
Hi, I am browsing the starlark function code and found a typo and fixed it. I am sure there are no similar errors. @yuwenma 