### PR TITLE
chore: add dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: /
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
Several Github Actions are using deprecated runtimes, let's use dependabot to open automatic PRs for them.