### PR TITLE
Fix set-ns to process unkown CRs

### DIFF
--- a/documentation/content/en/set-namespace/v0.4/_index.md
+++ b/documentation/content/en/set-namespace/v0.4/_index.md
@@ -44,8 +44,8 @@ Replace namespaces are commonly used in the following scenarios:
 This function not only update the namespace scoped resources' `metadata.namespace` or Namespace object's `metadata.name`,
 but handle some special resource types. See the full targeting resources below:
 
-- This function updates all namespace-scoped KRM resources `metadata.namespace` fields. 
-  We determine whether a custom KRM resource is namespace scoped by checking if it has `metadata.namespace` set.
+- This function updates all namespace-scoped KRM resources `metadata.namespace` fields.
+  Unknown custom resources are treated as namespace-scoped and will have `metadata.namespace` added if missing.
 - This function updates `RoleBinding` and `ClusterRoleBinding` resources `subjects` element whose kind is `ServiceAccount`
   and the subject's `namespace` is set.
 - This function updates `CustomResourceDefinition` (CRD) `spec/conversion/webhook/clientConfig/service/namespace` field 

--- a/documentation/content/en/set-namespace/v0.4/_index.md
+++ b/documentation/content/en/set-namespace/v0.4/_index.md
@@ -13,6 +13,14 @@ menu:
 
 {{< listexamples >}}
 
+## Known Issues
+
+**Versions v0.4.2 through v0.4.5 have a bug** where unknown Custom Resource Definitions (CRDs) without an existing `metadata.namespace` field are not processed.
+
+- **Affected versions**: v0.4.2, v0.4.3, v0.4.4, v0.4.5
+- **Workaround**: Use v0.4.1 or upgrade to v0.4.6+
+- **Symptom**: Unknown CRDs (resources not in the Kubernetes built-in API) do not get the namespace field added
+
 ## Overview
 
 <!--mdtogo:Short-->

--- a/documentation/content/en/set-namespace/v0.4/_index.md
+++ b/documentation/content/en/set-namespace/v0.4/_index.md
@@ -15,11 +15,10 @@ menu:
 
 ## Known Issues
 
-**Versions v0.4.2 through v0.4.5 have a bug** where unknown Custom Resource Definitions (CRDs) without an existing `metadata.namespace` field are not processed.
-
+**Versions v0.4.2 through v0.4.5 have a bug** where unknown custom resources (CRs) without an existing `metadata.namespace` field are not processed.
 - **Affected versions**: v0.4.2, v0.4.3, v0.4.4, v0.4.5
 - **Workaround**: Use v0.4.1 or upgrade to v0.4.6+
-- **Symptom**: Unknown CRDs (resources not in the Kubernetes built-in API) do not get the namespace field added
+- **Symptom**: Unknown custom resources (CRs) (resources defined by CustomResourceDefinitions, not in the Kubernetes built-in API) do not get the namespace field added
 
 ## Overview
 
@@ -45,7 +44,7 @@ This function not only update the namespace scoped resources' `metadata.namespac
 but handle some special resource types. See the full targeting resources below:
 
 - This function updates all namespace-scoped KRM resources `metadata.namespace` fields.
-  Unknown custom resources are treated as namespace-scoped and will have `metadata.namespace` added if missing.
+  Unknown custom resources (CRs) (resources not in the Kubernetes built-in API) do not get the namespace field added if missing.
 - This function updates `RoleBinding` and `ClusterRoleBinding` resources `subjects` element whose kind is `ServiceAccount`
   and the subject's `namespace` is set.
 - This function updates `CustomResourceDefinition` (CRD) `spec/conversion/webhook/clientConfig/service/namespace` field 

--- a/documentation/go.mod
+++ b/documentation/go.mod
@@ -1,3 +1,8 @@
 module github.com/krm-functions-catalog/docs
 
 go 1.25.7
+
+require (
+	github.com/google/docsy v0.12.0 // indirect
+	github.com/google/docsy/dependencies v0.7.2 // indirect
+)

