### PR TITLE
Modernize outdated Go practices across catalog functions

### DIFF
--- a/functions/go/annotate-apply-time-mutations/pkg/annotation.go
+++ b/functions/go/annotate-apply-time-mutations/pkg/annotation.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 The kpt Authors
+// Copyright 2021-2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ func WriteAnnotation(obj *yaml.RNode, atm mutation.ApplyTimeMutation) error {
 	// and sigs.k8s.io/kustomize/kyaml/yaml requires yaml field tags...
 	yamlBytes, err := k8syaml.Marshal(atm)
 	if err != nil {
-		return fmt.Errorf("failed to format apply-time-mutation annotation: %v", err)
+		return fmt.Errorf("failed to format apply-time-mutation annotation: %w", err)
 	}
 	a := obj.GetAnnotations()
 	if a == nil {
@@ -45,7 +45,7 @@ func WriteAnnotation(obj *yaml.RNode, atm mutation.ApplyTimeMutation) error {
 	a[mutation.Annotation] = string(yamlBytes)
 	err = obj.SetAnnotations(a)
 	if err != nil {
-		return fmt.Errorf("failed to update annotations: %v", err)
+		return fmt.Errorf("failed to update annotations: %w", err)
 	}
 	return nil
 }

--- a/functions/go/annotate-apply-time-mutations/pkg/annotation_test.go
+++ b/functions/go/annotate-apply-time-mutations/pkg/annotation_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 The kpt Authors
+// Copyright 2021-2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import (
 )
 
 func TestWriteAnnotation(t *testing.T) {
+	t.Parallel()
 	testCases := map[string]struct {
 		config         string
 		subs           mutation.ApplyTimeMutation

--- a/functions/go/annotate-apply-time-mutations/pkg/comment_scanner_test.go
+++ b/functions/go/annotate-apply-time-mutations/pkg/comment_scanner_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 The kpt Authors
+// Copyright 2021-2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import (
 )
 
 func TestApplySettersReferenceParse(t *testing.T) {
+	t.Parallel()
 	testCases := map[string]struct {
 		s          string
 		wantStruct mutation.ResourceReference
@@ -72,6 +73,7 @@ func TestApplySettersReferenceParse(t *testing.T) {
 }
 
 func TestCommentToTokenField(t *testing.T) {
+	t.Parallel()
 	testCases := map[string]struct {
 		s          string
 		givenIndex int
@@ -106,6 +108,7 @@ func TestCommentToTokenField(t *testing.T) {
 }
 
 func TestCommentScan(t *testing.T) {
+	t.Parallel()
 	testCases := map[string]struct {
 		config        string
 		expectResults []ScanResult

--- a/functions/go/annotate-apply-time-mutations/pkg/function_test.go
+++ b/functions/go/annotate-apply-time-mutations/pkg/function_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 The kpt Authors
+// Copyright 2021-2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,7 +27,11 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
+// filePathPattern matches test file path annotations in the form file-N.yaml.
+var filePathPattern = regexp.MustCompile(`file-(\d+)\.yaml`)
+
 func TestFunctionProcess(t *testing.T) {
+	t.Parallel()
 	testCases := map[string]struct {
 		configs         [][]string
 		expectedConfigs [][]string
@@ -256,14 +260,14 @@ func stringsToItems(configs [][]string) ([]*yaml.RNode, error) {
 		for j, config := range file {
 			node, err := yaml.Parse(config)
 			if err != nil {
-				return items, fmt.Errorf("failed to parse yaml (configs[%d][%d]): %v", i, j, err)
+				return items, fmt.Errorf("failed to parse yaml (configs[%d][%d]): %w", i, j, err)
 			}
 			a := node.GetAnnotations()
 			a[kioutil.PathAnnotation] = fmt.Sprintf("file-%d.yaml", i)
 			a[kioutil.IndexAnnotation] = strconv.Itoa(j)
 			err = node.SetAnnotations(a)
 			if err != nil {
-				return items, fmt.Errorf("failed to update annotations: %v", err)
+				return items, fmt.Errorf("failed to update annotations: %w", err)
 			}
 			items = append(items, node)
 		}
@@ -274,7 +278,6 @@ func stringsToItems(configs [][]string) ([]*yaml.RNode, error) {
 // itemsToStrings simulates writing a package of yaml files, each with zero or
 // more objects.
 func itemsToStrings(items []*yaml.RNode) ([][]string, error) {
-	filePathPattern := regexp.MustCompile(`file-(\d+).yaml`)
 	var configs [][]string
 	for i, item := range items {
 		a := item.GetAnnotations()
@@ -284,7 +287,7 @@ func itemsToStrings(items []*yaml.RNode) ([][]string, error) {
 		delete(a, kioutil.IndexAnnotation)
 		err := item.SetAnnotations(a)
 		if err != nil {
-			return configs, fmt.Errorf("failed to update annotations: %v", err)
+			return configs, fmt.Errorf("failed to update annotations: %w", err)
 		}
 
 		match := filePathPattern.FindStringSubmatch(filePath)
@@ -303,7 +306,7 @@ func itemsToStrings(items []*yaml.RNode) ([][]string, error) {
 
 		config, err := item.String()
 		if err != nil {
-			return configs, fmt.Errorf("failed to format yaml (configs[%d][%d]): %v", filePathIndex, fileIndex, err)
+			return configs, fmt.Errorf("failed to format yaml (configs[%d][%d]): %w", filePathIndex, fileIndex, err)
 		}
 
 		for filePathIndex >= len(configs) {

--- a/functions/go/annotate-apply-time-mutations/pkg/object_scanner_test.go
+++ b/functions/go/annotate-apply-time-mutations/pkg/object_scanner_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 The kpt Authors
+// Copyright 2021-2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import (
 )
 
 func TestObjectScan(t *testing.T) {
+	t.Parallel()
 	testCases := map[string]struct {
 		config       string
 		expectResult *ApplyTimeMutation

--- a/functions/go/apply-setters/applysetters/apply_setters.go
+++ b/functions/go/apply-setters/applysetters/apply_setters.go
@@ -27,6 +27,9 @@ import (
 
 const SetterCommentIdentifier = "# kpt-set: "
 
+// setterRefPattern matches setter references in the form ${name}.
+var setterRefPattern = regexp.MustCompile(`\$\{([^}]*)\}`)
+
 var _ kio.Filter = &ApplySetters{}
 
 // ApplySetters applies the setter values to the resource fields which are tagged
@@ -361,8 +364,7 @@ func validArraySetterPattern(pattern string) bool {
 // unresolvedSetters returns the list of values enclosed in ${} present within given
 // pattern e.g. pattern = foo-${image}:${tag}-bar return ["${image}", "${tag}"]
 func unresolvedSetters(pattern string) []string {
-	re := regexp.MustCompile(`\$\{([^}]*)\}`)
-	return re.FindAllString(pattern, -1)
+	return setterRefPattern.FindAllString(pattern, -1)
 }
 
 // clean extracts value enclosed in ${}

--- a/functions/go/apply-setters/applysetters/apply_setters_test.go
+++ b/functions/go/apply-setters/applysetters/apply_setters_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestApplySettersFilter(t *testing.T) {
+	t.Parallel()
 	var tests = []struct {
 		name              string
 		config            string
@@ -572,6 +573,7 @@ var resolvePatternCases = []patternTest{
 }
 
 func TestCurrentSetterValues(t *testing.T) {
+	t.Parallel()
 	for _, tests := range [][]patternTest{resolvePatternCases} {
 		for i := range tests {
 			test := tests[i]

--- a/functions/go/create-setters/createsetters/create_setters.go
+++ b/functions/go/create-setters/createsetters/create_setters.go
@@ -15,8 +15,9 @@
 package createsetters
 
 import (
+	"cmp"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"sigs.k8s.io/kustomize/kyaml/errors"
@@ -78,22 +79,6 @@ type Result struct {
 
 	// Comment is the line comment of the matching value
 	Comment string
-}
-
-// CompareSetters is to sort the setter values
-type CompareSetters []ScalarSetter
-
-func (a CompareSetters) Len() int {
-	return len(a)
-}
-
-// node with value of maximum length is placed first
-func (a CompareSetters) Less(i, j int) bool {
-	return len(a[i].Value) > len(a[j].Value)
-}
-
-func (a CompareSetters) Swap(i, j int) {
-	a[i], a[j] = a[j], a[i]
 }
 
 // Filter implements CreatSetters as a yaml.Filter
@@ -195,7 +180,7 @@ func (cs *CreateSetters) visitMapping(object *yaml.RNode, path string) error {
 		for _, values := range elements {
 			nodeValues = append(nodeValues, values.YNode().Value)
 		}
-		sort.Strings(nodeValues)
+		slices.Sort(nodeValues)
 
 		// checks if any of the values of node matches with ScalarSetters
 		// changes the node to FoldedStyle
@@ -316,7 +301,7 @@ func getArraySetter(input *yaml.RNode) []string {
 		output = append(output, as.YNode().Value)
 	}
 
-	sort.Strings(output)
+	slices.Sort(output)
 	return output
 }
 
@@ -406,8 +391,10 @@ func Decode(rn *yaml.RNode, fcd *CreateSetters) error {
 		}
 	}
 
-	// sorts all the Scalar Setters in lexicographically
-	// decreasing order of it's Value
-	sort.Sort(CompareSetters(fcd.ScalarSetters))
+	// sorts all the Scalar Setters in decreasing order of Value length
+	// (longest first) so that longer values are matched before shorter ones
+	slices.SortFunc(fcd.ScalarSetters, func(a, b ScalarSetter) int {
+		return cmp.Compare(len(b.Value), len(a.Value))
+	})
 	return nil
 }

--- a/functions/go/create-setters/createsetters/create_setters_test.go
+++ b/functions/go/create-setters/createsetters/create_setters_test.go
@@ -15,9 +15,10 @@
 package createsetters
 
 import (
+	"cmp"
 	"fmt"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 	"testing"
 
@@ -27,6 +28,7 @@ import (
 )
 
 func TestCreateSettersFilter(t *testing.T) {
+	t.Parallel()
 	var tests = []struct {
 		name              string
 		config            string
@@ -729,11 +731,14 @@ var inputSetters = []ScalarSetter{
 }
 
 func TestCurrentSetterValues(t *testing.T) {
+	t.Parallel()
 	for _, tests := range [][]lineCommentTest{resolveLineCommentCases} {
 		for i := range tests {
 			test := tests[i]
 			t.Run(test.name, func(t *testing.T) {
-				sort.Sort(CompareSetters(inputSetters))
+				slices.SortFunc(inputSetters, func(a, b ScalarSetter) int {
+					return cmp.Compare(len(b.Value), len(a.Value))
+				})
 				replacerArgs := []string{}
 				for _, setter := range inputSetters {
 					replacerArgs = append(replacerArgs, setter.Value)

--- a/functions/go/delete-annotations/main_test.go
+++ b/functions/go/delete-annotations/main_test.go
@@ -96,6 +96,7 @@ metadata:
 }
 
 func TestPolicyResources(t *testing.T) {
+	t.Parallel()
 	for i := range tests {
 		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {

--- a/functions/go/ensure-name-substring/ensure_name_substring_test.go
+++ b/functions/go/ensure-name-substring/ensure_name_substring_test.go
@@ -62,6 +62,7 @@ func runEnsureNameSubstringTransformer(t *testing.T, config, input string) strin
 }
 
 func TestEnsureNameSubstringDependsOn(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		TestName string
 		Config   string
@@ -209,6 +210,7 @@ metadata:
 }
 
 func TestSetDependsOnNameSubstring(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		TestName            string
 		EditMode            EditMode

--- a/functions/go/gatekeeper/validate_test.go
+++ b/functions/go/gatekeeper/validate_test.go
@@ -15,14 +15,15 @@
 package main
 
 import (
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"sigs.k8s.io/kustomize/kyaml/fn/framework"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 func TestSortResults(t *testing.T) {
+	t.Parallel()
 	testcases := []struct {
 		name   string
 		input  framework.Results
@@ -270,8 +271,8 @@ func TestSortResults(t *testing.T) {
 
 	for _, tc := range testcases {
 		tc.input.Sort()
-		if !reflect.DeepEqual(tc.input, tc.output) {
-			t.Errorf("in testcase %q, expect: %#v, but got: %#v", tc.name, tc.output, tc.input)
+		if diff := cmp.Diff(tc.output, tc.input); diff != "" {
+			t.Errorf("testcase %q mismatch (-want +got):\n%s", tc.name, diff)
 		}
 	}
 }

--- a/functions/go/generate-kpt-pkg-docs/docs/generate_test.go
+++ b/functions/go/generate-kpt-pkg-docs/docs/generate_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestGenerateReadme(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		r         string
@@ -374,6 +375,7 @@ spec:
 }
 
 func TestGenerateResourcesSection(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		resources string
@@ -477,6 +479,7 @@ This package has no top-level resources. See sub-packages.
 }
 
 func TestGenerateSubPkgSection(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		pkgs string
@@ -579,6 +582,7 @@ This package has no sub-packages.
 }
 
 func TestGenerateResourceTableSection(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		r    string
@@ -634,6 +638,7 @@ spec:
 }
 
 func TestGenerateSetterTableSection(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		r    string

--- a/functions/go/generate-kpt-pkg-docs/docs/insert_test.go
+++ b/functions/go/generate-kpt-pkg-docs/docs/insert_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestInsertBetweenIdx(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		original []string
 		start    int
@@ -91,6 +92,7 @@ func TestInsertBetweenIdx(t *testing.T) {
 }
 
 func TestFindInsertPoint(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		doc            string
 		docMarkerStart string
@@ -155,6 +157,7 @@ dolor`,
 }
 
 func TestInsertIntoReadme(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		title     string
 		current   string

--- a/functions/go/generate-kpt-pkg-docs/docs/pkg_test.go
+++ b/functions/go/generate-kpt-pkg-docs/docs/pkg_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestGetFnCfgPaths(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		kf   string

--- a/functions/go/generate-kpt-pkg-docs/docs/resources_test.go
+++ b/functions/go/generate-kpt-pkg-docs/docs/resources_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestGetResourceDocsLink(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		r    resid.Gvk
@@ -60,6 +61,7 @@ func TestGetResourceDocsLink(t *testing.T) {
 }
 
 func TestShouldSkipResource(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		r         string
@@ -159,6 +161,7 @@ func getRNodesFromStr(t *testing.T, res string) []*yaml.RNode {
 }
 
 func TestFindResourcePath(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		r    string

--- a/functions/go/kubeconform/kubeconform_test.go
+++ b/functions/go/kubeconform/kubeconform_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 OpenInfra Foundation Europe
+// Copyright (C) 2025-2026 OpenInfra Foundation Europe
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
 )
 
@@ -95,15 +94,11 @@ data:
 			if cfg.SchemaLocation != tt.expected.SchemaLocation {
 				t.Errorf("SchemaLocation: got %q, want %q", cfg.SchemaLocation, tt.expected.SchemaLocation)
 			}
-			if !reflect.DeepEqual(cfg.AdditionalSchemaLocations, tt.expected.AdditionalSchemaLocations) {
-				t.Errorf("AdditionalSchemaLocations: got %v, want %v", cfg.AdditionalSchemaLocations, tt.expected.AdditionalSchemaLocations)
-			}
+			assert.Equal(t, tt.expected.AdditionalSchemaLocations, cfg.AdditionalSchemaLocations, "AdditionalSchemaLocations mismatch")
 			if cfg.IgnoreMissingSchemas != tt.expected.IgnoreMissingSchemas {
 				t.Errorf("IgnoreMissingSchemas: got %v, want %v", cfg.IgnoreMissingSchemas, tt.expected.IgnoreMissingSchemas)
 			}
-			if !reflect.DeepEqual(cfg.SkipKinds, tt.expected.SkipKinds) {
-				t.Errorf("SkipKinds: got %v, want %v", cfg.SkipKinds, tt.expected.SkipKinds)
-			}
+			assert.Equal(t, tt.expected.SkipKinds, cfg.SkipKinds, "SkipKinds mismatch")
 			if cfg.Strict != tt.expected.Strict {
 				t.Errorf("Strict: got %v, want %v", cfg.Strict, tt.expected.Strict)
 			}
@@ -112,7 +107,6 @@ data:
 }
 
 func TestBuildKubeconformArgs(t *testing.T) {
-
 	tests := []struct {
 		name              string
 		schemaLocation    string

--- a/functions/go/list-setters/listsetters/list_setters.go
+++ b/functions/go/list-setters/listsetters/list_setters.go
@@ -31,6 +31,9 @@ import (
 
 const SetterCommentIdentifier = "# kpt-set: "
 
+// setterRefPattern matches setter references in the form ${name}.
+var setterRefPattern = regexp.MustCompile(`\$\{([^}]*)\}`)
+
 // ListSetters lists setters identified by the setter comments
 type ListSetters struct {
 	// ScalarSetters holds the discovered scalar setters
@@ -419,8 +422,7 @@ func currentSetterValues(pattern, value string) map[string]string {
 // unresolvedSetters returns the list of values enclosed in ${} present within given
 // pattern e.g. pattern = foo-${image}:${tag}-bar return ["${image}", "${tag}"]
 func unresolvedSetters(pattern string) []string {
-	re := regexp.MustCompile(`\$\{([^}]*)\}`)
-	return re.FindAllString(pattern, -1)
+	return setterRefPattern.FindAllString(pattern, -1)
 }
 
 // clean extracts value enclosed in ${}

--- a/functions/go/list-setters/listsetters/list_setters_test.go
+++ b/functions/go/list-setters/listsetters/list_setters_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestListSettersFilter(t *testing.T) {
+	t.Parallel()
 	var tests = []struct {
 		name           string
 		resourceMap    map[string]string
@@ -543,6 +544,7 @@ func setupInputs(t *testing.T, resourceMap map[string]string) string {
 }
 
 func TestCurrentSetterValues(t *testing.T) {
+	t.Parallel()
 	var tests = []struct {
 		name     string
 		value    string

--- a/functions/go/remove-local-config-resources/main_test.go
+++ b/functions/go/remove-local-config-resources/main_test.go
@@ -59,6 +59,7 @@ var Tests = []PrunerTest{
 }
 
 func TestPrunedResources(t *testing.T) {
+	t.Parallel()
 
 	for i := range Tests {
 		test := Tests[i]

--- a/functions/go/search-replace/searchreplace/pathparser_test.go
+++ b/functions/go/search-replace/searchreplace/pathparser_test.go
@@ -85,6 +85,7 @@ var tests = []parsertest{
 }
 
 func TestPathMatch(t *testing.T) {
+	t.Parallel()
 	for i := range tests {
 		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {

--- a/functions/go/search-replace/searchreplace/search_replace.go
+++ b/functions/go/search-replace/searchreplace/search_replace.go
@@ -36,6 +36,9 @@ const (
 	PathDelimiter = "."
 )
 
+// unresolvedCaptureGroupPattern matches unresolved capture group references like ${0}, ${1}.
+var unresolvedCaptureGroupPattern = regexp.MustCompile(`\$\{([0-9]+)\}`)
+
 // matchers returns the list of supported matchers
 func matchers() []string {
 	return []string{ByValue, ByFilePath, ByValueRegex, ByPath, PutValue, PutComment}
@@ -369,8 +372,7 @@ func resolvePattern(fieldValue, valueRegex, patternRegex string) (string, error)
 	}
 
 	// make sure that all capture groups are resolved and throw error if they are not
-	re := regexp.MustCompile(`\$\{([0-9]+)\}`)
-	if re.Match([]byte(res)) {
+	if unresolvedCaptureGroupPattern.MatchString(res) {
 		return "", errors.Errorf("unable to resolve capture groups")
 	}
 

--- a/functions/go/search-replace/searchreplace/search_replace_test.go
+++ b/functions/go/search-replace/searchreplace/search_replace_test.go
@@ -35,6 +35,7 @@ type test struct {
 }
 
 func TestSearchCommand(t *testing.T) {
+	t.Parallel()
 	for _, tests := range [][]test{searchReplaceCases, putPatternCases} {
 		for i := range tests {
 			test := tests[i]
@@ -110,6 +111,7 @@ func TestSearchCommand(t *testing.T) {
 }
 
 func TestDecode(t *testing.T) {
+	t.Parallel()
 	rn, err := kyaml.Parse(`data:
   by-value: foo
   put-values: bar`)

--- a/functions/go/set-annotations/annotations_transformer_test.go
+++ b/functions/go/set-annotations/annotations_transformer_test.go
@@ -18,8 +18,9 @@ package main
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func runAnnotationTransformerE(config, input string) (string, error) {
@@ -262,12 +263,12 @@ spec:
 		}: {"app": "myApp"},
 	}
 	runAnnotationTransformer(t, config, input)
-	if !reflect.DeepEqual(KustomizePlugin.Results, expectedResults) {
+	if diff := cmp.Diff(expectedResults, KustomizePlugin.Results); diff != "" {
 		fmt.Println("Actual:")
 		fmt.Println(KustomizePlugin.Results)
 		fmt.Println("===")
 		fmt.Println("Expected:")
 		fmt.Println(expectedResults)
-		t.Fatalf("Actual doesn't equal to expected")
+		t.Fatalf("Results mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/functions/go/set-annotations/go.mod
+++ b/functions/go/set-annotations/go.mod
@@ -3,6 +3,7 @@ module github.com/kptdev/krm-functions-catalog/functions/go/set-annotations
 go 1.26.3
 
 require (
+	github.com/google/go-cmp v0.7.0
 	sigs.k8s.io/kustomize/api v0.21.1
 	sigs.k8s.io/kustomize/kyaml v0.21.1
 	sigs.k8s.io/yaml v1.6.0

--- a/functions/go/set-enforcement-action/main_test.go
+++ b/functions/go/set-enforcement-action/main_test.go
@@ -141,6 +141,7 @@ data:
 }
 
 func TestPolicyResources(t *testing.T) {
+	t.Parallel()
 	for i := range tests {
 		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {

--- a/functions/go/set-image/transformer/images_transformer_test.go
+++ b/functions/go/set-image/transformer/images_transformer_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestUpdateContainerImages(t *testing.T) {
+	t.Parallel()
 	const podYAML = `
 apiVersion: v1
 kind: Pod

--- a/functions/go/sleep/processor/processor_test.go
+++ b/functions/go/sleep/processor/processor_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestSleepProcessor(t *testing.T) {
+	t.Parallel()
 	const delta = float64(time.Second) / 2
 
 	testCases := map[string]struct {

--- a/functions/go/starlark/starlark/config_test.go
+++ b/functions/go/starlark/starlark/config_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestStarlarkConfig(t *testing.T) {
+	t.Parallel()
 	testcases := []struct {
 		name         string
 		config       string

--- a/functions/go/upsert-resource/upsertresource/upsert_resource_test.go
+++ b/functions/go/upsert-resource/upsertresource/upsert_resource_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestUpsertResourceFilter(t *testing.T) {
+	t.Parallel()
 	var tests = []struct {
 		name              string
 		fnconfig          string
@@ -610,6 +611,7 @@ spec:
 }
 
 func TestIsSameResource(t *testing.T) {
+	t.Parallel()
 	var tests = []struct {
 		name      string
 		resource1 string
@@ -768,6 +770,7 @@ metadata:
 }
 
 func TestCombineInputAndMatchedAnnotations(t *testing.T) {
+	t.Parallel()
 	var tests = []struct {
 		name                string
 		inputResourceAnno   map[string]string


### PR DESCRIPTION
## Description
- What changed: Modernized Go code across catalog functions to use current idiomatic patterns available in Go 1.21+.
- Why it's needed: The codebase had several outdated patterns that reduce maintainability, performance, and developer experience (lost error chains, unnecessary allocations, sequential test execution).
- How it works:
  - Replaced `fmt.Errorf("...%v", err)` with `%w` to preserve error chains for `errors.Is`/`errors.As`
  - Replaced `reflect.DeepEqual` in tests with `cmp.Diff` / `assert.Equal` for better failure output
  - Added `t.Parallel()` to all safe top-level test functions for faster CI
  - Replaced `sort.Sort` with interface boilerplate with `slices.SortFunc`/`slices.Sort`
  - Moved `regexp.MustCompile` with constant patterns to package-level vars (avoids recompilation per call)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [x] Refactor
- [ ] Documentation
- [x] Tests
- [ ] Other: ________

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [x] Tests added/updated
- [ ] Documentation added/updated
- [x] All tests and gating checks pass

## AI Disclosure

- [x] **I have used AI in the creation of this PR.**

If so, please describe how:
  - Kiro to identify outdated Go patterns, implement the refactoring, and verify the changes compile and pass tests.