### PR TITLE
Revert workflow-based Netlify build trigger in favour of GitHub webhook

### DIFF
--- a/.github/workflows/after-tag-with-version.yaml
+++ b/.github/workflows/after-tag-with-version.yaml
@@ -117,16 +117,3 @@ jobs:
             --notes-file "$NOTES_FILE"
 
           rm -f "$NOTES_FILE"
-
-      - name: Trigger documentation site rebuild
-        env:
-          NETLIFY_BUILD_HOOK_URL: ${{ secrets.NETLIFY_BUILD_HOOK_URL }}
-        run: |
-          if [[ -z "$NETLIFY_BUILD_HOOK_URL" ]]; then
-            echo "::error::NETLIFY_BUILD_HOOK_URL secret is not set"
-            exit 1
-          fi
-          curl -sS -f -X POST \
-            -H 'Content-Type: application/json' \
-            --data-raw '{"clear_cache": true}' \
-            "$NETLIFY_BUILD_HOOK_URL"

--- a/documentation/config.toml
+++ b/documentation/config.toml
@@ -196,6 +196,14 @@ enable = false
   url = "https://porch.kpt.dev/"
   weight = 50
 
+# Disable caching for resources.GetRemote so that every build fetches fresh
+# data from the GitHub API. Without this, Hugo caches remote responses
+# indefinitely and the function catalog table shows stale release versions
+# until the cache is manually cleared.
+[caches]
+  [caches.getresource]
+    maxAge = -1
+
 [security]
   [security.funcs]
     getenv = ['^HUGO_', '^CI$', '^KRM_CATALOG_API_TOKEN$']


### PR DESCRIPTION
  ## Description
  - **What changed**: Reverted PR #1276 which triggered Netlify documentation site rebuilds from the `after-tag-with-version.yaml` workflow, and configured Hugo to always fetch fresh data from the GitHub API on every build.
  - **Why it's needed**: GitHub provides a native webhook feature that can trigger the Netlify build hook URL on release events. This is the proper mechanism for triggering rebuilds. it decouples documentation deployment from the CI workflow and avoids coupling release automation to docs infrastructure.
  - **How it works**: The workflow step that POSTed to the Netlify build hook has been removed. A GitHub webhook (configured in repo settings) will trigger Netlify builds on release events instead. Hugo's remote resource caching is disabled so that every triggered build always reflects the latest release data.

  ## Related Issue(s)
  - Reverts #1276

  ## Type of Change
  - [x] Enhancement
  - [ ] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Documentation
  - [ ] Tests
  - [ ] Other: ________

  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [ ] Tests added/updated
  - [ ] Documentation added/updated
  - [x] All tests and gating checks pass

  ## AI Disclosure

  - [x] **I have used AI in the creation of this PR.**

  If so, please describe how:
    - Kiro used for this PR message and implementing the revert