### PR TITLE
Prevent `ensure-name-substring` from mangling file names

### DIFF
--- a/examples/ensure-name-substring-advanced/.expected/diff.patch
+++ b/examples/ensure-name-substring-advanced/.expected/diff.patch
@@ -1,10 +1,7 @@
-diff --git a/fn-config.yaml b/ensurenamesubstring_prod-my-config.yaml
-similarity index 91%
-rename from fn-config.yaml
-rename to ensurenamesubstring_prod-my-config.yaml
+diff --git a/fn-config.yaml b/fn-config.yaml
 index 83138a9..e0b441f 100644
 --- a/fn-config.yaml
-+++ b/ensurenamesubstring_prod-my-config.yaml
++++ b/fn-config.yaml
 @@ -1,7 +1,7 @@
  apiVersion: fn.kpt.dev/v1alpha1
  kind: EnsureNameSubstring
@@ -14,147 +11,50 @@ index 83138a9..e0b441f 100644
    annotations:
      config.kubernetes.io/local-config: "true"
  additionalNameFields:
-diff --git a/Kptfile b/kptfile_example.yaml
-similarity index 100%
-rename from Kptfile
-rename to kptfile_example.yaml
-diff --git a/namespace_old-name.yaml b/namespace_old-name.yaml
-new file mode 100644
-index 0000000..3bc097f
---- /dev/null
-+++ b/namespace_old-name.yaml
-@@ -0,0 +1,4 @@
-+apiVersion: v1
-+kind: Namespace
-+metadata:
-+  name: old-name
 diff --git a/resources.yaml b/resources.yaml
-deleted file mode 100644
-index a5c1d84..0000000
+index a5c1d84..12a930c 100644
 --- a/resources.yaml
-+++ /dev/null
-@@ -1,54 +0,0 @@
--apiVersion: v1
--kind: ConfigMap
--metadata:
++++ b/resources.yaml
+@@ -1,7 +1,7 @@
+ apiVersion: v1
+ kind: ConfigMap
+ metadata:
 -  name: the-map
--  namespace: the-namespace
--data:
--  some-key: some-value
-----
--apiVersion: v1
--kind: Pod
--metadata:
--  name: the-pod
--  namespace: the-namespace
--spec:
--  containers:
--    - name: test-container
--      image: k8s.docker.io/busybox
--      command:
--        - /bin/sh
--        - -c
--        - env
--      env:
--        - name: SOME_KEY
--          valueFrom:
--            configMapKeyRef:
--              name: the-map
--              key: some-key
-----
--apiVersion: v1
--kind: Service
--metadata:
--  name: the-service
--  namespace: the-namespace
--spec:
--  ports:
--    - name: etcd-server-ssl
--      port: 2380
--    - name: etcd-client-ssl
--      port: 2379
--  clusterIP: None
--  publishNotReadyAddresses: true
-----
--apiVersion: v1
--kind: Namespace
--metadata:
--  name: old-name
-----
--apiVersion: dev.example.com/v1
--kind: MyResource
--metadata:
--  name: the-cr
--  namespace: the-namespace
--spec:
--  name: foo
-diff --git a/the-namespace/configmap_prod-the-map.yaml b/the-namespace/configmap_prod-the-map.yaml
-new file mode 100644
-index 0000000..36dcc15
---- /dev/null
-+++ b/the-namespace/configmap_prod-the-map.yaml
-@@ -0,0 +1,7 @@
-+apiVersion: v1
-+kind: ConfigMap
-+metadata:
 +  name: prod-the-map
-+  namespace: the-namespace
-+data:
-+  some-key: some-value
-diff --git a/the-namespace/myresource_prod-the-cr.yaml b/the-namespace/myresource_prod-the-cr.yaml
-new file mode 100644
-index 0000000..48fd57c
---- /dev/null
-+++ b/the-namespace/myresource_prod-the-cr.yaml
-@@ -0,0 +1,7 @@
-+apiVersion: dev.example.com/v1
-+kind: MyResource
-+metadata:
-+  name: prod-the-cr
-+  namespace: the-namespace
-+spec:
-+  name: foo
-diff --git a/the-namespace/pod_prod-the-pod.yaml b/the-namespace/pod_prod-the-pod.yaml
-new file mode 100644
-index 0000000..fa97c78
---- /dev/null
-+++ b/the-namespace/pod_prod-the-pod.yaml
-@@ -0,0 +1,19 @@
-+apiVersion: v1
-+kind: Pod
-+metadata:
+   namespace: the-namespace
+ data:
+   some-key: some-value
+@@ -9,7 +9,7 @@ data:
+ apiVersion: v1
+ kind: Pod
+ metadata:
+-  name: the-pod
 +  name: prod-the-pod
-+  namespace: the-namespace
-+spec:
-+  containers:
-+  - name: test-container
-+    image: k8s.docker.io/busybox
-+    command:
-+    - /bin/sh
-+    - -c
-+    - env
-+    env:
-+    - name: SOME_KEY
-+      valueFrom:
-+        configMapKeyRef:
-+          name: prod-the-map
-+          key: some-key
-diff --git a/the-namespace/service_prod-the-service.yaml b/the-namespace/service_prod-the-service.yaml
-new file mode 100644
-index 0000000..c689f2e
---- /dev/null
-+++ b/the-namespace/service_prod-the-service.yaml
-@@ -0,0 +1,13 @@
-+apiVersion: v1
-+kind: Service
-+metadata:
+   namespace: the-namespace
+ spec:
+   containers:
+@@ -23,13 +23,13 @@ spec:
+         - name: SOME_KEY
+           valueFrom:
+             configMapKeyRef:
+-              name: the-map
++              name: prod-the-map
+               key: some-key
+ ---
+ apiVersion: v1
+ kind: Service
+ metadata:
+-  name: the-service
 +  name: prod-the-service
-+  namespace: the-namespace
-+spec:
-+  ports:
-+  - name: etcd-server-ssl
-+    port: 2380
-+  - name: etcd-client-ssl
-+    port: 2379
-+  clusterIP: None
-+  publishNotReadyAddresses: true
+   namespace: the-namespace
+ spec:
+   ports:
+@@ -48,7 +48,7 @@ metadata:
+ apiVersion: dev.example.com/v1
+ kind: MyResource
+ metadata:
+-  name: the-cr
++  name: prod-the-cr
+   namespace: the-namespace
+ spec:
+   name: foo

