### PR TITLE
Fix documentation links that reference "master" to "main"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -278,11 +278,11 @@ Do you need a review or release of functions? We’d love to hear from you!
 
 [e2e test harness doc]: https://github.com/kptdev/kpt/blob/main/pkg/test/runner/README.md
 
-[golang-template]: https://raw.githubusercontent.com/kptdev/krm-functions-catalog/master/functions/go/_template/README.md
+[golang-template]: https://raw.githubusercontent.com/kptdev/krm-functions-catalog/main/functions/go/_template/README.md
 
-[docker-common]: https://raw.githubusercontent.com/kptdev/krm-functions-catalog/master/build/docker
+[docker-common]: https://raw.githubusercontent.com/kptdev/krm-functions-catalog/main/build/docker
 
-[example-template]: https://raw.githubusercontent.com/kptdev/krm-functions-catalog/master/examples/_template/README.md
+[example-template]: https://raw.githubusercontent.com/kptdev/krm-functions-catalog/main/examples/_template/README.md
 
 [Slack channel]: https://kubernetes.slack.com/channels/kpt/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -274,22 +274,14 @@ Do you need a review or release of functions? We’d love to hear from you!
 * Join our [discussions]
 
 
-[catalog website]: https://catalog.kpt.dev/
+## Useful links
 
