### PR TITLE
Fix set-namespace to fail on invalid configuration

### DIFF
--- a/functions/go/set-namespace/tests/no-fnconfig-resource/.expected/config.yaml
+++ b/functions/go/set-namespace/tests/no-fnconfig-resource/.expected/config.yaml
@@ -1,0 +1,1 @@
+exitCode: 1

--- a/functions/go/set-namespace/tests/no-fnconfig-resource/.expected/diff.patch
+++ b/functions/go/set-namespace/tests/no-fnconfig-resource/.expected/diff.patch
@@ -1,20 +1,24 @@
 diff --git a/Kptfile b/Kptfile
-index cf1b069..4d064a0 100644
+index cf1b069..1553fa8 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -5,3 +5,24 @@ metadata:
+@@ -5,3 +5,29 @@ metadata:
  pipeline:
    mutators:
      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +status:
 +  conditions:
 +    - type: Rendered
-+      status: "True"
-+      reason: RenderSuccess
++      status: "False"
++      reason: RenderFailed
++      message: |-
++        pkg.render: pkg .:
++        	pipeline.run: already handled error
 +  renderStatus:
 +    mutationSteps:
 +      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
-+        exitCode: 0
++        stderr: 'failed to evaluate function: error: function failure'
++        exitCode: 1
 +        results:
 +          - message: FunctionConfig is missing. Expect `ConfigMap.v1` or `SetNamespace.v1alpha1.fn.kpt.dev`
 +            severity: error
@@ -27,3 +31,4 @@ index cf1b069..4d064a0 100644
 +            resourceRef: {}
 +            file:
 +              index: -1
++    errorSummary: 'ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest: exit code 1'

--- a/functions/go/set-namespace/tests/no-fnconfig-resource/.expected/results.yaml
+++ b/functions/go/set-namespace/tests/no-fnconfig-resource/.expected/results.yaml
@@ -2,10 +2,11 @@ apiVersion: kpt.dev/v1
 kind: FunctionResultList
 metadata:
   name: fnresults
-exitCode: 0
+exitCode: 1
 items:
   - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
-    exitCode: 0
+    stderr: 'failed to evaluate function: error: function failure'
+    exitCode: 1
     results:
       - message: FunctionConfig is missing. Expect `ConfigMap.v1` or `SetNamespace.v1alpha1.fn.kpt.dev`
         severity: error

--- a/functions/go/set-namespace/transformer/namespace.go
+++ b/functions/go/set-namespace/transformer/namespace.go
@@ -30,7 +30,7 @@ func Run(rl *fn.ResourceList) (bool, error) {
 	err := tc.Config(rl.FunctionConfig)
 	if err != nil {
 		rl.Results = append(rl.Results, fn.ErrorConfigObjectResult(err, rl.FunctionConfig))
-		return true, nil
+		return false, nil
 	}
 	// Update "namespace" to the proper resources.
 	results := tc.Transform(rl.Items)


### PR DESCRIPTION
`set-namespace` was exiting 0 and reporting [PASS] when configuration was invalid (e.g., empty namespace), while simultaneously emitting an error-severity result. 

 Closes [#4547](https://github.com/kptdev/kpt/issues/4547)

 ### Root cause:

  The Run function in transformer/namespace.go returned true, nil on config error, signaling success to the framework:
```go
  if err != nil {
      rl.Results = append(rl.Results, fn.ErrorConfigObjectResult(err, rl.FunctionConfig))
      return true, nil  // ← bug: should signal failure
  }
```
### Fix:

Changed return true, nil to return false, nil so the framework correctly reports the function as failed (exit code 1, [FAIL]).

#### Before:

```bash
  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
  [Results]: [error] v1/ConfigMap/function-input: `data.namespace` should not be empty
  Exit code: 0
```

#### After:

```bash
  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
  [FAIL] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
  [Results]: [error] v1/ConfigMap/function-input: `data.namespace` should not be empty
  Exit code: 1
```
  
### Testing:

- Updated tests to test the behaviour