--- a/examples/ensure-name-substring-depends-on/.expected/diff.patch
+++ b/examples/ensure-name-substring-depends-on/.expected/diff.patch
@@ -1,130 +1,56 @@
-diff --git a/clusterrole_prod-secret-reader.yaml b/clusterrole_prod-secret-reader.yaml
-new file mode 100644
-index 0000000..17dfdd4
---- /dev/null
-+++ b/clusterrole_prod-secret-reader.yaml
-@@ -0,0 +1,4 @@
-+apiVersion: rbac.authorization.k8s.io/v1
-+kind: ClusterRole
-+metadata:
-+  name: prod-secret-reader
-diff --git a/clusterrolebinding_prod-read-secrets-global.yaml b/clusterrolebinding_prod-read-secrets-global.yaml
-new file mode 100644
-index 0000000..132852a
---- /dev/null
-+++ b/clusterrolebinding_prod-read-secrets-global.yaml
-@@ -0,0 +1,14 @@
-+apiVersion: rbac.authorization.k8s.io/v1
-+kind: ClusterRoleBinding
-+metadata:
-+  name: prod-read-secrets-global
-+  annotations:
-+    config.kubernetes.io/depends-on: rbac.authorization.k8s.io/ClusterRole/prod-secret-reader
-+roleRef:
-+  apiGroup: rbac.authorization.k8s.io
-+  kind: ClusterRole
-+  name: prod-secret-reader
-+subjects:
-+- apiGroup: rbac.authorization.k8s.io
-+  kind: Group
-+  name: admin
-diff --git a/default/deployment_prod-bar.yaml b/default/deployment_prod-bar.yaml
-new file mode 100644
-index 0000000..f8e9243
---- /dev/null
-+++ b/default/deployment_prod-bar.yaml
-@@ -0,0 +1,9 @@
-+apiVersion: v1
-+kind: Deployment
-+metadata:
-+  labels:
-+    app: bar
-+  name: prod-bar
-+  namespace: default
-+  annotations:
-+    config.kubernetes.io/depends-on: /namespaces/default/StatefulSet/outside-resource
-diff --git a/default/deployment_prod-wordpress.yaml b/default/deployment_prod-wordpress.yaml
-new file mode 100644
-index 0000000..cb2fd0b
---- /dev/null
-+++ b/default/deployment_prod-wordpress.yaml
-@@ -0,0 +1,9 @@
-+apiVersion: v1
-+kind: Deployment
-+metadata:
-+  labels:
-+    app: wordpress
-+  name: prod-wordpress
-+  namespace: default
-+  annotations:
-+    config.kubernetes.io/depends-on: /namespaces/default/StatefulSet/prod-wordpress-mysql
-diff --git a/default/statefulset_prod-wordpress-mysql.yaml b/default/statefulset_prod-wordpress-mysql.yaml
-new file mode 100644
-index 0000000..184db64
---- /dev/null
-+++ b/default/statefulset_prod-wordpress-mysql.yaml
-@@ -0,0 +1,7 @@
-+apiVersion: v1
-+kind: StatefulSet
-+metadata:
-+  labels:
-+    app: wordpress
-+  name: prod-wordpress-mysql
-+  namespace: default
-diff --git a/Kptfile b/kptfile_example.yaml
-similarity index 100%
-rename from Kptfile
-rename to kptfile_example.yaml
 diff --git a/resources.yaml b/resources.yaml
-deleted file mode 100644
-index 28bdcf3..0000000
+index 28bdcf3..63e0ad6 100644
 --- a/resources.yaml
-+++ /dev/null
-@@ -1,47 +0,0 @@
--apiVersion: v1
--kind: Deployment
--metadata:
--  annotations:
++++ b/resources.yaml
+@@ -2,10 +2,10 @@ apiVersion: v1
+ kind: Deployment
+ metadata:
+   annotations:
 -    config.kubernetes.io/depends-on: /namespaces/default/StatefulSet/wordpress-mysql
--  labels:
--    app: wordpress
++    config.kubernetes.io/depends-on: /namespaces/default/StatefulSet/prod-wordpress-mysql
+   labels:
+     app: wordpress
 -  name: wordpress
--  namespace: default
-----
--apiVersion: v1
--kind: StatefulSet
--metadata:
--  labels:
--    app: wordpress
++  name: prod-wordpress
+   namespace: default
+ ---
+ apiVersion: v1
+@@ -13,7 +13,7 @@ kind: StatefulSet
+ metadata:
+   labels:
+     app: wordpress
 -  name: wordpress-mysql
--  namespace: default
-----
--apiVersion: v1
--kind: Deployment
--metadata:
--  annotations:
--    config.kubernetes.io/depends-on: /namespaces/default/StatefulSet/outside-resource
--  labels:
--    app: bar
++  name: prod-wordpress-mysql
+   namespace: default
+ ---
+ apiVersion: v1
+@@ -23,19 +23,19 @@ metadata:
+     config.kubernetes.io/depends-on: /namespaces/default/StatefulSet/outside-resource
+   labels:
+     app: bar
 -  name: bar
--  namespace: default
-----
--apiVersion: rbac.authorization.k8s.io/v1
--kind: ClusterRoleBinding
--metadata:
--  annotations:
++  name: prod-bar
+   namespace: default
+ ---
+ apiVersion: rbac.authorization.k8s.io/v1
+ kind: ClusterRoleBinding
+ metadata:
+   annotations:
 -    config.kubernetes.io/depends-on: rbac.authorization.k8s.io/ClusterRole/secret-reader
 -  name: read-secrets-global
--roleRef:
--  apiGroup: rbac.authorization.k8s.io
--  kind: ClusterRole
++    config.kubernetes.io/depends-on: rbac.authorization.k8s.io/ClusterRole/prod-secret-reader
++  name: prod-read-secrets-global
+ roleRef:
+   apiGroup: rbac.authorization.k8s.io
+   kind: ClusterRole
 -  name: secret-reader