-[e2e test harness doc]: https://github.com/kptdev/kpt/blob/main/pkg/test/runner/README.md
-
-[golang-template]: https://raw.githubusercontent.com/kptdev/krm-functions-catalog/main/functions/go/_template/README.md
-
-[docker-common]: https://raw.githubusercontent.com/kptdev/krm-functions-catalog/main/build/docker
-
-[example-template]: https://raw.githubusercontent.com/kptdev/krm-functions-catalog/main/examples/_template/README.md
-
-[Slack channel]: https://kubernetes.slack.com/channels/kpt/
-
-[error message style guide]: https://github.com/kptdev/kpt/blob/main/docs/style-guides/errors.md
-
-[documentation style guide]: https://github.com/kptdev/kpt/blob/main/docs/style-guides/docs.md
-
-[GitHub Help]: https://help.github.com/articles/about-pull-requests/
-
-[discussions]: https://github.com/kptdev/kpt/discussions
+- [catalog website](https://catalog.kpt.dev/)
+- [e2e test harness doc](https://github.com/kptdev/kpt/blob/main/pkg/test/runner/README.md)
+- [golang-template](https://raw.githubusercontent.com/kptdev/krm-functions-catalog/main/functions/go/_template/README.md)
+- [docker](https://github.com/kptdev/krm-functions-catalog/tree/main/build/docker/go)
+- [example-template](https://raw.githubusercontent.com/kptdev/krm-functions-catalog/main/examples/_template/README.md)
+- [Slack channel](https://kubernetes.slack.com/channels/kpt/)
+- [error message style guide](https://github.com/kptdev/kpt/blob/main/architecture/style-guides/errors.md)
+- [GitHub Help](https://help.github.com/articles/about-pull-requests/)
+- [discussions](https://github.com/kptdev/kpt/discussions)

--- a/documentation/content/en/_index.md
+++ b/documentation/content/en/_index.md
@@ -8,7 +8,7 @@ menu:
 ---
 
 {{< alert >}}
-Please see the [versioning](https://github.com/kptdev/krm-functions-catalog/blob/master/VERSIONING.md) 
+Please see the [versioning](https://github.com/kptdev/krm-functions-catalog/blob/main/VERSIONING.md) 
 document, which details the SemVer tagging strategy being used for the released KRM Functions. 
 {{< /alert >}}
 

--- a/examples/apply-replacements-simple/README.md
+++ b/examples/apply-replacements-simple/README.md
@@ -13,7 +13,7 @@ with a simple example
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/apply-replacements-simple
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/apply-replacements-simple
 ```
 
 We use a `ApplyReplacements` object to configure the `apply-replacements` function. 

--- a/examples/apply-setters-simple/README.md
+++ b/examples/apply-setters-simple/README.md
@@ -13,7 +13,7 @@ resource fields parameterized by `kpt-set` comments.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/apply-setters-simple
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/apply-setters-simple
 ```
 
 We use `ConfigMap` to configure the `apply-setters` function. The desired

--- a/examples/create-setters-simple/README.md
+++ b/examples/create-setters-simple/README.md
@@ -13,7 +13,7 @@ resource fields using `create-setters` function.
 Get the example package by running the following command:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/create-setters-simple
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/create-setters-simple
 ```
 
 We use `ConfigMap` to configure the `create-setters` function.

--- a/examples/delete-annotations-imperative/README.md
+++ b/examples/delete-annotations-imperative/README.md
@@ -13,7 +13,7 @@ on all resources by running `delete-annotations` function imperatively.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/delete-annotations-imperative
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/delete-annotations-imperative
 ```
 
 ### Function invocation

--- a/examples/delete-annotations-simple/README.md
+++ b/examples/delete-annotations-simple/README.md
@@ -9,7 +9,7 @@ In this example, we will see how to delete annotations on a set of resources in 
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/delete-annotations-simple
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/delete-annotations-simple
 ```
 
 ### Function invocation

--- a/examples/ensure-name-substring-advanced/README.md
+++ b/examples/ensure-name-substring-advanced/README.md
@@ -13,7 +13,7 @@ function to prepend prefix in the resource names.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/ensure-name-substring-advanced
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/ensure-name-substring-advanced
 ```
 
 We use the following `Kptfile` and `fn-config.yaml` to run the function.

--- a/examples/ensure-name-substring-depends-on/README.md
+++ b/examples/ensure-name-substring-depends-on/README.md
@@ -18,7 +18,7 @@ the annotation.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/ensure-name-substring-depends-on
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/ensure-name-substring-depends-on
 ```
 
 We use the following `Kptfile` to configure the function.

--- a/examples/ensure-name-substring-imperative/README.md
+++ b/examples/ensure-name-substring-imperative/README.md
@@ -13,7 +13,7 @@ running [`ensure-name-substring`] function imperatively.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/ensure-name-substring-imperative
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/ensure-name-substring-imperative
 ```
 
 ### Function invocation

--- a/examples/ensure-name-substring-prefix/README.md
+++ b/examples/ensure-name-substring-prefix/README.md
@@ -13,7 +13,7 @@ function to prepend prefix in the resource names.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/ensure-name-substring-prefix
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/ensure-name-substring-prefix
 ```
 
 We use the following `Kptfile` to run the function.

--- a/examples/ensure-name-substring-suffix/README.md
+++ b/examples/ensure-name-substring-suffix/README.md
@@ -13,7 +13,7 @@ function to append suffix in the resource names.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/ensure-name-substring-suffix
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/ensure-name-substring-suffix
 ```
 
 We use the following `Kptfile` to run the function.

--- a/examples/gatekeeper-disallow-root-user/README.md
+++ b/examples/gatekeeper-disallow-root-user/README.md
@@ -13,7 +13,7 @@ enforce the policy `Containers must not run as root` on resources.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/gatekeeper-disallow-root-user
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/gatekeeper-disallow-root-user
 ```
 
 There are 3 resources: a `ConstraintTemplate`, a `DisallowRoot` and

--- a/examples/gatekeeper-imperative/README.md
+++ b/examples/gatekeeper-imperative/README.md
@@ -13,7 +13,7 @@ running [`gatekeeper`] function imperatively.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/gatekeeper-imperative
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/gatekeeper-imperative
 ```
 
 To ensure ConfigMaps do not contain fields with name `private_key`, we express

--- a/examples/gatekeeper-invalid-configmap/README.md
+++ b/examples/gatekeeper-invalid-configmap/README.md
@@ -13,7 +13,7 @@ function to validate resources using gatekeeper constraints.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/gatekeeper-invalid-configmap
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/gatekeeper-invalid-configmap
 ```
 
 There are 3 resources: a `ConstraintTemplate`, a `K8sBannedConfigMapKeysV1` and

--- a/examples/gatekeeper-warning-only/README.md
+++ b/examples/gatekeeper-warning-only/README.md
@@ -14,7 +14,7 @@ configured to be warnings instead of errors.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/gatekeeper-warning-only
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/gatekeeper-warning-only
 ```
 
 Here's an example `Kptfile` to run the function:

--- a/examples/generate-kpt-pkg-docs-simple/README.md
+++ b/examples/generate-kpt-pkg-docs-simple/README.md
@@ -16,7 +16,7 @@ Running `generate-kpt-pkg-docs` function on the example package will:
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/generate-kpt-pkg-docs-simple
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/generate-kpt-pkg-docs-simple
 ```
 
 ### Function invocation

--- a/examples/kubeconform-imperative/README.md
+++ b/examples/kubeconform-imperative/README.md
@@ -13,7 +13,7 @@ validate KRM resources.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/kubeconform-imperative
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/kubeconform-imperative
 ```
 
 We have a `ReplicationController` in `app.yaml` that has 2 schema violations:

--- a/examples/kubeconform-mount-schema/README.md
+++ b/examples/kubeconform-mount-schema/README.md
@@ -16,7 +16,7 @@ with [`kubeconform`] function to validate KRM resources.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get  https://github.com/kptdev/krm-functions-catalog/tree/master/examples/kubeconform-mount-schema
+$ kpt pkg get  https://github.com/kptdev/krm-functions-catalog/tree/main/examples/kubeconform-mount-schema
 ```
 
 We have a `ReplicationController` in `replicationcontroller.yaml` that has a

--- a/examples/kubeconform-simple/README.md
+++ b/examples/kubeconform-simple/README.md
@@ -13,7 +13,7 @@ validate KRM resources.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/kubeconform-simple
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/kubeconform-simple
 ```
 
 The following is the `Kptfile` in this example: 

--- a/examples/list-setters-simple/README.md
+++ b/examples/list-setters-simple/README.md
@@ -12,7 +12,7 @@ In this example, we will see how to list setters in a package.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/list-setters-simple
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/list-setters-simple
 ```
 
 ### Function invocation

--- a/examples/remove-local-config-resources-imperative/README.md
+++ b/examples/remove-local-config-resources-imperative/README.md
@@ -13,7 +13,7 @@ supplied resource list.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/remove-local-config-resources-imperative
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/remove-local-config-resources-imperative
 ```
 
 ### Function invocation

--- a/examples/render-helm-chart-local/README.md
+++ b/examples/render-helm-chart-local/README.md
@@ -13,7 +13,7 @@ function to render a helm chart that lives in your local filesystem.
 Run the following command to fetch the example package:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/render-helm-chart-local
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/render-helm-chart-local
 ```
 
 ```shell

--- a/examples/render-helm-chart-remote-values-file/README.md
+++ b/examples/render-helm-chart-remote-values-file/README.md
@@ -13,7 +13,7 @@ function with a remote values file.
 Run the following command to fetch the example package:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/render-helm-chart-remote-values-file
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/render-helm-chart-remote-values-file
 ```
 
 Run the following commands to render the helm chart in your local

--- a/examples/search-replace-create-setters/README.md
+++ b/examples/search-replace-create-setters/README.md
@@ -17,7 +17,7 @@ This is an advanced example depicting [setter] creation process using `search-re
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/search-replace-create-setters
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/search-replace-create-setters
 ```
 
 Let's start with the input resource

--- a/examples/search-replace-simple/README.md
+++ b/examples/search-replace-simple/README.md
@@ -15,7 +15,7 @@ This is a simple example depicting search and replace operation on KRM resource 
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/search-replace-simple
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/search-replace-simple
 ```
 
 Let's start with the input resource

--- a/examples/set-annotations-advanced/README.md
+++ b/examples/set-annotations-advanced/README.md
@@ -48,7 +48,7 @@ specify it in field `additionalAnnotationFields`.
 Invoke the function by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/set-annotations-advanced
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/set-annotations-advanced
 $ kpt fn render set-annotations-advanced
 ```
 

--- a/examples/set-annotations-imperative/README.md
+++ b/examples/set-annotations-imperative/README.md
@@ -13,7 +13,7 @@ on all resources by running [`set-annotations`] function imperatively.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/set-annotations-imperative
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/set-annotations-imperative
 ```
 
 ### Function invocation

--- a/examples/set-annotations-simple/README.md
+++ b/examples/set-annotations-simple/README.md
@@ -13,7 +13,7 @@ to upsert annotations to the `.metadata.annotations` field on all resources.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/set-annotations-simple
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/set-annotations-simple
 ```
 
 We use the following `Kptfile` to configure the function.

--- a/examples/set-enforcement-action-simple/README.md
+++ b/examples/set-enforcement-action-simple/README.md
@@ -13,7 +13,7 @@ dryrun for auditing purposes.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/set-enforcement-action-simple
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/set-enforcement-action-simple
 ```
 
 ### Function invocation

--- a/examples/set-image-advanced/README.md
+++ b/examples/set-image-advanced/README.md
@@ -50,7 +50,7 @@ field `additionalImageFields`.
 Invoke the function by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/set-image-advanced
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/set-image-advanced
 $ kpt fn render set-image-advanced
 ```
 

--- a/examples/set-image-digest/README.md
+++ b/examples/set-image-digest/README.md
@@ -14,7 +14,7 @@ resources.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/set-image-digest
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/set-image-digest
 ```
 
 We use the following `Kptfile` to configure the function.

--- a/examples/set-image-imperative/README.md
+++ b/examples/set-image-imperative/README.md
@@ -13,7 +13,7 @@ field on all resources by running [`set-image`] function imperatively.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/set-image-imperative
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/set-image-imperative
 ```
 
 ### Function invocation

--- a/examples/set-image-simple/README.md
+++ b/examples/set-image-simple/README.md
@@ -14,7 +14,7 @@ resources.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/set-image-simple
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/set-image-simple
 ```
 
 We use the following `Kptfile` to configure the function.

--- a/examples/set-labels-full-coverage/README.md
+++ b/examples/set-labels-full-coverage/README.md
@@ -13,7 +13,7 @@ to upsert all common labels to different built-in resources and CustomResourceDe
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/set-labels-full-coverage
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/set-labels-full-coverage
 ```
 
 We use the following `Kptfile` and `fn-config.yaml` to configure the function.

--- a/examples/set-labels-imperative/README.md
+++ b/examples/set-labels-imperative/README.md
@@ -13,7 +13,7 @@ all resources by running [`set-labels`] function imperatively.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/set-labels-imperative
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/set-labels-imperative
 ```
 
 ### Function invocation

--- a/examples/set-labels-simple/README.md
+++ b/examples/set-labels-simple/README.md
@@ -13,7 +13,7 @@ to upsert labels to the `.metadata.labels` field on all resources.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/set-labels-simple
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/set-labels-simple
 ```
 
 We use the following `Kptfile` to configure the function.

--- a/examples/set-namespace-depends-on/README.md
+++ b/examples/set-namespace-depends-on/README.md
@@ -19,7 +19,7 @@ portion of the annotation.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/set-namespace-depends-on
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/set-namespace-depends-on
 ```
 
 We use the following `set-namespace-depends-on/Kptfile` to configure the function.

--- a/examples/set-namespace-kpt-package-context/README.md
+++ b/examples/set-namespace-kpt-package-context/README.md
@@ -12,7 +12,7 @@ This example demonstrates how to run [`set-namespace`] function with kpt variant
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get --for-deployment https://github.com/kptdev/krm-functions-catalog/tree/master/examples/set-namespace-kpt-package-context
+$ kpt pkg get --for-deployment https://github.com/kptdev/krm-functions-catalog/tree/main/examples/set-namespace-kpt-package-context
 ```
 
 Since we use flag `--for-deployment`, kpt generates a local file `package-context.yaml` as below

--- a/examples/set-namespace-simple/README.md
+++ b/examples/set-namespace-simple/README.md
@@ -13,7 +13,7 @@ to replace the  `namespace` resource type in a variety of KRM resources.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/set-namespace-simple
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/set-namespace-simple
 ```
 
 We use the following `Kptfile` to configure the function.

--- a/examples/starlark-configmap-as-functionconfig/README.md
+++ b/examples/starlark-configmap-as-functionconfig/README.md
@@ -15,7 +15,7 @@ line arguments.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/starlark-configmap-as-functionconfig
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/starlark-configmap-as-functionconfig
 ```
 
 We are going to use the following starlark script:

--- a/examples/starlark-inject-sidecar/README.md
+++ b/examples/starlark-inject-sidecar/README.md
@@ -14,7 +14,7 @@ to inject sidecar container to `Deployment`.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/starlark-inject-sidecar
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/starlark-inject-sidecar
 ```
 
 We are going to use the following `Kptfile` and `fn-config.yaml` to configure

--- a/examples/starlark-load-library/README.md
+++ b/examples/starlark-load-library/README.md
@@ -13,7 +13,7 @@ In this example, we are going to demonstrate how to load a library in the
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/starlark-load-library
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/starlark-load-library
 ```
 
 We are going to use the following `Kptfile` and `fn-config.yaml` to configure

--- a/examples/starlark-poddisruptionbudget/README.md
+++ b/examples/starlark-poddisruptionbudget/README.md
@@ -15,7 +15,7 @@ the `functionConfig` and use it in the script.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/starlark-poddisruptionbudget
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/starlark-poddisruptionbudget
 ```
 
 We are going to use the following `Kptfile` and `fn-config.yaml` to configure

--- a/examples/starlark-set-namespace/README.md
+++ b/examples/starlark-set-namespace/README.md
@@ -14,7 +14,7 @@ to set namespaces to KRM resources.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/starlark-set-namespace
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/starlark-set-namespace
 ```
 
 We are going to use the following `Kptfile` and `fn-config.yaml` to configure

--- a/examples/starlark-validation/README.md
+++ b/examples/starlark-validation/README.md
@@ -14,7 +14,7 @@ to validate a `ConfigMap`.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/starlark-validation
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/starlark-validation
 ```
 
 We are going to use the following `Kptfile` and `fn-config.yaml` to configure

--- a/examples/upsert-resource-at-path/README.md
+++ b/examples/upsert-resource-at-path/README.md
@@ -10,7 +10,7 @@ In this example, we will see how to add a resource at specified path using `upse
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/upsert-resource-at-path
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/upsert-resource-at-path
 ```
 
 The input resource is present at path `.expected/fn-config.yaml`. It has an annotation

--- a/examples/upsert-resource-multiple/README.md
+++ b/examples/upsert-resource-multiple/README.md
@@ -11,7 +11,7 @@ function.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/upsert-resource-multiple
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/upsert-resource-multiple
 ```
 
 kpt CLI accepts only one resource as fn-config. Hence, `upsert-resource` function 

--- a/examples/upsert-resource-simple/README.md
+++ b/examples/upsert-resource-simple/README.md
@@ -12,7 +12,7 @@ package with the input resource.
 Get the example package by running the following commands:
 
 ```shell
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/master/examples/upsert-resource-simple
+$ kpt pkg get https://github.com/kptdev/krm-functions-catalog/tree/main/examples/upsert-resource-simple
 ```
 
 Let's start with the list of resources in a package:


### PR DESCRIPTION
There are some hanging references in the documentation that link to the old "master" branch. These links no longer work. This PR fixes the links by replacing "master" with "main".