### PR TITLE
 Fix create-setters matching setter values in internal kpt annotations

### DIFF
--- a/functions/go/create-setters/createsetters/create_setters.go
+++ b/functions/go/create-setters/createsetters/create_setters.go
@@ -248,6 +248,12 @@ func (cs *CreateSetters) visitScalar(object *yaml.RNode, path string) error {
 		return nil
 	}
 
+	// skip internal kpt annotations — these are runtime metadata, not user-authored content
+	if strings.Contains(path, ".annotations.internal.config.kubernetes.io") ||
+		strings.Contains(path, ".annotations.config.kubernetes.io") {
+		return nil
+	}
+
 	// doesn't add the comment to the nodes with multiple line values
 	if hasMultipleLines(object.YNode().Value) {
 		return nil

--- a/functions/go/create-setters/createsetters/create_setters_test.go
+++ b/functions/go/create-setters/createsetters/create_setters_test.go
@@ -520,6 +520,33 @@ spec:
   image: dev # kpt-set: ${role}
 `,
 		},
+		{
+			name: "skip internal kpt annotations",
+			config: `
+data:
+  replicas: "4"
+`,
+			input: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  annotations:
+    internal.config.kubernetes.io/package-path: /tmp/some-path-with-4-in-it
+    config.kubernetes.io/local-config: "true"
+spec:
+  replicas: 4
+`,
+			expectedResources: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  annotations:
+    internal.config.kubernetes.io/package-path: /tmp/some-path-with-4-in-it
+    config.kubernetes.io/local-config: "true"
+spec:
+  replicas: 4 # kpt-set: ${replicas}
+`,
+		},
 	}
 	for i := range tests {
 		test := tests[i]


### PR DESCRIPTION
Fixes https://github.com/kptdev/kpt/issues/4462

### Summary

The create-setters function was incorrectly creating setter comments on `internal.config.kubernetes.io/*` and `config.kubernetes.io/*` annotations. These are kpt runtime metadata injected during fn render (e.g. filesystem paths) and are not user-authored resource content. When a setter value like 4 appeared as a substring in a temp directory path, the function would produce spurious and non-deterministic results.

### Changes

functions/go/create-setters/createsetters/create_setters.go:
- Added a path check in visitScalar() to skip fields under `internal.config.kubernetes.io` and `config.kubernetes.io annotations

functions/go/create-setters/createsetters/create_setters_test.go:
- Added test case skip internal kpt annotations verifying that:
  - `internal.config.kubernetes.io/package-path` containing the setter value is not matched
  - config.kubernetes.io/local-config` is not matched
  - Regular fields like `spec.replicas` still correctly receive setter comments
