### PR TITLE
Add -latest suffix to release tags

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,18 +6,23 @@ krm-functions-catalog repo.
 
 1. Checking the [CI status](https://github.com/kptdev/krm-functions-catalog/actions/workflows/ci.yaml) of the master branch. 
    If the CI is failing on the master, we need to fix it before doing a release.
-1. Go to the [releases pages] in your browser.
-1. Click `Draft a new release` to create a new release for a function. The tag
+2. Go to the [releases pages] in your browser.
+3. Click `Draft a new release` to create a new release for a function. The tag
    version format should be `functions/{language}/{function-name}/{semver}`. e.g.
    `functions/go/set-namespace/v1.2.3` and `functions/ts/kubeval/v2.3.4`. The release name should be
    `{funtion-name} {semver}`. The release notes for this function should be in
    the body. 
-1. Click `Publish release` button.
-1. Verify the new functions is released in ghcr.io/kptdev/krm-functions-catalog/{funtion-name}/{semver} or, if using the GitHub based CD flow, check
+4. Click `Publish release` button.
+5. Verify the new functions are released in ghcr.io/kptdev/krm-functions-catalog/{funtion-name}/{semver} or, if using the GitHub based CD flow, check
    the relevant [GitHub packages section](https://github.com/orgs/kptdev/packages?repo_name=krm-functions-catalog)
-1. Send an announcement on the [kpt slack channel]
+   The example above will push the following tags to the registry:
+   * v1.2.3
+   * v1.2-latest
+   * v1-latest
 
-!! NOTE: This section needs to be revised
+6. Send an announcement on the [kpt slack channel]
+
+> ⚠️ **Warning:**  The update docs section is currently being revised. DO NOT USE!!
 ## Updating function docs
 
 After creating a release, the docs for the function should be updated to reflect

--- a/scripts/git-tag-parser.sh
+++ b/scripts/git-tag-parser.sh
@@ -17,14 +17,14 @@
 VERNUM='0|[1-9][0-9]*'
 SEMVER_REGEX="^[vV]?($VERNUM)\\.($VERNUM)\\.($VERNUM)$"
 
-# get_versions return versions: vX.Y.Z, vX.Y and vX if the input matches
+# get_versions return versions: vX.Y.Z, vX.Y-latest and vX-latest if the input matches
 # SEMVER_REGEX. Otherwise, it returns the input.
 # example 1:
 # Invocation: get_versions v1.2.3
-# Return: v1.2.3 v1.2 v1
+# Return: v1.2.3 v1.2-latest v1-latest
 # example 2:
-# Invocation: get_versions unstable
-# Return: unstable
+# Invocation: get_versions latest
+# Return: latest
 function get_versions {
   local version=$1
   if [[ "${version}" =~ $SEMVER_REGEX ]]; then
@@ -33,8 +33,8 @@ function get_versions {
     local patch=${BASH_REMATCH[3]}
 
     echo v"${major}"."${minor}"."${patch}"
-    echo v"${major}"."${minor}"
-    echo v"${major}"
+    echo v"${major}"."${minor}"-latest
+    echo v"${major}"-latest
   else
     echo "${version}"
   fi


### PR DESCRIPTION
See slack discussion here - https://kubernetes.slack.com/archives/C0155NSPJSZ/p1758622793038159

Adding "-latest" suffix to v{major}.{minor} and v{maker} tags