--subjects:
--- apiGroup: rbac.authorization.k8s.io
--  kind: Group
--  name: admin
-----
--apiVersion: rbac.authorization.k8s.io/v1
--kind: ClusterRole
--metadata:
++  name: prod-secret-reader
+ subjects:
+ - apiGroup: rbac.authorization.k8s.io
+   kind: Group
+@@ -44,4 +44,4 @@ subjects:
+ apiVersion: rbac.authorization.k8s.io/v1
+ kind: ClusterRole
+ metadata:
 -  name: secret-reader
++  name: prod-secret-reader

--- a/examples/ensure-name-substring-imperative/.expected/diff.patch
+++ b/examples/ensure-name-substring-imperative/.expected/diff.patch
@@ -1,117 +1,38 @@
 diff --git a/app.yaml b/app.yaml
-deleted file mode 100644
-index d7b0328..0000000
+index d7b0328..175354c 100644
 --- a/app.yaml
-+++ /dev/null
-@@ -1,45 +0,0 @@
--apiVersion: v1
--kind: ConfigMap
--metadata:
++++ b/app.yaml
+@@ -1,7 +1,7 @@
+ apiVersion: v1
+ kind: ConfigMap
+ metadata:
 -  name: the-map
--  namespace: the-namespace
--data:
--  some-key: some-value
-----
--apiVersion: v1
--kind: Pod
--metadata:
--  name: the-pod
--  namespace: the-namespace
--spec:
--  containers:
--    - name: test-container
--      image: k8s.docker.io/busybox
--      command:
--        - /bin/sh
--        - -c
--        - env
--      env:
--        - name: SOME_KEY
--          valueFrom:
--            configMapKeyRef:
--              name: the-map
--              key: some-key
-----
--apiVersion: v1
--kind: Service
--metadata:
--  name: the-service
--  namespace: the-namespace
--spec:
--  ports:
--    - name: etcd-server-ssl
--      port: 2380
--    - name: etcd-client-ssl
--      port: 2379
--  publishNotReadyAddresses: true
-----
--apiVersion: v1
--kind: Namespace
--metadata:
--  name: the-namespace
-diff --git a/namespace_the-namespace.yaml b/namespace_the-namespace.yaml
-new file mode 100644
-index 0000000..19102b3
---- /dev/null
-+++ b/namespace_the-namespace.yaml
-@@ -0,0 +1,4 @@
-+apiVersion: v1
-+kind: Namespace
-+metadata:
-+  name: the-namespace
-diff --git a/the-namespace/configmap_prod-the-map.yaml b/the-namespace/configmap_prod-the-map.yaml
-new file mode 100644
-index 0000000..36dcc15
---- /dev/null
-+++ b/the-namespace/configmap_prod-the-map.yaml
-@@ -0,0 +1,7 @@
-+apiVersion: v1
-+kind: ConfigMap
-+metadata:
 +  name: prod-the-map
-+  namespace: the-namespace
-+data:
-+  some-key: some-value
-diff --git a/the-namespace/pod_prod-the-pod.yaml b/the-namespace/pod_prod-the-pod.yaml
-new file mode 100644
-index 0000000..fa97c78
---- /dev/null
-+++ b/the-namespace/pod_prod-the-pod.yaml
-@@ -0,0 +1,19 @@
-+apiVersion: v1
-+kind: Pod
-+metadata:
+   namespace: the-namespace
+ data:
+   some-key: some-value
+@@ -9,7 +9,7 @@ data:
+ apiVersion: v1
+ kind: Pod
+ metadata:
+-  name: the-pod
 +  name: prod-the-pod
-+  namespace: the-namespace
-+spec:
-+  containers:
-+  - name: test-container
-+    image: k8s.docker.io/busybox
-+    command:
-+    - /bin/sh
-+    - -c
-+    - env
-+    env:
-+    - name: SOME_KEY
-+      valueFrom:
-+        configMapKeyRef:
-+          name: prod-the-map
-+          key: some-key
-diff --git a/the-namespace/service_prod-the-service.yaml b/the-namespace/service_prod-the-service.yaml
-new file mode 100644
-index 0000000..2a4109e
---- /dev/null
-+++ b/the-namespace/service_prod-the-service.yaml
-@@ -0,0 +1,12 @@
-+apiVersion: v1
-+kind: Service
-+metadata:
+   namespace: the-namespace
+ spec:
+   containers:
+@@ -23,13 +23,13 @@ spec:
+         - name: SOME_KEY
+           valueFrom:
+             configMapKeyRef:
+-              name: the-map
++              name: prod-the-map
+               key: some-key
+ ---
+ apiVersion: v1
+ kind: Service
+ metadata:
+-  name: the-service
 +  name: prod-the-service
-+  namespace: the-namespace
-+spec:
-+  ports:
-+  - name: etcd-server-ssl
-+    port: 2380
-+  - name: etcd-client-ssl
-+    port: 2379
-+  publishNotReadyAddresses: true
+   namespace: the-namespace
+ spec:
+   ports:

--- a/examples/ensure-name-substring-prefix/.expected/diff.patch
+++ b/examples/ensure-name-substring-prefix/.expected/diff.patch
@@ -1,123 +1,31 @@
-diff --git a/Kptfile b/kptfile_example.yaml
-similarity index 100%
-rename from Kptfile
-rename to kptfile_example.yaml
-diff --git a/namespace_the-namespace.yaml b/namespace_the-namespace.yaml
-new file mode 100644
-index 0000000..19102b3
---- /dev/null
-+++ b/namespace_the-namespace.yaml
-@@ -0,0 +1,4 @@
-+apiVersion: v1
-+kind: Namespace
-+metadata:
-+  name: the-namespace
 diff --git a/resources.yaml b/resources.yaml
-deleted file mode 100644
-index 1522e4c..0000000
+index 1522e4c..107ca31 100644
 --- a/resources.yaml
-+++ /dev/null
-@@ -1,46 +0,0 @@
--apiVersion: v1
--kind: ConfigMap
--metadata:
++++ b/resources.yaml
+@@ -1,7 +1,7 @@
+ apiVersion: v1
+ kind: ConfigMap
+ metadata:
 -  name: the-map
