### PR TITLE
Trigger documentation site rebuild after function release

### DIFF
--- a/.github/workflows/after-tag-with-version.yaml
+++ b/.github/workflows/after-tag-with-version.yaml
@@ -117,3 +117,16 @@ jobs:
             --notes-file "$NOTES_FILE"
 
           rm -f "$NOTES_FILE"
+
+      - name: Trigger documentation site rebuild
+        env:
+          NETLIFY_BUILD_HOOK_URL: ${{ secrets.NETLIFY_BUILD_HOOK_URL }}
+        run: |
+          if [[ -z "$NETLIFY_BUILD_HOOK_URL" ]]; then
+            echo "::error::NETLIFY_BUILD_HOOK_URL secret is not set"
+            exit 1
+          fi
+          curl -sS -f -X POST \
+            -H 'Content-Type: application/json' \
+            --data-raw '{"clear_cache": true}' \
+            "$NETLIFY_BUILD_HOOK_URL"


### PR DESCRIPTION
 ## Description
  - **What changed**: Added a step to the `after-tag-with-version.yaml` workflow that triggers a Netlify documentation site rebuild after every function release tag push.
  - **Why it's needed**: The homepage function catalog table fetches release versions from the GitHub API via Hugo's `resources.GetRemote` at build time. Since releases are created manually (via tag push), there was no mechanism to trigger a docs rebuild then the cached data remained stale indefinitely.
  - **How it works**: After the image push and release notes steps complete, the workflow POSTs to a Netlify build hook with `{"clear_cache": true}`, which triggers a fresh build with no cached remote resources.

  ### Why triggering per tag is safe

  The `after-tag-with-version.yaml` workflow runs independently for each tag push. When using `manual-patch-release` with `functions: "all"`, multiple tags are created in quick succession each triggering a separate Netlify build hook call. 
This is handled gracefully by Netlify's [context queue](https://docs.netlify.com/build/configure-builds/troubleshooting-tips/#enqueued-builds): when multiple builds are triggered on the same site in an identical deploy context, they enter a context queue. 
When the current build completes, only the **newest** enqueued build runs and all intermediate ones are skipped. So even if 10+ tags fire simultaneously, at most 2 actual builds occur (the one in progress + the latest queued). No wasted build minutes, no race conditions.

  ## Related Issue(s)
  - N/A

  ## Type of Change
  - [x] Bug fix
  - [ ] New feature
  - [ ] Enhancement
  - [ ] Refactor
  - [ ] Documentation
  - [ ] Tests
  - [ ] Other: ________

  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [ ] Tests added/updated
  - [ ] Documentation added/updated
  - [x] All tests and gating checks pass

  ## AI Disclosure

  - [x] **I have used AI in the creation of this PR.**

  If so, please describe how:
    - Kiro used for this PR message and analysis