### PR TITLE
Fix floating image tags by building once with multiple tags

### DIFF
--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 #
 # Copyright 2021 Google LLC
-# Modifications Copyright (C) 2025 OpenInfra Foundation Europe.
+# Modifications Copyright (C) 2025-2026 OpenInfra Foundation Europe.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,7 +27,8 @@ function err {
 function docker_build {
   action=$1 # docker buildx operation, it should be either load or push.
   name=$2 # function name, e.g. apply-setters
-  tag=$3 # function tag, e.g. v1.2.3
+  shift 2
+  local tags=("$@") # one or more tags, e.g. v1.2.3 v1.2 v1
 
   build_args=()
 
@@ -53,7 +54,13 @@ function docker_build {
     echo "Setting build context to ${function_dir}"
   fi
 
-  echo "building ${CR_REGISTRY}/${name}:${tag}"
+  # Build tag arguments
+  local tag_args=()
+  for tag in "${tags[@]}"; do
+    tag_args+=(-t "${CR_REGISTRY}/${name}:${tag}")
+  done
+
+  echo "building ${CR_REGISTRY}/${name} with tags: ${tags[*]}"
 
   case "${action}" in
     load)
@@ -61,7 +68,7 @@ function docker_build {
 
       # Use + conditional parameter expansion to protect from unbound array variable
       docker buildx build --load \
-        -t "${CR_REGISTRY}/${name}:${tag}" \
+        "${tag_args[@]}" \
         -f "${dockerfile}" \
         "${build_args[@]+"${build_args[@]}"}" \
         "${extra_args_array[@]+"${extra_args_array[@]}"}" \
@@ -71,7 +78,7 @@ function docker_build {
       IFS=' ' read -r -a extra_args_array <<< "${EXTRA_BUILD_ARGS:-}"
       # build and push multi-arch image.
       docker buildx build --push \
-        -t "${CR_REGISTRY}/${name}:${tag}" \
+        "${tag_args[@]}" \
         -f "${dockerfile}" \
         --platform "linux/amd64,linux/arm64" \
         "${build_args[@]+"${build_args[@]}"}" \

--- a/scripts/go-function-release.sh
+++ b/scripts/go-function-release.sh
@@ -1,6 +1,7 @@
 #! /bin/bash
 #
 # Copyright 2021 Google LLC
+# Modifications Copyright (C) 2026 The kpt Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -65,14 +66,10 @@ EXTRA_BUILD_ARGS="${EXTRA_BUILD_ARGS:-}"
 
 case "$1" in
   build)
-    for version in "${version_array[@]}"; do
-      docker_build "load" "${CURRENT_FUNCTION}" "${version}"
-    done
+    docker_build "load" "${CURRENT_FUNCTION}" "${version_array[@]}"
     ;;
   push)
-    for version in "${version_array[@]}"; do
-      docker_build "push" "${CURRENT_FUNCTION}" "${version}"
-    done
+    docker_build "push" "${CURRENT_FUNCTION}" "${version_array[@]}"
     ;;
   *)
     echo "Usage: $0 {build|push}"


### PR DESCRIPTION
## Description
  - **What changed**: Updated `scripts/docker.sh` and `scripts/go-function-release.sh` to build a single image and tag it with all versions in one `docker buildx build` invocation, instead of rebuilding once per tag.
  - **Why it's needed**: The previous loop-per-tag approach called `docker buildx build` separately for each tag (`v1.2.3`, `v1.2`, `v1`), producing a different manifest digest for each, even though the source was identical. This meant floating tags (`vX.Y`, `vX`) never shared the same digest as the pinned tag. This is the root cause identified in kptdev/kpt#4621.
  - **How it works**: `docker_build` in `docker.sh` now accepts variadic tags and builds all `-t` flags into a single `docker buildx build` command. `go-function-release.sh` passes all expanded versions in one call for both the `build` (load) and `push` paths. For a semver release (`TAG=v0.5.6`), `get_versions` expands to `v0.5.6 v0.5 v0` and all three tags are pushed in one build with the same manifest digest.

  ## Related Issue(s)
  - Partially addresses kptdev/kpt#4621 (fixes the floating tag mechanism; retroactive tag update and `VERSIONING.md` changes tracked separately)

  ## Type of Change
  - [x] Bug fix
  - [ ] New feature
  - [ ] Enhancement
  - [ ] Refactor
  - [ ] Documentation
  - [ ] Tests
  - [ ] Other: ________

  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [ ] Tests added/updated
  - [ ] Documentation added/updated
  - [x] All tests and gating checks pass

 

##  AI Disclosure

  - [x] I have used AI in the creation of this PR.

  If so, please describe how:
  - Kiro to investigate the root cause of stale floating tags, verify the issue against GHCR and test locally.