--- a/documentation/go.sum
+++ b/documentation/go.sum
@@ -1,0 +1,8 @@
+github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.12.0 h1:CddZKL39YyJzawr8GTVaakvcUTCJRAAYdz7W0qfZ2P4=
+github.com/google/docsy v0.12.0/go.mod h1:1bioDqA493neyFesaTvQ9reV0V2vYy+xUAnlnz7+miM=
+github.com/google/docsy/dependencies v0.7.2 h1:+t5ufoADQAj4XneFphz4A+UU0ICAxmNaRHVWtMYXPSI=
+github.com/google/docsy/dependencies v0.7.2/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
+github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
+github.com/twbs/bootstrap v5.3.6+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -30,7 +30,6 @@
   },
   "devDependencies": {
     "autoprefixer": "^10.4.21",
-    "hugo-extended": "^0.127.0",
     "postcss": "^8.5.6",
     "postcss-cli": "^11.0.1"
   },

--- a/functions/go/set-namespace/README.md
+++ b/functions/go/set-namespace/README.md
@@ -31,8 +31,8 @@ Replace namespaces are commonly used in the following scenarios:
 This function not only update the namespace scoped resources' `metadata.namespace` or Namespace object's `metadata.name`,
 but handle some special resource types. See the full targeting resources below:
 
-- This function updates all namespace-scoped KRM resources `metadata.namespace` fields. 
-  We determine whether a custom KRM resource is namespace scoped by checking if it has `metadata.namespace` set.
+- This function updates all namespace-scoped KRM resources `metadata.namespace` fields.
+  Unknown custom resources are treated as namespace-scoped and will have `metadata.namespace` added if missing.
 - This function updates `RoleBinding` and `ClusterRoleBinding` resources `subjects` element whose kind is `ServiceAccount`
   and the subject's `namespace` is set.
 - This function updates `CustomResourceDefinition` (CRD) `spec/conversion/webhook/clientConfig/service/namespace` field 

--- a/functions/go/set-namespace/README.md
+++ b/functions/go/set-namespace/README.md
@@ -1,5 +1,13 @@
 # set-namespace
 
+## Known Issues
+
+**Versions v0.4.2 through v0.4.5 have a bug** where unknown Custom Resource Definitions (CRDs) without an existing `metadata.namespace` field are not processed.
+
+- **Affected versions**: v0.4.2, v0.4.3, v0.4.4, v0.4.5
+- **Workaround**: Use v0.4.1 or upgrade to the latest version
+- **Symptom**: Unknown CRDs (resources not in the Kubernetes built-in API) do not get the namespace field added
+
 ## Overview
 
 <!--mdtogo:Short-->

--- a/functions/go/set-namespace/README.md
+++ b/functions/go/set-namespace/README.md
@@ -2,11 +2,10 @@
 
 ## Known Issues
 
-**Versions v0.4.2 through v0.4.5 have a bug** where unknown Custom Resource Definitions (CRDs) without an existing `metadata.namespace` field are not processed.
-
+**Versions v0.4.2 through v0.4.5 have a bug** where unknown custom resources (CRs) without an existing `metadata.namespace` field are not processed.
 - **Affected versions**: v0.4.2, v0.4.3, v0.4.4, v0.4.5
-- **Workaround**: Use v0.4.1 or upgrade to the latest version
-- **Symptom**: Unknown CRDs (resources not in the Kubernetes built-in API) do not get the namespace field added
+- **Workaround**: Use v0.4.1 or upgrade to v0.4.6+
+- **Symptom**: Unknown custom resources (CRs) (resources defined by CustomResourceDefinitions, not in the Kubernetes built-in API) do not get the namespace field added
 
 ## Overview
 
@@ -32,7 +31,7 @@ This function not only update the namespace scoped resources' `metadata.namespac
 but handle some special resource types. See the full targeting resources below:
 
 - This function updates all namespace-scoped KRM resources `metadata.namespace` fields.