--  namespace: the-namespace
--data:
--  some-key: some-value
-----
--apiVersion: v1
--kind: Pod
--metadata:
--  name: the-pod
--  namespace: the-namespace
--spec:
--  containers:
--    - name: test-container
--      image: k8s.docker.io/busybox
--      command:
--        - /bin/sh
--        - -c
--        - env
--      env:
--        - name: SOME_KEY
--          valueFrom:
--            configMapKeyRef:
--              name: the-map
--              key: some-key
-----
--apiVersion: v1
--kind: Service
--metadata:
--  name: with-prod-service
--  namespace: the-namespace
--spec:
--  ports:
--    - name: etcd-server-ssl
--      port: 2380
--    - name: etcd-client-ssl
--      port: 2379
--  clusterIP: None
--  publishNotReadyAddresses: true
-----
--apiVersion: v1
--kind: Namespace
--metadata:
--  name: the-namespace
-diff --git a/the-namespace/configmap_prod-the-map.yaml b/the-namespace/configmap_prod-the-map.yaml
-new file mode 100644
-index 0000000..36dcc15
---- /dev/null
-+++ b/the-namespace/configmap_prod-the-map.yaml
-@@ -0,0 +1,7 @@
-+apiVersion: v1
-+kind: ConfigMap
-+metadata:
 +  name: prod-the-map
-+  namespace: the-namespace
-+data:
-+  some-key: some-value
-diff --git a/the-namespace/pod_prod-the-pod.yaml b/the-namespace/pod_prod-the-pod.yaml
-new file mode 100644
-index 0000000..fa97c78
---- /dev/null
-+++ b/the-namespace/pod_prod-the-pod.yaml
-@@ -0,0 +1,19 @@
-+apiVersion: v1
-+kind: Pod
-+metadata:
+   namespace: the-namespace
+ data:
+   some-key: some-value
+@@ -9,7 +9,7 @@ data:
+ apiVersion: v1
+ kind: Pod
+ metadata:
+-  name: the-pod
 +  name: prod-the-pod
-+  namespace: the-namespace
-+spec:
-+  containers:
-+  - name: test-container
-+    image: k8s.docker.io/busybox
-+    command:
-+    - /bin/sh
-+    - -c
-+    - env
-+    env:
-+    - name: SOME_KEY
-+      valueFrom:
-+        configMapKeyRef:
-+          name: prod-the-map
-+          key: some-key
-diff --git a/the-namespace/service_with-prod-service.yaml b/the-namespace/service_with-prod-service.yaml
-new file mode 100644
-index 0000000..d07fe57
---- /dev/null
-+++ b/the-namespace/service_with-prod-service.yaml
-@@ -0,0 +1,13 @@
-+apiVersion: v1
-+kind: Service
-+metadata:
-+  name: with-prod-service
-+  namespace: the-namespace
-+spec:
-+  ports:
-+  - name: etcd-server-ssl
-+    port: 2380
-+  - name: etcd-client-ssl
-+    port: 2379
-+  clusterIP: None
-+  publishNotReadyAddresses: true
+   namespace: the-namespace
+ spec:
+   containers:
+@@ -23,7 +23,7 @@ spec:
+         - name: SOME_KEY
+           valueFrom:
+             configMapKeyRef:
+-              name: the-map
++              name: prod-the-map
+               key: some-key
+ ---
+ apiVersion: v1

--- a/examples/ensure-name-substring-suffix/.expected/diff.patch
+++ b/examples/ensure-name-substring-suffix/.expected/diff.patch
@@ -1,123 +1,31 @@
-diff --git a/Kptfile b/kptfile_example.yaml
-similarity index 100%
-rename from Kptfile
-rename to kptfile_example.yaml
-diff --git a/namespace_the-namespace.yaml b/namespace_the-namespace.yaml
-new file mode 100644
-index 0000000..19102b3
---- /dev/null
-+++ b/namespace_the-namespace.yaml
-@@ -0,0 +1,4 @@
-+apiVersion: v1
-+kind: Namespace
-+metadata:
-+  name: the-namespace
 diff --git a/resources.yaml b/resources.yaml
-deleted file mode 100644
-index b1fcb0b..0000000
+index b1fcb0b..d487fd4 100644
 --- a/resources.yaml
-+++ /dev/null
-@@ -1,46 +0,0 @@
--apiVersion: v1
--kind: ConfigMap
--metadata:
++++ b/resources.yaml
+@@ -1,7 +1,7 @@
+ apiVersion: v1
+ kind: ConfigMap
+ metadata:
 -  name: the-map
--  namespace: the-namespace
--data:
--  some-key: some-value
-----
--apiVersion: v1
--kind: Pod
--metadata:
--  name: the-pod
--  namespace: the-namespace
--spec:
--  containers:
--    - name: test-container
--      image: k8s.docker.io/busybox
--      command:
--        - /bin/sh
--        - -c
--        - env
--      env:
--        - name: SOME_KEY
--          valueFrom:
--            configMapKeyRef:
--              name: the-map
--              key: some-key
-----
--apiVersion: v1
--kind: Service
--metadata:
--  name: the-service-prod
--  namespace: the-namespace
--spec:
--  ports:
--    - name: etcd-server-ssl
--      port: 2380
--    - name: etcd-client-ssl
--      port: 2379
--  clusterIP: None
--  publishNotReadyAddresses: true
-----
--apiVersion: v1
--kind: Namespace
--metadata:
--  name: the-namespace
-diff --git a/the-namespace/configmap_the-map-prod.yaml b/the-namespace/configmap_the-map-prod.yaml
-new file mode 100644
-index 0000000..4023c97
---- /dev/null
-+++ b/the-namespace/configmap_the-map-prod.yaml
-@@ -0,0 +1,7 @@
-+apiVersion: v1
-+kind: ConfigMap
-+metadata:
 +  name: the-map-prod
-+  namespace: the-namespace
-+data:
-+  some-key: some-value
-diff --git a/the-namespace/pod_the-pod-prod.yaml b/the-namespace/pod_the-pod-prod.yaml
-new file mode 100644
-index 0000000..1963a4b
---- /dev/null
-+++ b/the-namespace/pod_the-pod-prod.yaml
-@@ -0,0 +1,19 @@
-+apiVersion: v1
-+kind: Pod
-+metadata:
+   namespace: the-namespace
+ data:
+   some-key: some-value
+@@ -9,7 +9,7 @@ data:
+ apiVersion: v1
+ kind: Pod
+ metadata:
+-  name: the-pod
 +  name: the-pod-prod
