### PR TITLE
Remove diffStripRegEx workaround in create-setters-simple test

### DIFF
--- a/examples/create-setters-simple/.expected/config.yaml
+++ b/examples/create-setters-simple/.expected/config.yaml
@@ -1,2 +1,0 @@
-# This is temporary fix. Should be removed once the fix for https://github.com/kptdev/kpt/issues/4462 is released.
-diffStripRegEx: "^\\+\\s+(results:|- message:|field:|path:|file:|severity:)"

--- a/examples/create-setters-simple/.expected/diff.patch
+++ b/examples/create-setters-simple/.expected/diff.patch
@@ -1,8 +1,8 @@
 diff --git a/Kptfile b/Kptfile
-index 5aa759e..8ac91d5 100644
+index 5aa759e..7ca4e2c 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -11,3 +11,38 @@ pipeline:
+@@ -11,3 +11,28 @@ pipeline:
        selectors:
          - kind: Deployment
          - kind: MyKind
@@ -16,11 +16,6 @@ index 5aa759e..8ac91d5 100644
 +      - image: ghcr.io/kptdev/krm-functions-catalog/create-setters:latest
 +        exitCode: 0
 +        results:
-+          - message: 'Added line comment "kpt-set: /tmp/kpt-pipeline-e2e-39110${nginx-replicas}1686/create-setters-simple" for field with value "/tmp/kpt-pipeline-e2e-3911041686/create-setters-simple"'
-+            field:
-+              path: metadata.annotations.internal.config.kubernetes.io/package-path
-+            file:
-+              path: resources.yaml
 +          - message: 'Added line comment "kpt-set: ${nginx-replicas}" for field with value "4"'
 +            field:
 +              path: spec.replicas
@@ -34,11 +29,6 @@ index 5aa759e..8ac91d5 100644
 +          - message: 'Added line comment "kpt-set: ${env}" for field with value "[dev stage]"'
 +            field:
 +              path: environments
-+            file:
-+              path: resources.yaml
-+          - message: 'Added line comment "kpt-set: /tmp/kpt-pipeline-e2e-39110${nginx-replicas}1686/create-setters-simple" for field with value "/tmp/kpt-pipeline-e2e-3911041686/create-setters-simple"'
-+            field:
-+              path: metadata.annotations.internal.config.kubernetes.io/package-path
 +            file:
 +              path: resources.yaml
 diff --git a/resources.yaml b/resources.yaml


### PR DESCRIPTION
  ## Description
  - What changed: Removed the `diffStripRegEx` workaround from the `create-setters-simple` example test and updated the expected diff to reflect the correct results.
  - Why it's needed: The workaround was a temporary fix for kptdev/kpt#4462, where `create-setters` incorrectly matched setter values inside internal annotation paths. The fix has been released in `create-setters` `v0.1.4`, so the workaround is no longer needed.
  - How it works: Deleted the now-unnecessary `.expected/config.yaml` and updated `.expected/diff.patch` to only contain the 3 legitimate setter results (removing the 2 spurious `package-path` matches).

  ## Related Issue(s)
  - Closes kptdev/kpt#4482

  ## Type of Change
  - [x] Tests
  - [x] Other: Remove temporary workaround

  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [x] Tests added/updated
  - [ ] Documentation added/updated
  - [x] All tests and gating checks pass


  ## AI Disclosure

  - [x] **I have used AI in the creation of this PR.**

  If so, please describe how:
    - Kiro to identify the correct expected diff output and verify test results.