-  Unknown custom resources are treated as namespace-scoped and will have `metadata.namespace` added if missing.
+  Unknown custom resources (CRs) (resources not in the Kubernetes built-in API) do not get the namespace field added if missing.
 - This function updates `RoleBinding` and `ClusterRoleBinding` resources `subjects` element whose kind is `ServiceAccount`
   and the subject's `namespace` is set.
 - This function updates `CustomResourceDefinition` (CRD) `spec/conversion/webhook/clientConfig/service/namespace` field 

--- a/functions/go/set-namespace/generated/docs.go
+++ b/functions/go/set-namespace/generated/docs.go
@@ -16,8 +16,8 @@ Replace namespaces are commonly used in the following scenarios:
 This function not only update the namespace scoped resources' ` + "`" + `metadata.namespace` + "`" + ` or Namespace object's ` + "`" + `metadata.name` + "`" + `,
 but handle some special resource types. See the full targeting resources below:
 
-- This function updates all namespace-scoped KRM resources ` + "`" + `metadata.namespace` + "`" + ` fields. 
-  We determine whether a custom KRM resource is namespace scoped by checking if it has ` + "`" + `metadata.namespace` + "`" + ` set.
+- This function updates all namespace-scoped KRM resources ` + "`" + `metadata.namespace` + "`" + ` fields.
+  Unknown custom resources (CRs) (resources not in the Kubernetes built-in API) do not get the namespace field added if missing.
 - This function updates ` + "`" + `RoleBinding` + "`" + ` and ` + "`" + `ClusterRoleBinding` + "`" + ` resources ` + "`" + `subjects` + "`" + ` element whose kind is ` + "`" + `ServiceAccount` + "`" + `
   and the subject's ` + "`" + `namespace` + "`" + ` is set.
 - This function updates ` + "`" + `CustomResourceDefinition` + "`" + ` (CRD) ` + "`" + `spec/conversion/webhook/clientConfig/service/namespace` + "`" + ` field 

