### PR TITLE
Upgrade Go to 1.26.5

### DIFF
--- a/documentation/netlify.toml
+++ b/documentation/netlify.toml
@@ -2,7 +2,7 @@
 # (https://gohugo.io/hosting-and-deployment/hosting-on-netlify/#configure-hugo-version-in-netlify)
 
 [build.environment]
-  GO_VERSION = "1.26.3"
+  GO_VERSION = "1.26.5"
   HUGO_VERSION = "0.161.1"
   NODE_VERSION = "24.15.0"
 

--- a/functions/go/annotate-apply-time-mutations/go.mod
+++ b/functions/go/annotate-apply-time-mutations/go.mod
@@ -1,6 +1,6 @@
 module github.com/kptdev/krm-functions-catalog/functions/go/annotate-apply-time-mutations
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/functions/go/apply-replacements/go.mod
+++ b/functions/go/apply-replacements/go.mod
@@ -1,6 +1,6 @@
 module github.com/kptdev/krm-functions-catalog/functions/go/apply-replacements
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/kptdev/krm-functions-sdk/go/fn v1.0.3

--- a/functions/go/apply-setters/go.mod
+++ b/functions/go/apply-setters/go.mod
@@ -1,6 +1,6 @@
 module github.com/kptdev/krm-functions-catalog/functions/go/apply-setters
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/kptdev/kpt/api v0.0.2

--- a/functions/go/bar/go.mod
+++ b/functions/go/bar/go.mod
@@ -1,6 +1,6 @@
 module github.com/kptdev/krm-functions-catalog/functions/go/bar
 
-go 1.26.3
+go 1.26.5
 
 require github.com/kptdev/krm-functions-sdk/go/fn v1.0.4
 

--- a/functions/go/create-setters/go.mod
+++ b/functions/go/create-setters/go.mod
@@ -1,6 +1,6 @@
 module github.com/kptdev/krm-functions-catalog/functions/go/create-setters
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/functions/go/delete-annotations/go.mod
+++ b/functions/go/delete-annotations/go.mod
@@ -1,6 +1,6 @@
 module github.com/kptdev/krm-functions-catalog/functions/go/delete-annotations
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/kptdev/krm-functions-sdk/go/fn v1.0.3

--- a/functions/go/drop-comments/go.mod
+++ b/functions/go/drop-comments/go.mod
@@ -1,6 +1,6 @@
 module github.com/kptdev/krm-functions-catalog/functions/go/drop-comments
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/kptdev/krm-functions-sdk/go/fn v1.0.4

--- a/functions/go/ensure-name-substring/go.mod
+++ b/functions/go/ensure-name-substring/go.mod
@@ -1,6 +1,6 @@
 module github.com/kptdev/krm-functions-catalog/functions/go/ensure-name-substring
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/functions/go/foo/go.mod
+++ b/functions/go/foo/go.mod
@@ -1,6 +1,6 @@
 module github.com/kptdev/krm-functions-catalog/functions/go/foo
 
-go 1.26.3
+go 1.26.5
 
 require github.com/kptdev/krm-functions-sdk/go/fn v1.0.4
 

--- a/functions/go/gatekeeper/go.mod
+++ b/functions/go/gatekeeper/go.mod
@@ -1,8 +1,9 @@
 module github.com/kptdev/krm-functions-catalog/functions/go/gatekeeper
 
