### PR TITLE
Add container image reference to release notes

### DIFF
--- a/.github/workflows/after-tag-with-version.yaml
+++ b/.github/workflows/after-tag-with-version.yaml
@@ -81,9 +81,14 @@ jobs:
           VERSION="${{ steps.extract.outputs.version }}"
           FUNC_DIR="functions/go/${IMAGE_NAME}"
 
-          IMAGE_BASE=$(grep '^image:' "${FUNC_DIR}/metadata.yaml" | awk '{print $2}')
+          if [[ ! -f "${FUNC_DIR}/metadata.yaml" ]]; then
+            echo "::error::${FUNC_DIR}/metadata.yaml not found"
+            exit 1
+          fi
+
+          IMAGE_BASE=$(grep '^image:' "${FUNC_DIR}/metadata.yaml" | awk '{print $2}' | tr -d '"')
           if [[ -z "$IMAGE_BASE" ]]; then
-            echo "::error::No image field found in ${FUNC_DIR}/metadata.yaml"
+            echo "::error::No image field in ${FUNC_DIR}/metadata.yaml"
             exit 1
           fi
 
@@ -109,8 +114,11 @@ jobs:
             exit 0
           fi
 
-          NEW_BODY="$(printf '%s\n\n## Container Image\n\n```\n%s\n```' "$CURRENT_BODY" "$IMAGE_REF")"
+          NOTES_FILE=$(mktemp)
+          printf '%s\n\n## Container Image\n\n```\n%s\n```' "$CURRENT_BODY" "$IMAGE_REF" > "$NOTES_FILE"
 
           gh release edit "$TAG" \
             --repo "${{ github.repository }}" \
-            --notes "$NEW_BODY"
+            --notes-file "$NOTES_FILE"
+
+          rm -f "$NOTES_FILE"

--- a/.github/workflows/after-tag-with-version.yaml
+++ b/.github/workflows/after-tag-with-version.yaml
@@ -1,5 +1,5 @@
 # Copyright 2022 Google LLC
-# Modifications Copyright (C) 2025 OpenInfra Foundation Europe.
+# Modifications Copyright (C) 2025-2026 OpenInfra Foundation Europe.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
-      contents: read
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -73,3 +73,44 @@ jobs:
             echo "Tag does not match any known type, skipping."
             exit 0
           fi
+
+      - name: Read image reference from metadata
+        id: meta
+        run: |
+          IMAGE_NAME="${{ steps.extract.outputs.image_name }}"
+          VERSION="${{ steps.extract.outputs.version }}"
+          FUNC_DIR="functions/go/${IMAGE_NAME}"
+
+          IMAGE_BASE=$(grep '^image:' "${FUNC_DIR}/metadata.yaml" | awk '{print $2}')
+          if [[ -z "$IMAGE_BASE" ]]; then
+            echo "::error::No image field found in ${FUNC_DIR}/metadata.yaml"
+            exit 1
+          fi
+
+          echo "image_ref=${IMAGE_BASE}:${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Add image reference to release notes
+        if: steps.meta.outputs.image_ref != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          IMAGE_REF="${{ steps.meta.outputs.image_ref }}"
+
+          if ! gh release view "$TAG" --repo "${{ github.repository }}" > /dev/null 2>&1; then
+            echo "No release found for tag $TAG, skipping."
+            exit 0
+          fi
+
+          CURRENT_BODY=$(gh release view "$TAG" --repo "${{ github.repository }}" --json body -q .body)
+
+          if [[ "$CURRENT_BODY" == *"$IMAGE_REF"* ]]; then
+            echo "Image reference already present in release notes, skipping."
+            exit 0
+          fi
+
+          NEW_BODY="$(printf '%s\n\n## Container Image\n\n```\n%s\n```' "$CURRENT_BODY" "$IMAGE_REF")"
+
+          gh release edit "$TAG" \
+            --repo "${{ github.repository }}" \
+            --notes "$NEW_BODY"


### PR DESCRIPTION
After the image is pushed to GHCR, the workflow now appends the container image reference to the GitHub release notes.

Fixes https://github.com/kptdev/kpt/issues/4478

## Changes

- Read the image base path from the function's `metadata.yaml` and append the version tag to construct the full image reference
- Append a "Container Image" section to the release notes with the image ref

## Testing

Verified in a personal fork by creating a draft release and triggering the workflow with a test tag. The image reference was correctly read from metadata.yaml and appended to the release notes.
- https://github.com/aravindtga/krm-functions-catalog/releases/tag/functions%2Fgo%2Fupsert-resource%2Fv0.2.3
- https://github.com/aravindtga/krm-functions-catalog/actions/runs/24574921580/job/71857614157 (Image details gets updated in release body)
- https://github.com/aravindtga/krm-functions-catalog/actions/runs/24574921580/job/71860296655 (Image reference already exists case)