--- a/functions/go/set-namespace/transformer/namespace.go
+++ b/functions/go/set-namespace/transformer/namespace.go
@@ -61,7 +61,7 @@ type ObjectMeta struct {
 // it provides the method "Transform" to change the "namespace" and update the "config.kubernetes.io/depends-on" annotation.
 type SetNamespace struct {
 	TypeMeta         `json:",inline" yaml:",inline"`
-	ObjectMeta       `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	ObjectMeta       `json:"metadata" yaml:"metadata,omitempty"`
 	NewNamespace     string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	NamespaceMatcher string `json:"namespaceMatcher,omitempty" yaml:"namespaceMatcher,omitempty"`
 }
@@ -116,6 +116,9 @@ func (p *SetNamespace) Transform(objects fn.KubeObjects) fn.Results {
 	// Skip local resource which `kpt live apply` skips.
 	objects = objects.WhereNot(func(o *fn.KubeObject) bool { return o.IsLocalConfig() })
 
+	// Skip meta resources like Kptfile
+	objects = objects.WhereNot(fn.IsMetaResource())
+
 	// Store resources' GKNN before the namespace change. This map will be used to determine whether a resource which other
 	// resources depends on has its namespace changes.
 	dependsOnMap := MapGKNNBeforeChange(objects)
@@ -142,44 +145,13 @@ func ReplaceNamespace(objects fn.KubeObjects, newNs string, dependsOnMap map[str
 	return results
 }
 
-// ListAllOrigins adds the constraints for general replacement.
-// If a resource does not have upstream origin, it gives warnings (the resource will still be updated).
-func ListAllOrigins(objects fn.KubeObjects) ([]string, fn.Results, error) {
-	var results fn.Results
-	originNss := sets.NewString()
-	for _, o := range objects {
-		if o.HasUpstreamOrigin() {
-			origin, err := o.GetOriginID()
-			if err != nil {
-				continue
-			}
-			if o.IsClusterScoped() {
-				continue
-			}
-			if origin.Namespace == fn.UnknownNamespace {
-				// This should rarely happen.
-				return nil, nil, fmt.Errorf("%v is namespace-scoped, but has cluster-scoped or unknown scoped origin %v",
-					o.ShortString(), origin.String())
-			}
-			originNss.Insert(origin.Namespace)
-		} else {
-			results = append(results, fn.GeneralResult(fmt.Sprintf(
-				"%v does not have upstream origin.", o.ShortString()), fn.Warning))
-		}
-	}
-	return originNss.List(), results, nil
-}
-
 // WalkAndReplace iterate each KRM resource and updates the "namespace" fields.
 func WalkAndReplace(objects fn.KubeObjects, newNs string, matchers ...string) (fn.Results, int, []string) {
 	count := 0
 	oldnss := sets.NewString()
 	var results fn.Results
 	VisitAll(objects, func(origin string, currentPtr *string, idStr ...string) {
-		// Skip if the resource is a cluster scoped or unknown scoped resource.
-		if origin == fn.UnknownNamespace {
-			return
-		}
+		// Set default namespace if empty
 		if *currentPtr == "" {
 			*currentPtr = fn.DefaultNamespace
 		}
@@ -212,15 +184,8 @@ func WalkAndReplace(objects fn.KubeObjects, newNs string, matchers ...string) (f
 
 // VisitAll applies "visitor" function to both namespace scoped and cluster scoped resource.
 func VisitAll(objects fn.KubeObjects, visitor func(origin string, currentPtr *string, idStr ...string)) {
-	VisitSpecialClusterResource(objects, visitor)
-	VisitNamespaceResource(objects, visitor)
-}
-
-// VisitSpecialClusterResource applies "visitor" function to some special cluster-scoped resource that
-// have sub fields meaning "namespace".
-func VisitSpecialClusterResource(objects fn.KubeObjects, visitor func(origin string, currentPtr *string, idStr ...string)) {
-	clusterScoped := objects.Where(func(o *fn.KubeObject) bool { return o.IsClusterScoped() })
-	for _, o := range clusterScoped {
+	for _, o := range objects {
+		// Handle special cluster-scoped resources with nested namespace fields
 		switch {
 		case o.IsGVK("", "v1", "Namespace"):
 			name := o.GetName()
@@ -241,7 +206,8 @@ func VisitSpecialClusterResource(objects fn.KubeObjects, visitor func(origin str
 			nsPtr := &namespace
 			visitor("", nsPtr)
 			SetNestedStringOrDie(&o.SubObject, *nsPtr, "spec", "service", "namespace")
-		case o.GetKind() == "ClusterRoleBinding" || o.GetKind() == "RoleBinding":
+		case o.GetKind() == "ClusterRoleBinding":
+			// ClusterRoleBinding: process subjects' namespace fields only
 			subjects := o.GetSlice("subjects")
 			for _, s := range subjects {
 				if namespace, found, _ := s.NestedString("namespace"); found {
@@ -250,26 +216,41 @@ func VisitSpecialClusterResource(objects fn.KubeObjects, visitor func(origin str
 					SetNestedStringOrDie(s, *nsPtr, "namespace")
 				}
 			}
+		case o.GetKind() == "RoleBinding":
+			// RoleBinding: process both metadata.namespace and subjects' namespace fields
+			subjects := o.GetSlice("subjects")
+			for _, s := range subjects {
+				if namespace, found, _ := s.NestedString("namespace"); found {
+					nsPtr := &namespace
+					visitor("", nsPtr)
+					SetNestedStringOrDie(s, *nsPtr, "namespace")
+				}
+			}
+			// Also process metadata.namespace for RoleBinding (it's namespace-scoped)
+			namespace := o.GetNamespace()
+			nsPtr := &namespace
+			origin, err := o.GetOriginID()
+			originNs := ""
+			if err == nil {
+				originNs = origin.Namespace
+			}
+			visitor(originNs, nsPtr, o.ShortString())
+			_ = o.SetNamespace(*nsPtr)
+		case o.GetKind() == "ClusterRole":
+			// Skip ClusterRole - it's cluster-scoped and has no namespace fields
 		default:
-			// skip the cluster scoped resource
+			// For all other resources, process metadata.namespace
+			// This includes namespace-scoped resources and unknown CRDs
+			namespace := o.GetNamespace()
+			nsPtr := &namespace
+			origin, err := o.GetOriginID()
+			originNs := ""
+			if err == nil {
+				originNs = origin.Namespace
+			}
+			visitor(originNs, nsPtr, o.ShortString())
+			_ = o.SetNamespace(*nsPtr)
 		}
-	}
-}
-
-// VisitNamespaceResource applies "visitor" to namespace-scoped resource.
-// We made a hypothesis here that if a unknown scoped resource has a non-empty metadata.namespace, the resource will be
-// treated as namespace scoped.
-func VisitNamespaceResource(objects fn.KubeObjects, visitor func(origin string, currentPtr *string, idStr ...string)) {
-	namespaceScoped := objects.Where(func(o *fn.KubeObject) bool { return o.IsNamespaceScoped() })
-	for _, o := range namespaceScoped {
-		namespace := o.GetNamespace()
-		nsPtr := &namespace
-		origin, err := o.GetOriginID()
-		if err != nil {
-			origin.Namespace = fn.UnknownNamespace
-		}
-		visitor(origin.Namespace, nsPtr, o.ShortString())
-		_ = o.SetNamespace(*nsPtr)
 	}
 }
 

--- a/tests/set-namespace/unknown-crd-no-namespace/.expected/diff.patch
+++ b/tests/set-namespace/unknown-crd-no-namespace/.expected/diff.patch
@@ -1,0 +1,19 @@
+diff --git a/resources.yaml b/resources.yaml
+index 62f8744..3c6b9d2 100644
+--- a/resources.yaml
++++ b/resources.yaml
+@@ -2,6 +2,7 @@ apiVersion: apps/v1
+ kind: Deployment
+ metadata:
+   name: nginx-deployment
++  namespace: prod
+ spec:
+   replicas: 3
+ ---
+@@ -9,5 +10,6 @@ apiVersion: custom.io/v1
+ kind: Custom
+ metadata:
+   name: custom
++  namespace: prod
+ spec:
+   image: nginx:1.2.3

--- a/tests/set-namespace/unknown-crd-no-namespace/.krmignore
+++ b/tests/set-namespace/unknown-crd-no-namespace/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/tests/set-namespace/unknown-crd-no-namespace/Kptfile
+++ b/tests/set-namespace/unknown-crd-no-namespace/Kptfile
@@ -1,0 +1,9 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: unknown-crd-no-namespace
+pipeline:
+  mutators:
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
+      configMap:
+        namespace: prod

--- a/tests/set-namespace/unknown-crd-no-namespace/resources.yaml
+++ b/tests/set-namespace/unknown-crd-no-namespace/resources.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+---
+apiVersion: custom.io/v1
+kind: Custom
+metadata:
+  name: custom
+spec:
+  image: nginx:1.2.3


### PR DESCRIPTION
Fix: set-namespace not processing unknown CRDs
Fixes bug in v0.4.2-v0.4.5 where unknown Custom Resource Definitions without an existing metadata.namespace field are skipped instead of having the namespace added.

Changes:

Remove early return for unknown namespace origins

Add filter for meta resources (Kptfiles)

Fix RoleBinding to process both subjects and metadata.namespace

Add documentation warning for affected versions

Affected: v0.4.2, v0.4.3, v0.4.4, v0.4.5

The current impl breaks the tests in kpt that include "custom" resources. ie. https://github.com/kptdev/kpt/blob/main/e2e/testdata/fn-eval/out-of-place-fnchain-stdout/resources.yaml#L22