### PR TITLE
Add latest version column to function catalog documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,6 +147,11 @@ examples and e2e tests, run the following command
 $ make e2e-test
 ```
 
+### Documentation
+
+For details on running the documentation site locally, refer to the
+[documentation README](documentation/README.md).
+
 ### Change Existing Functions
 
 You must follow the layout convention when you make changes to existing

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -26,6 +26,19 @@ npm install
 Then run the site using `npm run serve`. To have the site run locally with a functioning local search, run
 `npm run serve:with-pagefind`.
 
+## API Token for Version Fetching
+
+The documentation site fetches the latest release versions of KRM functions from
+the GitHub API. To avoid rate limiting, set the `KRM_CATALOG_API_TOKEN`
+environment variable with a GitHub personal access token (no scopes required for
+public repos).
+
+- `export KRM_CATALOG_API_TOKEN=<your-token>` before running `npm run serve`.
+
+The token is optional. Without it, unauthenticated API requests are subject to
+lower rate limits, which may cause version information to be unavailable during
+builds.
+
 ## License
 
 Licensed under the [Creative Commons Attribution 4.0 International license](LICENSE-documentation)

--- a/documentation/config.toml
+++ b/documentation/config.toml
@@ -191,3 +191,7 @@ enable = false
   name = "Guides"
   url = "https://kpt.dev/guides/"
   weight = 40
+
+[security]
+  [security.funcs]
+    getenv = ['^HUGO_', '^CI$', '^KRM_CATALOG_API_TOKEN$']

--- a/documentation/layouts/shortcodes/listfunctions.html
+++ b/documentation/layouts/shortcodes/listfunctions.html
@@ -9,7 +9,7 @@
 {{ $token := getenv "KRM_CATALOG_API_TOKEN" }}
 {{ $apiURL := "https://api.github.com/repos/kptdev/krm-functions-catalog/git/matching-refs/tags/functions/go/" }}
 {{ $apiHeaders := dict "Accept" "application/vnd.github+json" "X-GitHub-Api-Version" "2026-03-10" }}
-{{ if ne $token "" }}
+{{ if $token }}
   {{ $apiHeaders = merge $apiHeaders (dict "Authorization" (printf "Bearer %s" $token)) }}
 {{ end }}
 {{ $opts := dict "headers" $apiHeaders }}

--- a/documentation/layouts/shortcodes/listfunctions.html
+++ b/documentation/layouts/shortcodes/listfunctions.html
@@ -3,10 +3,57 @@
 
 {{ $files := readDir $currentDir }}
 
+<!-- Fetch all function release tags -->
+{{ $latestVersions := dict }}
+{{ $releaseTags := dict }}
+{{ $token := getenv "KRM_CATALOG_API_TOKEN" }}
+{{ $apiURL := "https://api.github.com/repos/kptdev/krm-functions-catalog/git/matching-refs/tags/functions/go/" }}
+{{ $apiHeaders := dict "Accept" "application/vnd.github+json" "X-GitHub-Api-Version" "2026-03-10" }}
+{{ if ne $token "" }}
+  {{ $apiHeaders = merge $apiHeaders (dict "Authorization" (printf "Bearer %s" $token)) }}
+{{ end }}
+{{ $opts := dict "headers" $apiHeaders }}
+{{ with resources.GetRemote $apiURL $opts }}
+  {{ $refs := . | transform.Unmarshal }}
+  {{ if and (reflect.IsSlice $refs) (gt (len $refs) 0) }}
+    {{ range $refs }}
+      {{ $tag := .ref | replaceRE "^refs/tags/functions/go/" "" }}
+      {{ $parts := split $tag "/" }}
+      {{ if eq (len $parts) 2 }}
+        {{ $fnName := index $parts 0 }}
+        {{ $v := index $parts 1 | replaceRE "^v" "" | replaceRE "[-+].*" "" }}
+        {{ $semver := split $v "." }}
+        {{ if ge (len $semver) 3 }}
+          {{ $maj := index $semver 0 | int }}
+          {{ $min := index $semver 1 | int }}
+          {{ $pat := index $semver 2 | int }}
+          {{ $curVer := index $latestVersions $fnName }}
+          {{ $isBetter := true }}
+          {{ if $curVer }}
+            {{ $curV := $curVer | replaceRE "^v" "" | replaceRE "[-+].*" "" }}
+            {{ $curParts := split $curV "." }}
+            {{ $curMaj := index $curParts 0 | int }}
+            {{ $curMin := index $curParts 1 | int }}
+            {{ $curPat := index $curParts 2 | int }}
+            {{ $isBetter = or (gt $maj $curMaj) (and (eq $maj $curMaj) (gt $min $curMin)) (and (eq $maj $curMaj) (eq $min $curMin) (gt $pat $curPat)) }}
+          {{ end }}
+          {{ if $isBetter }}
+            {{ $version := index $parts 1 }}
+            {{ $fullTag := printf "functions/go/%s/%s" $fnName $version }}
+            {{ $latestVersions = merge $latestVersions (dict $fnName $version) }}
+            {{ $releaseTags = merge $releaseTags (dict $fnName $fullTag) }}
+          {{ end }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
 <table class="table table-striped">
 <thead>
   <tr>
     <th>Function</th>
+    <th>Latest Version</th>
     <th>Description</th>
     <th>Tags</th>
   </tr>
@@ -65,6 +112,13 @@
                 <a href="{{ printf "%s/%s/" $functionName $highestVersion }}">{{ .Title }}</a>
               {{ end }}
             </td>
+            <td>
+              {{ $ver := index $latestVersions $functionName }}
+              {{ $tag := index $releaseTags $functionName }}
+              {{ if $ver }}
+                <a href="https://github.com/kptdev/krm-functions-catalog/releases/tag/{{ $tag }}">{{ $ver }}</a>
+              {{ else }}—{{ end }}
+            </td>
             <td>{{ .Params.description | markdownify }}</td>
             <td>
               {{ if .Params.tags }}
@@ -79,6 +133,13 @@
       {{ $title := .Name | replaceRE "\\.[^.]+$" "" }}
       <tr>
         <td><a href="{{ printf "%s" .Name }}">{{ $title }}</a></td>
+        <td>
+          {{ $ver := index $latestVersions .Name }}
+          {{ $tag := index $releaseTags .Name }}
+          {{ if $ver }}
+            <a href="https://github.com/kptdev/krm-functions-catalog/releases/tag/{{ $tag }}">{{ $ver }}</a>
+          {{ else }}—{{ end }}
+        </td>
         <td>No description available</td>
         <td></td>
       </tr>


### PR DESCRIPTION
### Description

This PR adds a "Latest Version" column to the function listing on the catalog documentation site, showing the latest released version for each function with a link to its GitHub release.

### Changes

- documentation/layouts/shortcodes/listfunctions.html
  - Fetch latest release tags per function from the GitHub git/matching-refs API
  - Use numeric semver comparison (major.minor.patch) to determine the latest version, avoiding lexicographic ordering bugs with double-digit versions (e.g., v0.10.0 vs v0.9.0)
- Documentation updated

### Notes

- The API token is optional. Without it, unauthenticated requests are subject to GitHub's lower rate limits, which may cause version info to be unavailable during builds.
- For Netlify, set `KRM_CATALOG_API_TOKEN` via the site's environment variables in the Netlify UI.