-+  namespace: the-namespace
-+spec:
-+  containers:
-+  - name: test-container
-+    image: k8s.docker.io/busybox
-+    command:
-+    - /bin/sh
-+    - -c
-+    - env
-+    env:
-+    - name: SOME_KEY
-+      valueFrom:
-+        configMapKeyRef:
-+          name: the-map-prod
-+          key: some-key
-diff --git a/the-namespace/service_the-service-prod.yaml b/the-namespace/service_the-service-prod.yaml
-new file mode 100644
-index 0000000..e26b3ec
---- /dev/null
-+++ b/the-namespace/service_the-service-prod.yaml
-@@ -0,0 +1,13 @@
-+apiVersion: v1
-+kind: Service
-+metadata:
-+  name: the-service-prod
-+  namespace: the-namespace
-+spec:
-+  ports:
-+  - name: etcd-server-ssl
-+    port: 2380
-+  - name: etcd-client-ssl
-+    port: 2379
-+  clusterIP: None
-+  publishNotReadyAddresses: true
+   namespace: the-namespace
+ spec:
+   containers:
+@@ -23,7 +23,7 @@ spec:
+         - name: SOME_KEY
+           valueFrom:
+             configMapKeyRef:
+-              name: the-map
++              name: the-map-prod
+               key: some-key
+ ---
+ apiVersion: v1

--- a/functions/go/ensure-name-substring/README.md
+++ b/functions/go/ensure-name-substring/README.md
@@ -42,6 +42,7 @@ This function does Not process the following resources:
 - `CustomResourceDefinition`
 - `Namespace`
 - `APIService`
+- `Kptfile`
 
 In addition to updating the `metadata.name` field for each resource, the
 function will also update the [fields][namereference] that references the name

--- a/functions/go/ensure-name-substring/ensure_name_substring_test.go
+++ b/functions/go/ensure-name-substring/ensure_name_substring_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/kyaml/fn/framework"
+	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
@@ -45,7 +46,9 @@ func runEnsureNameSubstringTransformerE(config, input string) (string, error) {
 	if err = ens.Transform(resMap); err != nil {
 		return "", err
 	}
-	resMap.RemoveBuildAnnotations()
+	if err = removeKustomizeTrackingAnnotations(resMap); err != nil {
+		return "", err
+	}
 	y, err := resMap.AsYaml()
 	if err != nil {
 		return "", err
@@ -370,4 +373,90 @@ func TestSetDependsOnNameSubstring(t *testing.T) {
 			assert.Equal(t, tc.Expected, actual)
 		})
 	}
