### PR TITLE
Security: bump oras-go to v2.6.1 to fix CVE-2026-50151

### DIFF
--- a/functions/go/gatekeeper/go.mod
+++ b/functions/go/gatekeeper/go.mod
@@ -116,7 +116,11 @@ require (
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
-	oras.land/oras-go/v2 v2.6.0 // indirect
+	// CVE-2026-50151: credential forwarding via unvalidated Location header.
+	// Pulled in transitively by github.com/open-policy-agent/gatekeeper/v3 and
+	// github.com/open-policy-agent/opa. Remove this override once gatekeeper
+	// bumps to oras-go >= v2.6.1 in a future release.
+	oras.land/oras-go/v2 v2.6.1 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect
 	sigs.k8s.io/controller-runtime v0.23.3 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect

--- a/functions/go/gatekeeper/go.sum
+++ b/functions/go/gatekeeper/go.sum
@@ -323,8 +323,8 @@ k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a h1:xCeOEAOoGYl2jnJoHkC3hk
 k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a/go.mod h1:uGBT7iTA6c6MvqUvSXIaYZo9ukscABYi2btjhvgKGZ0=
 k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 h1:AZYQSJemyQB5eRxqcPky+/7EdBj0xi3g0ZcxxJ7vbWU=
 k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
-oras.land/oras-go/v2 v2.6.0 h1:X4ELRsiGkrbeox69+9tzTu492FMUu7zJQW6eJU+I2oc=
-oras.land/oras-go/v2 v2.6.0/go.mod h1:magiQDfG6H1O9APp+rOsvCPcW1GD2MM7vgnKY0Y+u1o=
+oras.land/oras-go/v2 v2.6.1 h1:bonOEkjLfp8tt6qXWRRWP6p1F+9octchOf2EqnWB4Zs=
+oras.land/oras-go/v2 v2.6.1/go.mod h1:dhtFrFOuZuDtAVeZ9FUnaa5zfzplG3ZnFX9/uH1J/Yk=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUoEKRkHKSmGjxb6lWwrBlJsXc+eUYQHM=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.23.3 h1:VjB/vhoPoA9l1kEKZHBMnQF33tdCLQKJtydy4iqwZ80=


### PR DESCRIPTION
 ## Description
  - What changed: Bumped transitive dependency `oras.land/oras-go/v2` from `v2.6.0` to `v2.6.1` in `functions/go/gatekeeper/go.mod`.
  - Why it's needed: `v2.6.0` is vulnerable to credential forwarding via an unvalidated `Location` header during monolithic blob upload (CVE-2026-50151, CVSS 7.5 High). A malicious registry can redirect upload requests to an attacker-controlled endpoint, leaking the caller's `Authorization` header.
  - How it works: Overrides the indirect dependency version selected by `github.com/open-policy-agent/gatekeeper/v3@v3.22.2` and `github.com/open-policy-agent/opa@v1.13.2`, which haven't released a bump yet. Go's MVS picks the higher version. A comment in `go.mod` documents the override and when it can be removed.

  ## Related Issue(s)
  - Fixes https://github.com/kptdev/krm-functions-catalog/security/dependabot/719
  - References https://github.com/advisories/GHSA-jxpm-75mh-9fp7

  ## Type of Change
  - [x] Bug fix
  - [ ] New feature
  - [ ] Enhancement
  - [ ] Refactor
  - [ ] Documentation
  - [ ] Tests
  - [ ] Other: ________

  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [ ] Tests added/updated
  - [ ] Documentation added/updated
  - [x] All tests and gating checks pass


  ## AI Disclosure

  - [x] **I have used AI in the creation of this PR.**

  If so, please describe how:
    - Kiro to identify the CVE, verify the dependency chain, apply the fix, and generate the PR message.