### PR TITLE
Parallelize make targets for faster builds

### DIFF
--- a/.github/workflows/after-push-to-branch.yaml
+++ b/.github/workflows/after-push-to-branch.yaml
@@ -1,6 +1,5 @@
 # Copyright 2022-2026 The kpt Authors
 #
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -32,6 +31,7 @@ jobs:
       with:
         go-version-file: documentation/go.mod
         install-kpt: 'false'
+        cache-dependency-path: functions/go/*/go.sum
     - uses: docker/setup-qemu-action@v4
     - uses: docker/setup-buildx-action@v4
     - name: Log in to GHCR

--- a/.github/workflows/after-tag-with-version.yaml
+++ b/.github/workflows/after-tag-with-version.yaml
@@ -34,6 +34,7 @@ jobs:
         with:
           go-version-file: documentation/go.mod
           install-kpt: 'false'
+          cache-dependency-path: functions/go/*/go.sum
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 The kpt Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: CI
 
 on:
@@ -58,6 +72,7 @@ jobs:
         with:
           go-version-file: documentation/go.mod
           install-kpt: 'false'
+          cache-dependency-path: functions/go/*/go.sum
       - name: Run unit tests
         run: |
           make unit-test
@@ -74,6 +89,7 @@ jobs:
         uses: kptdev/porch/.github/actions/setup-go-kpt@main
         with:
           go-version-file: functions/go/list-setters/go.mod
+          cache-dependency-path: functions/go/*/go.sum
       - name: Install kustomize
         uses: syntaqx/setup-kustomize@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,6 +90,12 @@ jobs:
         with:
           go-version-file: functions/go/list-setters/go.mod
           cache-dependency-path: functions/go/*/go.sum
+      - name: Cache golangci-lint
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/golangci-lint
+          key: golangci-lint-${{ hashFiles('functions/go/*/go.sum') }}
+          restore-keys: golangci-lint-
       - name: Install kustomize
         uses: syntaqx/setup-kustomize@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@
 SHELL=/bin/bash
 export TAG ?= latest
 export DEFAULT_CR ?= ghcr.io/kptdev/krm-functions-catalog
+NPROC := $(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)
 
 
 .DEFAULT_GOAL := help
@@ -24,7 +25,7 @@ help: ## Print this help
 .PHONY: test unit-test e2e-test push
 
 unit-test: ## Run unit tests for Go functions
-	cd functions/go && $(MAKE) test -j$(shell nproc)
+	cd functions/go && $(MAKE) test -j$(NPROC)
 
 e2e-test: ## Run all e2e tests
 	cd tests/e2etest && go test -v -run TestE2E ./...
@@ -42,14 +43,14 @@ tidy:
 
 .PHONY: build
 build: ## Build all function images.
-	cd functions/go && $(MAKE) build -j$(shell nproc)
+	cd functions/go && $(MAKE) build -j$(NPROC)
 
 .PHONY: format
 format: ## Run go fix, vet, fmt, lint and generate docs for all functions
-	cd functions/go && $(MAKE) format -j$(shell nproc)
+	cd functions/go && $(MAKE) format -j$(NPROC)
 
 push: ## Push images to registry. WARN: This operation should only be done in CI environment.
-	cd functions/go && $(MAKE) push -j$(shell nproc)
+	cd functions/go && $(MAKE) push -j$(NPROC)
 
 validate-metadata: ## Validate all metadata.yaml files against the schema
 	cd scripts/generate_docs && go run . validate

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ help: ## Print this help
 .PHONY: test unit-test e2e-test push
 
 unit-test: ## Run unit tests for Go functions
-	cd functions/go && $(MAKE) test
+	cd functions/go && $(MAKE) test -j$(shell nproc)
 
 e2e-test: ## Run all e2e tests
 	cd tests/e2etest && go test -v -run TestE2E ./...
@@ -42,14 +42,14 @@ tidy:
 
 .PHONY: build
 build: ## Build all function images.
-	cd functions/go && $(MAKE) build
+	cd functions/go && $(MAKE) build -j$(shell nproc)
 
 .PHONY: format
 format: ## Run go fix, vet, fmt, lint and generate docs for all functions
-	cd functions/go && $(MAKE) format
+	cd functions/go && $(MAKE) format -j$(shell nproc)
 
 push: ## Push images to registry. WARN: This operation should only be done in CI environment.
-	cd functions/go && $(MAKE) push
+	cd functions/go && $(MAKE) push -j$(shell nproc)
 
 validate-metadata: ## Validate all metadata.yaml files against the schema
 	cd scripts/generate_docs && go run . validate