+}
+
+func TestProcessPreservesKptfilePathAnnotation(t *testing.T) {
+	t.Parallel()
+
+	// given
+	kptfile, err := yaml.Parse(`apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: test-ensure-name-substring
+  annotations:
+    config.kubernetes.io/local-config: "true"
+    internal.config.kubernetes.io/path: Kptfile
+    internal.config.kubernetes.io/index: "0"
+info:
+  description: Minimal package to reproduce ensure-name-substring Kptfile handling
+`)
+	assert.NoError(t, err)
+	config, err := yaml.Parse(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fn-config
+data:
+  append: "-test"
+`)
+	assert.NoError(t, err)
+	tc, err := getDefaultConfig()
+	assert.NoError(t, err)
+	ensp := EnsureNameSubstringProcessor{tc: &tc}
+	rl := &framework.ResourceList{
+		Items:          []*yaml.RNode{kptfile},
+		FunctionConfig: config,
+	}
+
+	// when
+	err = ensp.Process(rl)
+
+	// then
+	assert.NoError(t, err)
+	assert.Len(t, rl.Items, 1)
+	assert.Equal(t, "test-ensure-name-substring", rl.Items[0].GetName())
+	assert.Equal(t, "Kptfile", rl.Items[0].GetAnnotations()[kioutil.PathAnnotation])
+	assert.Equal(t, "0", rl.Items[0].GetAnnotations()[kioutil.IndexAnnotation])
+}
+
+func TestProcessPreservesPathAnnotationWhenRenaming(t *testing.T) {
+	t.Parallel()
+
+	// given
+	cm, err := yaml.Parse(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: the-map
+  annotations:
+    internal.config.kubernetes.io/path: resources.yaml
+    internal.config.kubernetes.io/index: "0"
+data:
+  some-key: some-value
+`)
+	assert.NoError(t, err)
+	config, err := yaml.Parse(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fn-config
+data:
+  prepend: prod-
+`)
+	assert.NoError(t, err)
+	tc, err := getDefaultConfig()
+	assert.NoError(t, err)
+	ensp := EnsureNameSubstringProcessor{tc: &tc}
+	rl := &framework.ResourceList{
+		Items:          []*yaml.RNode{cm},
+		FunctionConfig: config,
+	}
+
+	// when
+	err = ensp.Process(rl)
+
+	// then
+	assert.NoError(t, err)
+	assert.Len(t, rl.Items, 1)
+	assert.Equal(t, "prod-the-map", rl.Items[0].GetName())
+	assert.Equal(t, "resources.yaml", rl.Items[0].GetAnnotations()[kioutil.PathAnnotation])
+	assert.Empty(t, rl.Items[0].GetAnnotations()["internal.config.kubernetes.io/previousNames"])
+	assert.Empty(t, rl.Items[0].GetAnnotations()["internal.config.kubernetes.io/prefixes"])
 }

--- a/functions/go/ensure-name-substring/ensure_name_substring_test.go
+++ b/functions/go/ensure-name-substring/ensure_name_substring_test.go
@@ -457,6 +457,6 @@ data:
 	assert.Len(t, rl.Items, 1)
 	assert.Equal(t, "prod-the-map", rl.Items[0].GetName())
 	assert.Equal(t, "resources.yaml", rl.Items[0].GetAnnotations()[kioutil.PathAnnotation])
-	assert.Empty(t, rl.Items[0].GetAnnotations()["internal.config.kubernetes.io/previousNames"])
-	assert.Empty(t, rl.Items[0].GetAnnotations()["internal.config.kubernetes.io/prefixes"])
+	assert.NotContains(t, rl.Items[0].GetAnnotations(), "internal.config.kubernetes.io/previousNames")
+	assert.NotContains(t, rl.Items[0].GetAnnotations(), "internal.config.kubernetes.io/prefixes")
 }

--- a/functions/go/ensure-name-substring/generated/docs.go
+++ b/functions/go/ensure-name-substring/generated/docs.go
@@ -29,6 +29,7 @@ This function does Not process the following resources:
 - ` + "`" + `CustomResourceDefinition` + "`" + `
 - ` + "`" + `Namespace` + "`" + `
 - ` + "`" + `APIService` + "`" + `
+- ` + "`" + `Kptfile` + "`" + `
 
 In addition to updating the ` + "`" + `metadata.name` + "`" + ` field for each resource, the
 function will also update the [fields][namereference] that references the name

--- a/functions/go/ensure-name-substring/main.go
+++ b/functions/go/ensure-name-substring/main.go
@@ -97,18 +97,24 @@ func (ensp *EnsureNameSubstringProcessor) Process(resourceList *framework.Resour
 	return nil
 }
 
-// kptPackageAnnotations must be preserved so kpt can write resources back to
-// their original package paths (especially the literal "Kptfile" filename).
-var kptPackageAnnotations = []string{
-	kioutil.PathAnnotation,
-	kioutil.IndexAnnotation,
-	kioutil.SeqIndentAnnotation,
-	kioutil.IdAnnotation,
-	kioutil.InternalAnnotationsMigrationResourceIDAnnotation,
-	kioutil.LegacyPathAnnotation,  //nolint:staticcheck
-	kioutil.LegacyIndexAnnotation, //nolint:staticcheck
-	kioutil.LegacyIdAnnotation,    //nolint:staticcheck
-}
+var kustomizeTrackingAnnos = func() []string {
+	// kptPackageAnnotations must be preserved so kpt can write resources back to
+	// their original package paths (especially the literal "Kptfile" filename).
+	kptPackageAnnotations := []string{
+		kioutil.PathAnnotation,
+		kioutil.IndexAnnotation,
+		kioutil.SeqIndentAnnotation,
+		kioutil.IdAnnotation,
+		kioutil.InternalAnnotationsMigrationResourceIDAnnotation,
+		kioutil.LegacyPathAnnotation,  //nolint:staticcheck
+		kioutil.LegacyIndexAnnotation, //nolint:staticcheck
+		kioutil.LegacyIdAnnotation,    //nolint:staticcheck
+	}
+
+	return slices.DeleteFunc(slices.Clone(resource.BuildAnnotations), func(s string) bool {
+		return slices.Contains(kptPackageAnnotations, s)
+	})
+}()
 
 func removeKustomizeTrackingAnnotations(m resmap.ResMap) error {
 	for _, r := range m.Resources() {
@@ -116,10 +122,7 @@ func removeKustomizeTrackingAnnotations(m resmap.ResMap) error {
 		if len(annotations) == 0 {
 			continue
 		}
-		annosToRemove := slices.DeleteFunc(resource.BuildAnnotations, func(s string) bool {
-			return slices.Contains(kptPackageAnnotations, s)
-		})
-		for _, a := range annosToRemove {
+		for _, a := range kustomizeTrackingAnnos {
 			delete(annotations, a)
 		}
 		if err := r.SetAnnotations(annotations); err != nil {

--- a/functions/go/ensure-name-substring/main.go
+++ b/functions/go/ensure-name-substring/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"slices"
 
 	"github.com/kptdev/krm-functions-catalog/functions/go/ensure-name-substring/generated"
 	nameref "github.com/kptdev/krm-functions-catalog/functions/go/ensure-name-substring/third_party/sigs.k8s.io/kustomize/api/accumulator"
@@ -98,15 +99,15 @@ func (ensp *EnsureNameSubstringProcessor) Process(resourceList *framework.Resour
 
 // kptPackageAnnotations must be preserved so kpt can write resources back to
 // their original package paths (especially the literal "Kptfile" filename).
-var kptPackageAnnotations = map[string]bool{
-	kioutil.PathAnnotation:                                   true,
-	kioutil.IndexAnnotation:                                  true,
-	kioutil.SeqIndentAnnotation:                              true,
-	kioutil.IdAnnotation:                                     true,
-	kioutil.InternalAnnotationsMigrationResourceIDAnnotation: true,
-	kioutil.LegacyPathAnnotation:                             true, //nolint:staticcheck
-	kioutil.LegacyIndexAnnotation:                            true, //nolint:staticcheck
-	kioutil.LegacyIdAnnotation:                               true, //nolint:staticcheck
+var kptPackageAnnotations = []string{
+	kioutil.PathAnnotation,
+	kioutil.IndexAnnotation,
+	kioutil.SeqIndentAnnotation,
+	kioutil.IdAnnotation,
+	kioutil.InternalAnnotationsMigrationResourceIDAnnotation,
+	kioutil.LegacyPathAnnotation,  //nolint:staticcheck
+	kioutil.LegacyIndexAnnotation, //nolint:staticcheck
+	kioutil.LegacyIdAnnotation,    //nolint:staticcheck
 }
 
 func removeKustomizeTrackingAnnotations(m resmap.ResMap) error {
@@ -115,10 +116,10 @@ func removeKustomizeTrackingAnnotations(m resmap.ResMap) error {
 		if len(annotations) == 0 {
 			continue
 		}
-		for _, a := range resource.BuildAnnotations {
-			if kptPackageAnnotations[a] {
-				continue
-			}
+		annosToRemove := slices.DeleteFunc(resource.BuildAnnotations, func(s string) bool {
+			return slices.Contains(kptPackageAnnotations, s)
+		})
+		for _, a := range annosToRemove {
 			delete(annotations, a)
 		}
 		if err := r.SetAnnotations(annotations); err != nil {

--- a/functions/go/ensure-name-substring/main.go
+++ b/functions/go/ensure-name-substring/main.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/fn/framework"
 	"sigs.k8s.io/kustomize/kyaml/fn/framework/command"
+	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
 	"sigs.k8s.io/yaml"
 )
 
@@ -84,9 +85,46 @@ func (ensp *EnsureNameSubstringProcessor) Process(resourceList *framework.Resour
 		return fmt.Errorf("failed to fix name back reference: %w", err)
 	}
 
-	// remove kustomize build annotations
-	resMap.RemoveBuildAnnotations()
+	// Remove kustomize tracking annotations (previousNames, prefixes, etc.)
+	// without dropping kpt path/index annotations. RemoveBuildAnnotations()
+	// also clears those, which would rewrite files such as Kptfile to
+	// kind_name.yaml when the package is written back.
+	if err = removeKustomizeTrackingAnnotations(resMap); err != nil {
+		return fmt.Errorf("failed to remove kustomize tracking annotations: %w", err)
+	}
 	resourceList.Items = resMap.ToRNodeSlice()
+	return nil
+}
+
+// kptPackageAnnotations must be preserved so kpt can write resources back to
+// their original package paths (especially the literal "Kptfile" filename).
+var kptPackageAnnotations = map[string]bool{
+	kioutil.PathAnnotation:                                   true,
+	kioutil.IndexAnnotation:                                  true,
+	kioutil.SeqIndentAnnotation:                              true,
+	kioutil.IdAnnotation:                                     true,
+	kioutil.InternalAnnotationsMigrationResourceIDAnnotation: true,
+	kioutil.LegacyPathAnnotation:                             true, //nolint:staticcheck
+	kioutil.LegacyIndexAnnotation:                            true, //nolint:staticcheck
+	kioutil.LegacyIdAnnotation:                               true, //nolint:staticcheck
+}
+
+func removeKustomizeTrackingAnnotations(m resmap.ResMap) error {
+	for _, r := range m.Resources() {
+		annotations := r.GetAnnotations()
+		if len(annotations) == 0 {
+			continue
+		}
+		for _, a := range resource.BuildAnnotations {
+			if kptPackageAnnotations[a] {
+				continue
+			}
+			delete(annotations, a)
+		}
+		if err := r.SetAnnotations(annotations); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/functions/go/ensure-name-substring/tests/legacy-config/.expected/diff.patch
+++ b/functions/go/ensure-name-substring/tests/legacy-config/.expected/diff.patch
@@ -1,11 +1,8 @@
-diff --git a/fn-config.yaml b/ensurenamesubstring_prod-my-config.yaml
-similarity index 52%
-rename from fn-config.yaml
-rename to ensurenamesubstring_prod-my-config.yaml
-index 84f999f..be9bd1a 100644
+diff --git a/fn-config.yaml b/fn-config.yaml
+index 84f999f..9915f86 100644
 --- a/fn-config.yaml
-+++ b/ensurenamesubstring_prod-my-config.yaml
-@@ -1,11 +1,11 @@
++++ b/fn-config.yaml
+@@ -1,7 +1,7 @@
  apiVersion: fn.kpt.dev/v1alpha1
  kind: EnsureNameSubstring
  metadata:
@@ -13,156 +10,51 @@ index 84f999f..be9bd1a 100644
 +  name: prod-my-config
  editMode: prepend
  fieldSpecs:
--  - kind: MyResource
--    group: dev.example.com
--    path: spec/name
--    version: v1
-+- kind: MyResource
-+  group: dev.example.com
-+  path: spec/name
-+  version: v1
- substring: prod-
-diff --git a/Kptfile b/kptfile_example.yaml
-similarity index 100%
-rename from Kptfile
-rename to kptfile_example.yaml
-diff --git a/namespace_old-name.yaml b/namespace_old-name.yaml
-new file mode 100644
-index 0000000..3bc097f
---- /dev/null
-+++ b/namespace_old-name.yaml
-@@ -0,0 +1,4 @@
-+apiVersion: v1
-+kind: Namespace
-+metadata:
-+  name: old-name
+   - kind: MyResource
 diff --git a/resources.yaml b/resources.yaml
-deleted file mode 100644
-index a5c1d84..0000000
+index a5c1d84..12a930c 100644
 --- a/resources.yaml
-+++ /dev/null
-@@ -1,54 +0,0 @@
--apiVersion: v1
--kind: ConfigMap
--metadata:
++++ b/resources.yaml
+@@ -1,7 +1,7 @@
+ apiVersion: v1
+ kind: ConfigMap
+ metadata:
 -  name: the-map
--  namespace: the-namespace
--data:
--  some-key: some-value
-----
--apiVersion: v1
--kind: Pod
--metadata:
--  name: the-pod
--  namespace: the-namespace
--spec:
--  containers:
--    - name: test-container
--      image: k8s.docker.io/busybox
--      command:
--        - /bin/sh
--        - -c
--        - env
--      env:
--        - name: SOME_KEY
--          valueFrom:
--            configMapKeyRef:
--              name: the-map
--              key: some-key
-----
--apiVersion: v1
--kind: Service
--metadata:
--  name: the-service
--  namespace: the-namespace
--spec:
--  ports:
--    - name: etcd-server-ssl
--      port: 2380
--    - name: etcd-client-ssl
--      port: 2379
--  clusterIP: None
--  publishNotReadyAddresses: true
-----
--apiVersion: v1
--kind: Namespace
--metadata:
--  name: old-name
-----
--apiVersion: dev.example.com/v1
--kind: MyResource
--metadata:
--  name: the-cr
--  namespace: the-namespace
--spec:
--  name: foo
-diff --git a/the-namespace/configmap_prod-the-map.yaml b/the-namespace/configmap_prod-the-map.yaml
-new file mode 100644
-index 0000000..36dcc15
---- /dev/null
-+++ b/the-namespace/configmap_prod-the-map.yaml
-@@ -0,0 +1,7 @@
-+apiVersion: v1
-+kind: ConfigMap
-+metadata:
 +  name: prod-the-map
-+  namespace: the-namespace
-+data:
-+  some-key: some-value
-diff --git a/the-namespace/myresource_prod-the-cr.yaml b/the-namespace/myresource_prod-the-cr.yaml
-new file mode 100644
-index 0000000..48fd57c
---- /dev/null
-+++ b/the-namespace/myresource_prod-the-cr.yaml
-@@ -0,0 +1,7 @@
-+apiVersion: dev.example.com/v1
-+kind: MyResource
-+metadata:
-+  name: prod-the-cr
-+  namespace: the-namespace
-+spec:
-+  name: foo
-diff --git a/the-namespace/pod_prod-the-pod.yaml b/the-namespace/pod_prod-the-pod.yaml
-new file mode 100644
-index 0000000..fa97c78
---- /dev/null
-+++ b/the-namespace/pod_prod-the-pod.yaml
-@@ -0,0 +1,19 @@
-+apiVersion: v1
-+kind: Pod
-+metadata:
+   namespace: the-namespace
+ data:
+   some-key: some-value
+@@ -9,7 +9,7 @@ data:
+ apiVersion: v1
+ kind: Pod
+ metadata:
+-  name: the-pod
 +  name: prod-the-pod
-+  namespace: the-namespace
-+spec:
-+  containers:
-+  - name: test-container
-+    image: k8s.docker.io/busybox
-+    command:
-+    - /bin/sh
-+    - -c
-+    - env
-+    env:
-+    - name: SOME_KEY
-+      valueFrom:
-+        configMapKeyRef:
-+          name: prod-the-map
-+          key: some-key
-diff --git a/the-namespace/service_prod-the-service.yaml b/the-namespace/service_prod-the-service.yaml
-new file mode 100644
-index 0000000..c689f2e
---- /dev/null
-+++ b/the-namespace/service_prod-the-service.yaml
-@@ -0,0 +1,13 @@
-+apiVersion: v1
-+kind: Service
-+metadata:
+   namespace: the-namespace
+ spec:
+   containers:
+@@ -23,13 +23,13 @@ spec:
+         - name: SOME_KEY
+           valueFrom:
+             configMapKeyRef:
+-              name: the-map
++              name: prod-the-map
+               key: some-key
+ ---
+ apiVersion: v1
+ kind: Service
+ metadata:
+-  name: the-service
 +  name: prod-the-service
-+  namespace: the-namespace
-+spec:
-+  ports:
-+  - name: etcd-server-ssl
-+    port: 2380
-+  - name: etcd-client-ssl
-+    port: 2379
-+  clusterIP: None
-+  publishNotReadyAddresses: true
+   namespace: the-namespace
+ spec:
+   ports:
+@@ -48,7 +48,7 @@ metadata:
+ apiVersion: dev.example.com/v1
+ kind: MyResource
+ metadata:
+-  name: the-cr
++  name: prod-the-cr
+   namespace: the-namespace
+ spec:
+   name: foo

--- a/functions/go/ensure-name-substring/tests/local-config/.expected/diff.patch
+++ b/functions/go/ensure-name-substring/tests/local-config/.expected/diff.patch
@@ -1,41 +1,7 @@
-diff --git a/local-config.yaml b/configmap_prod-local-config-map.yaml
-similarity index 81%
-rename from local-config.yaml
-rename to configmap_prod-local-config-map.yaml
-index b8d83d1..304fc07 100644
---- a/local-config.yaml
-+++ b/configmap_prod-local-config-map.yaml
-@@ -1,7 +1,7 @@
- apiVersion: v1
- kind: ConfigMap
- metadata:
--  name: local-config-map
-+  name: prod-local-config-map
-   annotations:
-     config.kubernetes.io/local-config: "true"
- data:
-diff --git a/resources.yaml b/configmap_prod-the-map.yaml
-similarity index 76%
-rename from resources.yaml
-rename to configmap_prod-the-map.yaml
-index 3127bfa..b6bb670 100644
---- a/resources.yaml
-+++ b/configmap_prod-the-map.yaml
-@@ -1,6 +1,6 @@
- apiVersion: v1
- kind: ConfigMap
- metadata:
--  name: the-map
-+  name: prod-the-map
- data:
-   some-key: some-value
-diff --git a/fn-config.yaml b/ensurenamesubstring_prod-my-config.yaml
-similarity index 87%
-rename from fn-config.yaml
-rename to ensurenamesubstring_prod-my-config.yaml
+diff --git a/fn-config.yaml b/fn-config.yaml
 index d25180f..5842b05 100644
 --- a/fn-config.yaml
-+++ b/ensurenamesubstring_prod-my-config.yaml
++++ b/fn-config.yaml
 @@ -1,7 +1,7 @@
  apiVersion: fn.kpt.dev/v1alpha1
  kind: EnsureNameSubstring
@@ -45,7 +11,28 @@ index d25180f..5842b05 100644
    annotations:
      config.kubernetes.io/local-config: "true"
  editMode: prepend
-diff --git a/Kptfile b/kptfile_example.yaml
-similarity index 100%
-rename from Kptfile
-rename to kptfile_example.yaml
+diff --git a/local-config.yaml b/local-config.yaml
+index b8d83d1..304fc07 100644
+--- a/local-config.yaml
++++ b/local-config.yaml
+@@ -1,7 +1,7 @@
+ apiVersion: v1
+ kind: ConfigMap
+ metadata:
+-  name: local-config-map
++  name: prod-local-config-map
+   annotations:
+     config.kubernetes.io/local-config: "true"
+ data:
+diff --git a/resources.yaml b/resources.yaml
+index 3127bfa..b6bb670 100644
+--- a/resources.yaml
++++ b/resources.yaml
+@@ -1,6 +1,6 @@
+ apiVersion: v1
+ kind: ConfigMap
+ metadata:
+-  name: the-map
++  name: prod-the-map
+ data:
+   some-key: some-value


### PR DESCRIPTION
Since the update to kustomize/api v0.10.1 which added path annotations (among others) to `resource.BuildAnnotations` the function was renaming every single file by removing said annotations.

Somehow this was missed for quite a while, potentially making v0.2.1-v0.2.4 unusable.

In this PR, we subtract the annotations the function strips so that kpt can properly output the files.

I used AI in the creation of this PR: Cursor's Grok 4.5 variant was used to identify the issue and track the broken versions.

_Note: For the diff.patch files, it is better to just look at the files on the branch, because the diff on the UI is very messy._