-go 1.26.3
+go 1.26.5
 
 require (
+	github.com/google/go-cmp v0.7.0
 	github.com/open-policy-agent/gatekeeper/v3 v3.22.2
 	github.com/spf13/cobra v1.10.2
 	k8s.io/apimachinery v0.36.1
@@ -38,7 +39,6 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/cel-go v0.26.0 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/functions/go/generate-kpt-pkg-docs/go.mod
+++ b/functions/go/generate-kpt-pkg-docs/go.mod
@@ -1,6 +1,6 @@
 module github.com/kptdev/krm-functions-catalog/functions/go/generate-kpt-pkg-docs
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/kptdev/kpt v1.0.0-beta.64

--- a/functions/go/kubeconform/go.mod
+++ b/functions/go/kubeconform/go.mod
@@ -1,6 +1,6 @@
 module github.com/kptdev/krm-functions-catalog/functions/go/kubeconform
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/kptdev/krm-functions-sdk/go/fn v1.0.3

--- a/functions/go/list-setters/go.mod
+++ b/functions/go/list-setters/go.mod
@@ -1,6 +1,6 @@
 module github.com/kptdev/krm-functions-catalog/functions/go/list-setters
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/kptdev/kpt v1.0.0-beta.64

--- a/functions/go/no-op/go.mod
+++ b/functions/go/no-op/go.mod
@@ -1,6 +1,6 @@
 module github.com/kptdev/krm-functions-catalog/functions/go/no-op
 
-go 1.26.3
+go 1.26.5
 
 require github.com/kptdev/krm-functions-sdk/go/fn v1.0.4
 

--- a/functions/go/printenv/go.mod
+++ b/functions/go/printenv/go.mod
@@ -1,6 +1,6 @@
 module github.com/kptdev/krm-functions-catalog/functions/go/printenv
 
-go 1.26.3
+go 1.26.5
 
 require github.com/kptdev/krm-functions-sdk/go/fn v1.0.4
 

--- a/functions/go/remove-local-config-resources/go.mod
+++ b/functions/go/remove-local-config-resources/go.mod
@@ -1,6 +1,6 @@
 module github.com/kptdev/krm-functions-catalog/functions/go/remove-local-config-resources
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/functions/go/render-helm-chart/go.mod
+++ b/functions/go/render-helm-chart/go.mod
@@ -1,6 +1,6 @@
 module github.com/kptdev/krm-functions-catalog/functions/go/render-helm-chart
 
-go 1.26.3
+go 1.26.5
 
 require (
 	dario.cat/mergo v1.0.2

--- a/functions/go/search-replace/go.mod
+++ b/functions/go/search-replace/go.mod
@@ -1,6 +1,6 @@
 module github.com/kptdev/krm-functions-catalog/functions/go/search-replace
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0

--- a/functions/go/set-annotations/go.mod
+++ b/functions/go/set-annotations/go.mod
@@ -1,6 +1,6 @@
 module github.com/kptdev/krm-functions-catalog/functions/go/set-annotations
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/functions/go/set-enforcement-action/go.mod
+++ b/functions/go/set-enforcement-action/go.mod
@@ -1,6 +1,6 @@
 module github.com/kptdev/krm-functions-catalog/functions/go/set-enforcement-action
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/functions/go/set-image/go.mod
+++ b/functions/go/set-image/go.mod
@@ -1,6 +1,6 @@
 module github.com/kptdev/krm-functions-catalog/functions/go/set-image
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/kptdev/krm-functions-sdk/go/fn v1.0.3

--- a/functions/go/set-labels/go.mod
+++ b/functions/go/set-labels/go.mod
@@ -1,6 +1,6 @@
 module github.com/kptdev/krm-functions-catalog/functions/go/set-labels
 
-go 1.26.3
+go 1.26.5
 
 require github.com/kptdev/krm-functions-sdk/go/fn v1.0.4
 

--- a/functions/go/set-namespace/go.mod
+++ b/functions/go/set-namespace/go.mod
@@ -1,6 +1,6 @@
 module github.com/kptdev/krm-functions-catalog/functions/go/set-namespace
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/kptdev/krm-functions-sdk/go/fn v1.0.3

--- a/functions/go/sleep/go.mod
+++ b/functions/go/sleep/go.mod
@@ -1,6 +1,6 @@
 module github.com/kptdev/krm-functions-catalog/functions/go/sleep
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/functions/go/starlark/go.mod
+++ b/functions/go/starlark/go.mod
@@ -1,6 +1,6 @@
 module github.com/kptdev/krm-functions-catalog/functions/go/starlark
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/kptdev/krm-functions-sdk/go/fn v1.0.3

--- a/functions/go/upsert-resource/go.mod
+++ b/functions/go/upsert-resource/go.mod
@@ -1,6 +1,6 @@
 module github.com/kptdev/krm-functions-catalog/functions/go/upsert-resource
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/scripts/generate_docs/go.mod
+++ b/scripts/generate_docs/go.mod
@@ -1,6 +1,6 @@
 module github.com/kptdev/krm-functions-catalog/scripts/generate_docs
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2


### PR DESCRIPTION
## Description

- Go version bumped to `1.26.5`
- All modules verified (`go mod tidy`, `go fmt`, `go vet`, `go build`)

## AI Disclosure

- [x] **I have used AI in the creation of this PR.**

Automated via go-upgrade script (AI-assisted development).