### PR TITLE
Fix the kubeval link in the docs to point at the correct kubeval loction

### DIFF
--- a/functions/ts/kubeval/README.md
+++ b/functions/ts/kubeval/README.md
@@ -66,6 +66,6 @@ Config Connector resources).
 If you want to convert OpenAPI to json schema, you can use
 [openapi2jsonschema](https://github.com/instrumenta/openapi2jsonschema).
 
-[`kubeval`]:https://kubeval.com
+[`kubeval`]:https://github.com/instrumenta/kubeval
 
 [json schemas]:https://json-schema.org


### PR DESCRIPTION
The current link points to 'kubeval.com', which now hosts a site selling slot machine games.