--- a/functions/go/Makefile
+++ b/functions/go/Makefile
@@ -106,6 +106,7 @@ push: $(FUNCTION_PUSH) ## Push images to registry. WARN: This operation should o
 $(FUNCTION_PUSH):
 	$(MAKE) CURRENT_FUNCTION=$(subst -PUSH,,$@) TAG=$(TAG) DEFAULT_CR=$(DEFAULT_CR) func-push
 
+.PHONY: install-mdtogo
 install-mdtogo:
 	go install github.com/kptdev/kpt/mdtogo@main
 
@@ -114,6 +115,7 @@ install-mdtogo:
 func-verify: func-format func-test
 func-format: docs-generate func-fix func-vet func-fmt func-lint
 
+.PHONY: install-golangci-lint
 install-golangci-lint:
 	(which $(GOPATH)/bin/golangci-lint || \
 		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(GOPATH)/bin latest)

--- a/functions/go/Makefile
+++ b/functions/go/Makefile
@@ -73,7 +73,7 @@ $(FUNCTIONS):
 test: generate $(FUNCTION_TESTS) ## Run unit tests for all functions
 
 .PHONY: $(FUNCTION_TESTS)
-$(FUNCTION_TESTS):
+$(FUNCTION_TESTS): | generate
 	$(MAKE) CURRENT_FUNCTION=$(subst -TEST,,$@) func-test
 
 generate: install-mdtogo generate-docs
@@ -82,21 +82,21 @@ generate: install-mdtogo generate-docs
 generate-docs: $(FUNCTION_GENERATE_DOCS) ## Generate docs for all functions
 
 .PHONY: $(FUNCTION_GENERATE_DOCS)
-$(FUNCTION_GENERATE_DOCS):
+$(FUNCTION_GENERATE_DOCS): | install-mdtogo
 	$(MAKE) CURRENT_FUNCTION=$(subst -GENERATE,,$@) docs-generate
 
 .PHONY: build
 build: generate $(FUNCTION_BUILDS) ## Build all function images. 'TAG' env is used to specify tag. 'dev' will be used if not set.
 
 .PHONY: $(FUNCTION_BUILDS)
-$(FUNCTION_BUILDS):
+$(FUNCTION_BUILDS): | generate install-golangci-lint
 	$(MAKE) CURRENT_FUNCTION=$(subst -BUILD,,$@) TAG=$(TAG) DEFAULT_CR=$(DEFAULT_CR) func-build
 
 .PHONY: format
 format: generate $(FUNCTION_FORMATS)
 
 .PHONY: $(FUNCTION_FORMATS)
-$(FUNCTION_FORMATS):
+$(FUNCTION_FORMATS): | generate install-golangci-lint
 	$(MAKE) CURRENT_FUNCTION=$(subst -FORMAT,,$@) TAG=$(TAG) DEFAULT_CR=$(DEFAULT_CR) func-format
 
 .PHONY: push
@@ -114,16 +114,18 @@ install-mdtogo:
 func-verify: func-format func-test
 func-format: docs-generate func-fix func-vet func-fmt func-lint
 
+install-golangci-lint:
+	(which $(GOPATH)/bin/golangci-lint || \
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(GOPATH)/bin latest)
+
 func-fix:
 	cd $(CURRENT_FUNCTION) && go fix -omitzero=false ./...
 
 func-fmt:
 	cd $(CURRENT_FUNCTION) && go fmt ./...
 
-func-lint:
-	(which $(GOPATH)/bin/golangci-lint || \
-		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.11.4/install.sh | sh -s -- -b $(GOPATH)/bin v2.11.4)
-	cd $(CURRENT_FUNCTION) && time $(GOPATH)/bin/golangci-lint run --fix --timeout=10m ./...
+func-lint: install-golangci-lint
+	cd $(CURRENT_FUNCTION) && time $(GOPATH)/bin/golangci-lint run --allow-parallel-runners --fix --timeout=10m ./...
 
 func-test:
 	cd $(CURRENT_FUNCTION) && go test -cover ./...


### PR DESCRIPTION
Enable parallel execution across all fan-out make targets to significantly reduce build, test, format, and push times by utilizing all available CPU cores.

## Changes

### Root Makefile

- `unit-test`: run function tests in parallel with `-j$(nproc)`
- `build`: run function builds in parallel with `-j$(nproc)`
- `format`: run function format checks in parallel with `-j$(nproc)`
- `push`: run function image pushes in parallel with `-j$(nproc)`

### functions/go/Makefile

- Update golangci-lint to use `main` branch installer
- Add `--allow-parallel-runners` flag to golangci-lint to avoid cache lock contention when multiple instances run concurrently

### Composite workflow action
- Cache-dependency-path added to cache the required go dependencies across workflow runs

## Testing

- `make unit-test` passes - all function unit tests complete successfully
- `make test` (unit + e2e) passes when images are pre-built

## AI Disclosure
- `kiro CLI` has been used to draft the PR description and testing